### PR TITLE
新しいOpenAIのモデル追加

### DIFF
--- a/src/components/settings/modelProvider.tsx
+++ b/src/components/settings/modelProvider.tsx
@@ -312,10 +312,10 @@ const ModelProvider = () => {
                       }
                     }}
                   >
-                    <option value="gpt-4o-mini">gpt-4o-mini</option>
                     <option value="chatgpt-4o-latest">chatgpt-4o-latest</option>
-                    <option value="gpt-4o-2024-08-06">gpt-4o-2024-08-06</option>
-                    <option value="gpt-4o">gpt-4o(2024-05-13)</option>
+                    <option value="gpt-4o-mini">gpt-4o-mini</option>
+                    <option value="gpt-4o-2024">gpt-4o-2024-08-06</option>
+                    <option value="gpt-4o-2024-11-20">gpt-4o-2024-11-20</option>
                     <option value="gpt-4-turbo">gpt-4-turbo</option>
                   </select>
                 </div>

--- a/src/components/settings/slideConvert.tsx
+++ b/src/components/settings/slideConvert.tsx
@@ -135,10 +135,10 @@ const SlideConvert: React.FC<SlideConvertProps> = ({ onFolderUpdate }) => {
         >
           {aiService === 'openai' && (
             <>
-              <option value="gpt-4o-mini">gpt-4o-mini</option>
               <option value="chatgpt-4o-latest">chatgpt-4o-latest</option>
-              <option value="gpt-4o-2024-08-06">gpt-4o-2024-08-06</option>
-              <option value="gpt-4o">gpt-4o(2024-05-13)</option>
+              <option value="gpt-4o-mini">gpt-4o-mini</option>
+              <option value="gpt-4o-2024">gpt-4o-2024-08-06</option>
+              <option value="gpt-4o-2024-11-20">gpt-4o-2024-11-20</option>
               <option value="gpt-4-turbo">gpt-4-turbo</option>
             </>
           )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - OpenAIサービスのモデル選択ドロップダウンのオプションを更新しました。具体的には、`gpt-4o`が`gpt-4o-2024-11-20`に変更され、`gpt-4o(2024-05-13)`が削除されました。`gpt-4o-2024-08-06`は`gpt-4o-2024`として保持されています。

- **バグ修正**
  - AIサービスの変更に関するエラーハンドリングが引き続き機能します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->