### PR TITLE
Azure OpenAI Serviceを利用できない不具合を修正

### DIFF
--- a/src/components/settings/modelProvider.tsx
+++ b/src/components/settings/modelProvider.tsx
@@ -55,7 +55,7 @@ const ModelProvider = () => {
     anthropic: 'claude-3-5-sonnet-20241022',
     google: 'gemini-1.5-flash-latest',
     azure: '',
-    groq: 'gemma-7b-it',
+    groq: 'gemma2-9b-it',
     cohere: 'command-r-plus',
     mistralai: 'mistral-large-latest',
     perplexity: 'llama-3-sonar-large-32k-online',
@@ -637,8 +637,10 @@ const ModelProvider = () => {
                     })
                   }
                 >
-                  <option value="gemma-7b-it">gemma-7b-it</option>
-                  <option value="llama3-70b-8192">llama3-70b-8192</option>
+                  <option value="gemma2-9b-it">gemma2-9b-it</option>
+                  <option value="llama-3.3-70b-versatile">
+                    llama-3.3-70b-versatile
+                  </option>
                   <option value="llama3-8b-8192">llama3-8b-8192</option>
                   <option value="mixtral-8x7b-32768">mixtral-8x7b-32768</option>
                 </select>

--- a/src/features/chat/vercelAIChat.ts
+++ b/src/features/chat/vercelAIChat.ts
@@ -10,10 +10,6 @@ const getAIConfig = () => {
   const ss = settingsStore.getState()
   const aiService = ss.selectAIService as multiModalAIServiceKey
 
-  if (!multiModalAIServices.includes(aiService)) {
-    throw new Error('Invalid AI service')
-  }
-
   const apiKeyName = `${aiService}Key` as const
   const apiKey = ss[apiKeyName]
 

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -15,12 +15,7 @@ import {
   AudioModeInputType,
 } from '../constants/settings'
 
-export const multiModalAIServices = [
-  'openai',
-  'anthropic',
-  'google',
-  'azure',
-] as const
+export const multiModalAIServices = ['openai', 'anthropic', 'google'] as const
 export type multiModalAIServiceKey = (typeof multiModalAIServices)[number]
 
 type multiModalAPIKeys = {

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -15,7 +15,12 @@ import {
   AudioModeInputType,
 } from '../constants/settings'
 
-export const multiModalAIServices = ['openai', 'anthropic', 'google'] as const
+export const multiModalAIServices = [
+  'openai',
+  'anthropic',
+  'google',
+  'azure',
+] as const
 export type multiModalAIServiceKey = (typeof multiModalAIServices)[number]
 
 type multiModalAPIKeys = {

--- a/src/pages/api/convertSlide.ts
+++ b/src/pages/api/convertSlide.ts
@@ -164,6 +164,7 @@ async function createSlideLine(
     openai: () => createOpenAI({ apiKey }),
     anthropic: () => createAnthropic({ apiKey }),
     google: () => createGoogleGenerativeAI({ apiKey }),
+    azure: () => {},
   }
 
   const aiServiceInstance = aiServiceConfig[aiService as multiModalAIServiceKey]

--- a/src/pages/api/convertSlide.ts
+++ b/src/pages/api/convertSlide.ts
@@ -164,7 +164,6 @@ async function createSlideLine(
     openai: () => createOpenAI({ apiKey }),
     anthropic: () => createAnthropic({ apiKey }),
     google: () => createGoogleGenerativeAI({ apiKey }),
-    azure: () => {},
   }
 
   const aiServiceInstance = aiServiceConfig[aiService as multiModalAIServiceKey]


### PR DESCRIPTION
突然のp-r失礼します。
以下の変更を加えた後に関係しそうな機能の動作確認は行いましたが、リポジトリ全体を追えてはおりませんので、もしより適切な修正方法があればご教示いただけますと幸いです。

## 発生した事象
AI設定でAzure OpenAI Serviceを指定し、APIキーとEndpointを入力しても `Invalid AI service` エラーが生じるため返答を生成できませんでした。

## 変更内容
https://github.com/tegnike/aituber-kit/blob/8aa8032b3022a33a20847ca807837ebaafe9b15e/src/features/chat/vercelAIChat.ts#L11-L15
にて `multiModalAIServices` に `azure` が含まれていないことが原因と考えられますので、Azure OpenAI Serviceがマルチモーダル対応していることを踏まえて `azure` を追加しました。

## 動作確認
実行環境: Node.js v20.11.0
AI設定; Azure OpenAI Service gpt-4o
音声設定: にじボイス

テキスト入力、画像入力（画面共有、カメラ、ファイル添付）それぞれに対して返答があり、音声が再生され、表情が反映されたことを確認しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - `groq` AIサービスのデフォルトモデルを`'gemma-7b-it'`から`'gemma2-9b-it'`に更新。
  - `groq`サービスに新しいモデルオプション`'llama-3.3-70b-versatile'`を追加。
  - マルチモーダルAIサービスに`'azure'`を追加。

- **バグ修正**
  - AIサービス選択時のバリデーションチェックを削除し、任意のサービスを選択可能に。
  - APIリクエスト失敗時のエラーハンドリングを強化し、エラーコードを含むユーザーフレンドリーなメッセージを表示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->