### PR TITLE
システムプロンプトを環境変数で設定できるようにする

### DIFF
--- a/.env
+++ b/.env
@@ -106,3 +106,6 @@ NEXT_PUBLIC_REALTIME_API_MODE=""
 
 # Slide Mode (true or false)
 NEXT_PUBLIC_SLIDE_MODE=""
+
+# System Prompt
+NEXT_PUBLIC_SYSTEM_PROMPT="

--- a/.env.example
+++ b/.env.example
@@ -106,3 +106,6 @@ NEXT_PUBLIC_REALTIME_API_MODE=""
 
 # Slide Mode (true or false)
 NEXT_PUBLIC_SLIDE_MODE=""
+
+# System Prompt
+NEXT_PUBLIC_SYSTEM_PROMPT="

--- a/src/components/introduction.tsx
+++ b/src/components/introduction.tsx
@@ -6,10 +6,7 @@ import homeStore from '@/features/stores/home'
 import settingsStore from '@/features/stores/settings'
 import { IconButton } from './iconButton'
 import { Link } from './link'
-import {
-  VoiceLanguage,
-  isLanguageSupported,
-} from '@/features/constants/settings'
+import { isLanguageSupported } from '@/features/constants/settings'
 
 export const Introduction = () => {
   const showIntroduction = homeStore((s) => s.showIntroduction)

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -3,12 +3,7 @@ import { persist } from 'zustand/middleware'
 
 import { KoeiroParam, DEFAULT_PARAM } from '@/features/constants/koeiroParam'
 import { SYSTEM_PROMPT } from '@/features/constants/systemPromptConstants'
-import {
-  AIService,
-  AIVoice,
-  Language,
-  VoiceLanguage,
-} from '../constants/settings'
+import { AIService, AIVoice, Language } from '../constants/settings'
 
 export const multiModalAIServices = ['openai', 'anthropic', 'google'] as const
 export type multiModalAIServiceKey = (typeof multiModalAIServices)[number]
@@ -173,7 +168,7 @@ const settingsStore = create<SettingsState>()(
         process.env.NEXT_PUBLIC_SHOW_ASSISTANT_TEXT === 'true' ? true : false,
       showCharacterName:
         process.env.NEXT_PUBLIC_SHOW_CHARACTER_NAME === 'true' ? true : false,
-      systemPrompt: SYSTEM_PROMPT,
+      systemPrompt: process.env.NEXT_PUBLIC_SYSTEM_PROMPT || SYSTEM_PROMPT,
 
       // General
       selectLanguage:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 新しい環境変数 `NEXT_PUBLIC_SYSTEM_PROMPT` を追加し、AIサービスの初期設定に利用。
	- 設定ストアの `systemPrompt` プロパティが新しい環境変数から値を取得するように変更。

- **バグ修正**
	- 不要なインポート `VoiceLanguage` を削除し、インポート文を簡素化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->