### PR TITLE
キャラクタープリセット機能を実装

### DIFF
--- a/locales/ar/translation.json
+++ b/locales/ar/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "نص الشخصية",
   "CharacterSettingsInfo": "يتم تعيين هذه القيمة كنص تمهيدي للنظام.\nيرجى الرجوع إلى النص التمهيدي الأولي وتحديد علامات المشاعر للتحكم في تعبيرات وحركات الشخصية. مثال: [neutral]صباح الخير![happy]اليوم أيضاً يوم صعب!",
   "CharacterSettingsReset": "إعادة تعيين إعدادات الشخصية",
+  "characterpresetInfo": " يؤدي تحديد إعداد مسبق إلى تغيير موجه الأحرف.\nCmd + Shift + 1~5 (ماك) / Ctrl + Shift + 1~5 (ويندوز) للاختصارات.\n يؤدي تحديد إعداد مسبق أثناء الضغط باستمرار على مفتاح Shift إلى حفظ مطالبة الحرف الحالي في الإعداد المسبق.",
+  "Characterpreset1": " الإعداد المسبق 1",
+  "Characterpreset2": " الإعداد المسبق 2",
+  "Characterpreset3": " الإعداد المسبق 3",
+  "Characterpreset4": " الإعداد المسبق 4",
+  "Characterpreset5": " الإعداد المسبق 5",
   "SyntheticVoiceEngineChoice": "اختيار محرك الصوت الاصطناعي",
   "VoiceAdjustment": "ضبط الصوت",
   "VoiceEngineInstruction": "اختر محرك الصوت الاصطناعي الذي تريد استخدامه.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "جاري تنفيذ {{funcName}}",
     "FunctionExecutionFailed": "فشل تنفيذ {{funcName}}",
     "FirefoxNotSupported": "هذه الميزة غير مدعومة على Firefox",
-    "SpeechRecognitionError": "حدث خطأ في التعرف على الكلام"
+    "SpeechRecognitionError": "حدث خطأ في التعرف على الكلام",
+    "PresetSwitching": " تم التبديل إلى {{presetName}}."
   },
   "UsingOpenAITTS": "استخدام OpenAI",
   "OpenAITTSInfo": "استخدام OpenAI. يدعم لغات متعددة. إذا اخترت OpenAI كخدمة ذكاء اصطناعي، فلا تحتاج إلى تعيين مفتاح API أدناه.",

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Charakter-Prompt",
   "CharacterSettingsInfo": "Dieser Wert wird als Systemprompt festgelegt.\nBeziehen Sie sich auf den ursprünglichen Prompt und geben Sie Emotions-Tags an, um die Ausdrücke und Bewegungen des Charakters zu steuern. Beispiel: [neutral]Guten Morgen![happy]Auch heute wird ein geschäftiger Tag!",
   "CharacterSettingsReset": "Charaktereinstellungen zurücksetzen",
+  "characterpresetInfo": "Durch Auswahl einer Voreinstellung wird die Zeichenaufforderung geändert.\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) für Tastaturkürzel.\nWenn Sie eine Voreinstellung auswählen, während Sie die Umschalttaste gedrückt halten, wird die aktuelle Zeichenaufforderung in der Voreinstellung gespeichert.",
+  "Characterpreset1": " Voreinstellung 1",
+  "Characterpreset2": "Voreinstellung 2",
+  "Characterpreset3": "Voreinstellung 3",
+  "Characterpreset4": "Voreinstellung 4",
+  "Characterpreset5": "Voreinstellung 5",
   "SyntheticVoiceEngineChoice": "Sprachsynthese-Engine auswählen",
   "VoiceAdjustment": "Sprachanpassung",
   "VoiceEngineInstruction": "Wählen Sie die Sprachsynthese-Engine aus, die Sie verwenden möchten.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "Führe {{funcName}} aus",
     "FunctionExecutionFailed": "Ausführung von {{funcName}} fehlgeschlagen",
     "FirefoxNotSupported": "Diese Funktion wird in Firefox nicht unterstützt",
-    "SpeechRecognitionError": "Ein Spracherkennungsfehler ist aufgetreten"
+    "SpeechRecognitionError": "Ein Spracherkennungsfehler ist aufgetreten",
+    "PresetSwitching": "Umgestellt auf {{presetName}}."
   },
   "UsingOpenAITTS": "OpenAI verwenden",
   "OpenAITTSInfo": "OpenAI verwenden. Unterstützt mehrere Sprachen. Wenn Sie OpenAI als KI-Dienst auswählen, müssen Sie den API-Schlüssel unten nicht konfigurieren.",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Character Prompt",
   "CharacterSettingsInfo": "This value is set as the system prompt.\nPlease refer to the initial prompt and specify the emotion tags to control the character's expressions and motions. Example: [neutral]Good morning![happy]Today is also a hard day!",
   "CharacterSettingsReset": "Reset Character Settings",
+  "characterpresetInfo": "Selecting a preset changes the character prompt.\nShortcuts are available by pressing Cmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows).\nHolding down the Shift key and selecting a preset will save the current character prompt to the preset.",
+  "Characterpreset1": "Preset 1",
+  "Characterpreset2": "Preset 2",
+  "Characterpreset3": "Preset 3",
+  "Characterpreset4": "Preset 4",
+  "Characterpreset5": "Preset 5",
   "SyntheticVoiceEngineChoice": "Choose Synthetic Voice Engine",
   "VoiceAdjustment": "Voice Adjustment",
   "VoiceEngineInstruction": "Select the synthetic voice engine you want to use.",
@@ -199,7 +205,8 @@
     "FunctionExecutionFailed": "Execution of {{funcName}} failed",
     "FirefoxNotSupported": "This feature is not supported on Firefox",
     "SpeechRecognitionError": "Speech recognition error occurred",
-    "NoSpeechDetected": "No speech detected"
+    "NoSpeechDetected": "No speech detected",
+    "PresetSwitching": "Switched to {{presetName}}."
   },
   "UsingOpenAITTS": "Using OpenAI",
   "OpenAITTSInfo": "Using OpenAI. It supports multiple languages. If you select OpenAI as the AI service, you do not need to set the API key below.",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Prompt de personaje",
   "CharacterSettingsInfo": "Este valor se establece como el prompt del sistema.\nPor favor, consulte el prompt inicial y especifique las etiquetas de emoción para controlar las expresiones y movimientos del personaje. Ejemplo: [neutral]¡Buenos días![happy]¡Hoy también es un día difícil!",
   "CharacterSettingsReset": "Restablecer configuración del personaje",
+  "characterpresetInfo": "Al seleccionar un preajuste, cambia la indicación de caracteres.\nCmd + Mayús + 1~5 (Mac) / Ctrl + Mayús + 1~5 (Windows) para los atajos.\nSi se selecciona un preajuste mientras se mantiene pulsada la tecla Mayús, se guarda el carácter actual en el preajuste.",
+  "Characterpreset1": "Preajuste 1",
+  "Characterpreset2": "Preajuste 2",
+  "Characterpreset3": "Preajuste 3",
+  "Characterpreset4": "Preajuste 4",
+  "Characterpreset5": "Preajuste 5",
   "SyntheticVoiceEngineChoice": "Elegir motor de síntesis de voz",
   "VoiceAdjustment": "Ajuste de voz",
   "VoiceEngineInstruction": "Seleccione el motor de síntesis de voz que desea usar.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "Ejecutando {{funcName}}",
     "FunctionExecutionFailed": "La ejecución de {{funcName}} falló",
     "FirefoxNotSupported": "Esta función no está soportada en Firefox",
-    "SpeechRecognitionError": "Ocurrió un error de reconocimiento de voz"
+    "SpeechRecognitionError": "Ocurrió un error de reconocimiento de voz",
+    "PresetSwitching": "Cambiado a {{presetName}}."
   },
   "UsingOpenAITTS": "Usando OpenAI",
   "OpenAITTSInfo": "Usando OpenAI. Admite múltiples idiomas. Si selecciona OpenAI como servicio de IA, no necesita configurar la clave API abajo.",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Invite de personnage",
   "CharacterSettingsInfo": "Cette valeur est définie comme l'invite système.\nVeuillez vous référer à l'invite initiale et spécifier les balises d'émotion pour contrôler les expressions et les mouvements du personnage. Exemple : [neutral]Bonjour![happy]Aujourd'hui est aussi une journée difficile!",
   "CharacterSettingsReset": "Réinitialiser les paramètres du personnage",
+  "characterpresetInfo": "La sélection d'un préréglage modifie l'invite de caractères.\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) pour les raccourcis.\nLa sélection d'un préréglage tout en maintenant la touche Shift enfoncée permet d'enregistrer l'invite de caractères actuelle dans le préréglage.",
+  "Characterpreset1": "Préréglage 1",
+  "Characterpreset2": "Préréglage 2",
+  "Characterpreset3": "Préréglage 3",
+  "Characterpreset4": "Préréglage 4",
+  "Characterpreset5": "Préréglage 5",
   "SyntheticVoiceEngineChoice": "Choisir le moteur de synthèse vocale",
   "VoiceAdjustment": "Ajustement de la voix",
   "VoiceEngineInstruction": "Sélectionnez le moteur de synthèse vocale que vous souhaitez utiliser.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "Exécution de {{funcName}}",
     "FunctionExecutionFailed": "L'exécution de {{funcName}} a échoué",
     "FirefoxNotSupported": "Cette fonctionnalité n'est pas prise en charge sur Firefox",
-    "SpeechRecognitionError": "Une erreur de reconnaissance vocale s'est produite"
+    "SpeechRecognitionError": "Une erreur de reconnaissance vocale s'est produite",
+    "PresetSwitching": "Switched to {{presetName}}."
   },
   "UsingOpenAITTS": "Utilisation d'OpenAI",
   "OpenAITTSInfo": "Utilisation d'OpenAI. Prend en charge plusieurs langues. Si vous sélectionnez OpenAI comme service IA, vous n'avez pas besoin de définir la clé API ci-dessous.",

--- a/locales/hi/translation.json
+++ b/locales/hi/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "कैरेक्टर प्रॉम्प्ट",
   "CharacterSettingsInfo": "यह मान सिस्टम प्रॉम्प्ट के रूप में सेट किया जाता है।\nकृपया कैरेक्टर के भावों और गतियों को नियंत्रित करने के लिए भावना टैग निर्दिष्ट करने के लिए प्रारंभिक प्रॉम्प्ट का संदर्भ लें। उदाहरण: [neutral]सुप्रभात![happy]आज भी एक कठिन दिन है!",
   "CharacterSettingsReset": "कैरेक्टर सेटिंग्स रीसेट करें",
+  "characterpresetInfo": "प्रीसेट का चयन करने पर, चरित्र प्रॉम्प्ट बदल जाएगा।\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) का उपयोग करके शॉर्टकट बनाया जा सकता है।\nShift कुंजी को दबाए रखते हुए प्रीसेट का चयन करने पर, वर्तमान चरित्र प्रॉम्प्ट प्रीसेट में सहेजा जाएगा।",
+  "Characterpreset1": "प्रीसेट 1",
+  "Characterpreset2": "प्रीसेट 2",
+  "Characterpreset3": "प्रीसेट 3",
+  "Characterpreset4": "प्रीसेट 4",
+  "Characterpreset5": "प्रीसेट 5",
   "SyntheticVoiceEngineChoice": "सिंथेटिक वॉइस इंजन चुनें",
   "VoiceAdjustment": "आवाज़ समायोजन",
   "VoiceEngineInstruction": "उपयोग करने के लिए सिंथेटिक वॉइस इंजन चुनें।",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "{{funcName}} निष्पादित हो रहा है",
     "FunctionExecutionFailed": "{{funcName}} का निष्पादन विफल हुआ",
     "FirefoxNotSupported": "यह सुविधा Firefox पर समर्थित नहीं है",
-    "SpeechRecognitionError": "स्पीच पहचान त्रुटि हुई"
+    "SpeechRecognitionError": "स्पीच पहचान त्रुटि हुई",
+    "PresetSwitching": "{{presetName}} में स्विच कर दिया गया है।"
   },
   "UsingOpenAITTS": "OpenAI का उपयोग",
   "OpenAITTSInfo": "OpenAI का उपयोग करें। यह कई भाषाओं का समर्थन करता है। यदि आप AI सेवा के रूप में OpenAI का चयन करते हैं, तो आपको नीचे API कुंजी सेट करने की आवश्यकता नहीं है।",

--- a/locales/it/translation.json
+++ b/locales/it/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Prompt personaggio",
   "CharacterSettingsInfo": "Questo valore viene impostato come prompt di sistema.\nFai riferimento al prompt iniziale e specifica i tag delle emozioni per controllare le espressioni e i movimenti del personaggio. Esempio: [neutral]Buongiorno![happy]Anche oggi sarà una giornata impegnativa!",
   "CharacterSettingsReset": "Reimposta impostazioni personaggio",
+  "characterpresetInfo": "Selezionando una preimpostazione si cambia la richiesta di caratteri.\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) per le scorciatoie.\nSe si seleziona una preimpostazione tenendo premuto il tasto Shift, la richiesta di caratteri corrente viene salvata nella preimpostazione.",
+  "Characterpreset1": "Preset 1",
+  "Characterpreset2": "Preset 2",
+  "Characterpreset3": "Preset 3",
+  "Characterpreset4": "Preset 4",
+  "Characterpreset5": "Preset 5",
   "SyntheticVoiceEngineChoice": "Scegli motore sintesi vocale",
   "VoiceAdjustment": "Regolazione voce",
   "VoiceEngineInstruction": "Seleziona il motore di sintesi vocale che desideri utilizzare.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "Esecuzione {{funcName}}",
     "FunctionExecutionFailed": "Esecuzione {{funcName}} fallita",
     "FirefoxNotSupported": "Questa funzione non è supportata in Firefox",
-    "SpeechRecognitionError": "Si è verificato un errore di riconoscimento vocale"
+    "SpeechRecognitionError": "Si è verificato un errore di riconoscimento vocale",
+    "PresetSwitching": "Passato a {{presetName}}."
   },
   "UsingOpenAITTS": "Usando OpenAI",
   "OpenAITTSInfo": "Usando OpenAI. Supporta più lingue. Se selezioni OpenAI come servizio IA, non devi configurare la chiave API sotto.",

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "キャラクタープロンプト",
   "CharacterSettingsInfo": "この値はシステムプロンプトとして設定されます。\n初期プロンプトを参考に、感情タグを指定することでキャラクターの表情やモーションを制御できます。例: [neutral]おはようございます！[happy]今日もお疲れ様です！",
   "CharacterSettingsReset": "キャラクター設定リセット",
+  "characterpresetInfo": "プリセットを選択すると、キャラクタープロンプトが変更されます。\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows)でショートカットが可能です。\nShiftキーを押しながらプリセットを選ぶと、現在のキャラクタープロンプトがプリセットに保存されます。",
+  "Characterpreset1": "プリセット1",
+  "Characterpreset2": "プリセット2",
+  "Characterpreset3": "プリセット3",
+  "Characterpreset4": "プリセット4",
+  "Characterpreset5": "プリセット5",
   "SyntheticVoiceEngineChoice": "合成音声エンジンの選択",
   "VoiceAdjustment": "声の調整",
   "VoiceEngineInstruction": "使用する合成音声エンジンを選択してください。",
@@ -202,7 +208,8 @@
     "FunctionExecutionFailed": "{{funcName}}の実行に失敗しました",
     "FirefoxNotSupported": "Firefoxではこの機能はサポートされていません",
     "SpeechRecognitionError": "音声認識エラーが発生しました",
-    "NoSpeechDetected": "音声が検出されませんでした。"
+    "NoSpeechDetected": "音声が検出されませんでした。",
+    "PresetSwitching": "{{presetName}}に切り替わりました。"    
   },
   "UsingOpenAITTS": "OpenAIを使用する",
   "OpenAITTSInfo": "OpenAIを使用しています。多言語に対応可能です。AIサービスでOpenAIを選択している場合は下記のAPIキーを設定する必要はありません。",

--- a/locales/ko/translation.json
+++ b/locales/ko/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "캐릭터 프롬프트",
   "CharacterSettingsInfo": "이 값은 시스템 프롬프트로 설정됩니다.\n초기 프롬프트를 참고하여 감정 태그를 지정하여 캐릭터의 표정과 모션을 제어할 수 있습니다. 예: [neutral]좋은 아침이에요![happy]오늘도 힘든 하루예요!",
   "CharacterSettingsReset": "캐릭터 설정 재설정",
+  "characterpresetInfo": "프리셋을 선택하면 캐릭터 프롬프트가 변경됩니다.\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows)로 단축키가 가능합니다.\nShift 키를 누른 상태에서 프리셋을 선택하면 현재 캐릭터 프롬프트가 프리셋에 저장됩니다.",
+  "Characterpreset1": "프리셋 1",
+  "Characterpreset2": "프리셋 2",
+  "Characterpreset3": "프리셋 3",
+  "Characterpreset4": "프리셋 4",
+  "Characterpreset5": "프리셋 5",
   "SyntheticVoiceEngineChoice": "합성 음성 엔진 선택",
   "VoiceAdjustment": "목소리 조정",
   "VoiceEngineInstruction": "사용할 합성 음성 엔진을 선택하십시오.",
@@ -198,7 +204,8 @@
     "FunctionExecuting": "{{funcName}}을(를) 실행하고 있습니다",
     "FunctionExecutionFailed": "{{funcName}}의 실행에 실패했습니다",
     "FirefoxNotSupported": "Firefox에서는 이 기능을 지원하지 않습니다",
-    "SpeechRecognitionError": "음성 인식 오류가 발생했습니다"
+    "SpeechRecognitionError": "음성 인식 오류가 발생했습니다",
+    "PresetSwitching": "{{presetName}}으로 전환되었습니다."
   },
   "UsingOpenAITTS": "OpenAI 사용",
   "OpenAITTSInfo": "OpenAI를 사용하고 있습니다. 다국어에 대응할 수 있습니다. AI 서비스로 OpenAI를 선택한 경우 아래 API 키를 설정할 필요는 없습니다.",

--- a/locales/pl/translation.json
+++ b/locales/pl/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Prompt postaci",
   "CharacterSettingsInfo": "Ta wartość jest ustawiana jako systemowy prompt.\nBazując na początkowym promptcie, możesz określić tagi emocji, aby kontrolować wyraz twarzy i ruchy postaci. Przykład: [neutral] Dzień dobry! [happy] Miłego dnia!",
   "CharacterSettingsReset": "Resetuj ustawienia postaci",
+  "characterpresetInfo": "Wybranie ustawienia wstępnego powoduje zmianę podpowiedzi znaków.\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) dla skrótów.\nWybranie ustawienia wstępnego przy jednoczesnym przytrzymaniu klawisza Shift powoduje zapisanie bieżącego znaku zachęty w ustawieniu wstępnym.",
+  "Characterpreset1": "Ustawienie wstępne 1",
+  "Characterpreset2": "Ustawienie wstępne 2",
+  "Characterpreset3": "Ustawienie wstępne 3",
+  "Characterpreset4": "Ustawienie wstępne 4",
+  "Characterpreset5": "Ustawienie wstępne 5",
   "SyntheticVoiceEngineChoice": "Wybór silnika syntezatora mowy",
   "VoiceAdjustment": "Dostosowanie głosu",
   "VoiceEngineInstruction": "Wybierz silnik syntezatora mowy, którego chcesz używać.",
@@ -197,7 +203,8 @@
     "FunctionExecuting": "Wykonywanie {{funcName}}.",
     "FunctionExecutionFailed": "Wykonanie {{funcName}} nie powiodło się.",
     "FirefoxNotSupported": "Ta funkcja nie jest obsługiwana w Firefoxie",
-    "SpeechRecognitionError": "Wystąpił błąd rozpoznawania mowy"
+    "SpeechRecognitionError": "Wystąpił błąd rozpoznawania mowy",
+    "PresetSwitching": "Przełączono na {{presetName}}."
   },
   "UsingOpenAITTS": "Użyj OpenAI",
   "OpenAITTSInfo": "Używa OpenAI. Obsługuje wiele języków. Jeśli wybrano OpenAI jako usługę AI, nie ma potrzeby ustawiania klucza API poniżej.",

--- a/locales/pt/translation.json
+++ b/locales/pt/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Prompt do personagem",
   "CharacterSettingsInfo": "Este valor é definido como prompt do sistema.\nConsulte o prompt inicial e especifique tags de emoção para controlar expressões e movimentos do personagem. Exemplo: [neutral]Bom dia![happy]Hoje também será um dia ocupado!",
   "CharacterSettingsReset": "Redefinir configurações do personagem",
+  "characterpresetInfo": "A seleção de uma predefinição altera o prompt de caracteres.\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) para atalhos.\nSelecionar uma predefinição mantendo premida a tecla Shift guarda o prompt de caracteres atual na predefinição.",
+  "Characterpreset1": "Predefinição 1",
+  "Characterpreset2": "Predefinição 2",
+  "Characterpreset3": "Predefinição 3",
+  "Characterpreset4": "Predefinição 4",
+  "Characterpreset5": "Predefinição 5",
   "SyntheticVoiceEngineChoice": "Escolher motor de síntese de voz",
   "VoiceAdjustment": "Ajuste de voz",
   "VoiceEngineInstruction": "Selecione o motor de síntese de voz que deseja usar.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "Executando {{funcName}}",
     "FunctionExecutionFailed": "Falha na execução de {{funcName}}",
     "FirefoxNotSupported": "Esta função não é suportada no Firefox",
-    "SpeechRecognitionError": "Ocorreu um erro de reconhecimento de fala"
+    "SpeechRecognitionError": "Ocorreu um erro de reconhecimento de fala",
+    "PresetSwitching": "Mudou para {{presetName}}."
   },
   "UsingOpenAITTS": "Usando OpenAI",
   "OpenAITTSInfo": "Usando OpenAI. Suporta múltiplos idiomas. Se você selecionar OpenAI como serviço de IA, não precisa configurar a chave API abaixo.",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Промпт персонажа",
   "CharacterSettingsInfo": "Это значение устанавливается как системный промпт.\nОбратитесь к исходному промпту и укажите теги эмоций для управления выражениями и движениями персонажа. Пример: [neutral]Доброе утро![happy]Сегодня тоже будет насыщенный день!",
   "CharacterSettingsReset": "Сбросить настройки персонажа",
+  "characterpresetInfo": "Выбор предустановки изменяет подсказку символа.\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) для быстрого доступа.\nПри выборе предустановки с нажатой клавишей Shift текущая подсказка сохраняется в предустановке.",
+  "Characterpreset1": "Предустановка 1",
+  "Characterpreset2": "Предустановка 2",
+  "Characterpreset3": "Предустановка 3",
+  "Characterpreset4": "Предустановка 4",
+  "Characterpreset5": "Предустановка 5",
   "SyntheticVoiceEngineChoice": "Выбор движка синтеза речи",
   "VoiceAdjustment": "Настройка голоса",
   "VoiceEngineInstruction": "Выберите движок синтеза речи, который хотите использовать.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "Выполнение {{funcName}}",
     "FunctionExecutionFailed": "Ошибка выполнения {{funcName}}",
     "FirefoxNotSupported": "Эта функция не поддерживается в Firefox",
-    "SpeechRecognitionError": "Произошла ошибка распознавания речи"
+    "SpeechRecognitionError": "Произошла ошибка распознавания речи",
+    "PresetSwitching": "Переключились на {{presetName}}."
   },
   "UsingOpenAITTS": "Использование OpenAI",
   "OpenAITTSInfo": "Использует OpenAI. Поддерживает несколько языков. Если вы выбрали OpenAI как ИИ-сервис, не нужно настраивать API-ключ ниже.",

--- a/locales/th/translation.json
+++ b/locales/th/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "ข้อความ prompt ของตัวละคร",
   "CharacterSettingsInfo": "ค่านี้จะถูกตั้งเป็น prompt ระบบ\nโดยอ้างอิงจาก prompt เริ่มต้น คุณสามารถระบุแท็กอารมณ์เพื่อควบคุมการแสดงออกและการเคลื่อนไหวของตัวละครได้ ตัวอย่าง: [neutral] สวัสดีตอนเช้า! [happy] สวัสดีวันใหม่!",
   "CharacterSettingsReset": "รีเซ็ตการตั้งค่าตัวละคร",
+  "characterpresetInfo": "การเลือกค่าที่ตั้งไว้ล่วงหน้าจะเปลี่ยนพรอมต์อักขระ\nสามารถใช้ทางลัดกับ Cmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows)\nเมื่อกดปุ่ม Shift ค้างไว้ขณะเลือกค่าที่ตั้งไว้ล่วงหน้า ข้อความแจ้งอักขระปัจจุบันจะถูกบันทึกลงในค่าที่ตั้งไว้ล่วงหน้า",
+  "Characterpreset1": "ที่ตั้งไว้ล่วงหน้า 1",
+  "Characterpreset2": "ที่ตั้งไว้ล่วงหน้า 2",
+  "Characterpreset3": "ที่ตั้งไว้ล่วงหน้า 3",
+  "Characterpreset4": "ที่ตั้งไว้ล่วงหน้า 4",
+  "Characterpreset5": "ที่ตั้งไว้ล่วงหน้า 5",
   "SyntheticVoiceEngineChoice": "เลือกเครื่องยนต์สังเคราะห์เสียง",
   "VoiceAdjustment": "ปรับแต่งเสียง",
   "VoiceEngineInstruction": "กรุณาเลือกเครื่องยนต์สังเคราะห์เสียงที่ต้องการใช้",
@@ -197,7 +203,8 @@
     "FunctionExecuting": "กำลังดำเนินการ {{funcName}}",
     "FunctionExecutionFailed": "การดำเนินการ {{funcName}} ล้มเหลว",
     "FirefoxNotSupported": "ฟังก์ชันนี้ไม่รองรับใน Firefox",
-    "SpeechRecognitionError": "เกิดข้อผิดพลาดในการรู้จำเสียง"
+    "SpeechRecognitionError": "เกิดข้อผิดพลาดในการรู้จำเสียง",
+    "PresetSwitching": "เปลี่ยนเป็น {{presetName}}"
   },
   "UsingOpenAITTS": "ใช้ OpenAI",
   "OpenAITTSInfo": "ใช้ OpenAI รองรับหลายภาษา หากเลือก OpenAI ในบริการ AI ไม่จำเป็นต้องตั้งค่าคีย์ API ด้านล่าง",

--- a/locales/vi/translation.json
+++ b/locales/vi/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "Prompt nhân vật",
   "CharacterSettingsInfo": "Giá trị này được sử dụng làm prompt hệ thống.\nTham khảo prompt ban đầu và chỉ định các tag cảm xúc để điều khiển biểu cảm và chuyển động của nhân vật. Ví dụ: [neutral]Chào buổi sáng![happy]Hôm nay cũng là một ngày bận rộn!",
   "CharacterSettingsReset": "Đặt lại cài đặt nhân vật",
+  "characterpresetInfo": "Chọn cài đặt trước sẽ thay đổi lời nhắc ký tự.\nPhím tắt có thể được sử dụng với Cmd + Shift + 1 ~ 5 (Mac) / Ctrl + Shift + 1 ~ 5 (Windows).\nBằng cách giữ phím Shift trong khi chọn cài đặt trước, lời nhắc ký tự hiện tại sẽ được lưu vào cài đặt trước.",
+  "Characterpreset1": "Đặt trước 1",
+  "Characterpreset2": "Đặt trước 2",
+  "Characterpreset3": "Đặt trước 3",
+  "Characterpreset4": "Đặt trước 4",
+  "Characterpreset5": "Đặt trước 5",
   "SyntheticVoiceEngineChoice": "Chọn engine giọng nói tổng hợp",
   "VoiceAdjustment": "Điều chỉnh giọng nói",
   "VoiceEngineInstruction": "Chọn engine giọng nói tổng hợp bạn muốn sử dụng.",
@@ -196,7 +202,8 @@
     "FunctionExecuting": "Đang thực hiện {{funcName}}",
     "FunctionExecutionFailed": "Thực hiện {{funcName}} thất bại",
     "FirefoxNotSupported": "Tính năng không được hỗ trợ trên Firefox",
-    "SpeechRecognitionError": "Lỗi nhận dạng giọng nói"
+    "SpeechRecognitionError": "Lỗi nhận dạng giọng nói",
+    "PresetSwitching": "Đã chuyển sang {{presetName}}."
   },
   "UsingOpenAITTS": "Sử dụng OpenAI",
   "OpenAITTSInfo": "Sử dụng OpenAI. Hỗ trợ nhiều ngôn ngữ. Nếu chọn OpenAI, không cần nhập khóa API bên dưới.",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -54,6 +54,12 @@
   "CharacterSettingsPrompt": "角色提示",
   "CharacterSettingsInfo": "此值設置為系統提示。\n請參考初始提示，並指定感情標籤，以控制角色的表情和動作。\n例: [neutral]早上好！[happy]今天也要加油喔！",
   "CharacterSettingsReset": "重設角色設定",
+  "characterpresetInfo": "選擇預設會變更字元提示。\nCmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) 為捷徑。\n按住 Shift 鍵的同時選擇預設，可將目前的字元提示儲存在預設中。",
+  "Characterpreset1": "預設 1",
+  "Characterpreset2": "預設 2",
+  "Characterpreset3": "預設 3",
+  "Characterpreset4": "預設 4",
+  "Characterpreset5": "預設 5",
   "SyntheticVoiceEngineChoice": "選擇合成語音引擎",
   "VoiceAdjustment": "語音調整",
   "VoiceEngineInstruction": "選擇您要使用的合成音聲引擎。",
@@ -198,7 +204,8 @@
     "FunctionExecuting": "正在執行{{funcName}}",
     "FunctionExecutionFailed": "{{funcName}}執行失敗",
     "FirefoxNotSupported": "Firefox不支援此功能",
-    "SpeechRecognitionError": "語音認識發生錯誤"
+    "SpeechRecognitionError": "語音認識發生錯誤",
+    "PresetSwitching": "切換至 {{presetName}}。"
   },
   "UsingOpenAITTS": "使用 OpenAI",
   "OpenAITTSInfo": "使用 OpenAI。它支援多種語言。如果您選擇 OpenAI 作為 AI 服務，則不需要設定下面的 API 金鑰。",

--- a/src/components/settings/character.tsx
+++ b/src/components/settings/character.tsx
@@ -322,6 +322,35 @@ const Character = () => {
   >([])
   const selectAIService = settingsStore((s) => s.selectAIService)
   const systemPrompt = settingsStore((s) => s.systemPrompt)
+  const characterPresets = [
+    { key: "characterPreset1", value: settingsStore((s) => s.characterPreset1) },
+    { key: "characterPreset2", value: settingsStore((s) => s.characterPreset2) },
+    { key: "characterPreset3", value: settingsStore((s) => s.characterPreset3) },
+    { key: "characterPreset4", value: settingsStore((s) => s.characterPreset4) },
+    { key: "characterPreset5", value: settingsStore((s) => s.characterPreset5) },
+  ];
+  const [tooltipText, setTooltipText] = useState("");
+
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; visible: boolean }>({
+    x: 0,
+    y: 0,
+    visible: false
+  });
+
+  // ツールチップの縦のサイズの上限を20vhに設定
+  const tooltipMaxHeight = '20vh'
+
+  // ツールチップの表示位置を調整するための定数
+  const tooltipOffsetX = 15;
+  const tooltipOffsetY = 10;
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    setTooltip({ x: e.clientX + tooltipOffsetX, y: e.clientY + tooltipOffsetY, visible: true });
+  };
+
+  const handleMouseLeave = () => {
+    setTooltip((prev) => ({ ...prev, visible: false }));
+  };
 
   useEffect(() => {
     fetch('/api/get-vrm-list')
@@ -490,6 +519,50 @@ const Character = () => {
           >
             {t('CharacterSettingsReset')}
           </TextButton>
+        </div>
+        <div className="my-16 whitespace-pre-line">
+          {t('characterpresetInfo')}
+        </div>
+        <div className="my-24 mb-8 flex flex-wrap gap-4">
+          {characterPresets.map(({ key, value }, index) => (
+            <div key={key} className="relative">
+              <TextButton
+                onClick={(e) => {
+                  if (e.shiftKey) {
+                    settingsStore.setState({ [key]: systemPrompt });
+                    setTooltipText(systemPrompt);
+                  } else {
+                    settingsStore.setState({ systemPrompt: value });
+                    setTooltipText(value);
+                  }
+                }}
+                onMouseMove={(e) => {
+                  handleMouseMove(e);
+                  setTooltipText(value);
+                }}
+                onMouseLeave={() => {
+                  handleMouseLeave();
+                  setTooltipText("");
+                }}
+                className="mr-8 px-4 py-2 text-white rounded-md hover:bg-blue-600 transition"
+              >
+                {t(`Characterpreset${index + 1}`)}
+              </TextButton>
+
+              {tooltip.visible && (
+                <div
+                  className="fixed bg-black opacity-75 text-white text-xs px-2 py-1 rounded-md shadow-md pointer-events-none whitespace-pre-line max-w-xl overflow-hidden text-ellipsis"
+                  style={{
+                    left: `${tooltip.x}px`,
+                    top: `${tooltip.y}px`,
+                    maxHeight: `${tooltipMaxHeight}`,
+                  }}
+                >
+                  {tooltipText}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
         <textarea
           value={systemPrompt}

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -123,6 +123,11 @@ interface Integrations {
 
 interface Character {
   characterName: string
+  characterPreset1: string
+  characterPreset2: string
+  characterPreset3: string
+  characterPreset4: string
+  characterPreset5: string
   showAssistantText: boolean
   showCharacterName: boolean
   systemPrompt: string
@@ -265,6 +270,11 @@ const settingsStore = create<SettingsState>()(
 
       // Character
       characterName: process.env.NEXT_PUBLIC_CHARACTER_NAME || 'CHARACTER',
+      characterPreset1: process.env.NEXT_PUBLIC_CHARACTER_PRESET1 || SYSTEM_PROMPT,
+      characterPreset2: process.env.NEXT_PUBLIC_CHARACTER_PRESET2 || SYSTEM_PROMPT,
+      characterPreset3: process.env.NEXT_PUBLIC_CHARACTER_PRESET3 || SYSTEM_PROMPT,
+      characterPreset4: process.env.NEXT_PUBLIC_CHARACTER_PRESET4 || SYSTEM_PROMPT,
+      characterPreset5: process.env.NEXT_PUBLIC_CHARACTER_PRESET5 || SYSTEM_PROMPT,
       showAssistantText:
         process.env.NEXT_PUBLIC_SHOW_ASSISTANT_TEXT === 'true' ? true : false,
       showCharacterName:
@@ -404,6 +414,11 @@ const settingsStore = create<SettingsState>()(
         difyConversationId: state.difyConversationId,
         youtubeLiveId: state.youtubeLiveId,
         characterName: state.characterName,
+        characterPreset1: state.characterPreset1,
+        characterPreset2: state.characterPreset2, 
+        characterPreset3: state.characterPreset3, 
+        characterPreset4: state.characterPreset4, 
+        characterPreset5: state.characterPreset5, 
         showAssistantText: state.showAssistantText,
         showCharacterName: state.showCharacterName,
         systemPrompt: state.systemPrompt,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Form } from '@/components/form'
 import MessageReceiver from '@/components/messageReceiver'
 import { Introduction } from '@/components/introduction'
@@ -13,6 +15,7 @@ import settingsStore from '@/features/stores/settings'
 import '@/lib/i18n'
 import { buildUrl } from '@/utils/buildUrl'
 import { YoutubeManager } from '@/components/youtubeManager'
+import toastStore from '@/features/stores/toast'
 
 const Home = () => {
   const webcamStatus = homeStore((s) => s.webcamStatus)
@@ -25,6 +28,45 @@ const Home = () => {
       : `url(${buildUrl(backgroundImageUrl)})`
   const messageReceiverEnabled = settingsStore((s) => s.messageReceiverEnabled)
   const modelType = settingsStore((s) => s.modelType)
+  const { t } = useTranslation()
+  const characterPresets = [
+    { key: "characterPreset1", value: settingsStore((s) => s.characterPreset1) },
+    { key: "characterPreset2", value: settingsStore((s) => s.characterPreset2) },
+    { key: "characterPreset3", value: settingsStore((s) => s.characterPreset3) },
+    { key: "characterPreset4", value: settingsStore((s) => s.characterPreset4) },
+    { key: "characterPreset5", value: settingsStore((s) => s.characterPreset5) },
+  ];
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.shiftKey ) {
+        // shiftキーを押しながら数字キーを押すためのマッピング
+        const keyMap: { [key: string]: number } = {
+          Digit1: 1,
+          Digit2: 2,
+          Digit3: 3,
+          Digit4: 4,
+          Digit5: 5,
+        };
+
+        const keyNumber = keyMap[event.code];
+
+        if (keyNumber) {
+          settingsStore.setState({ systemPrompt: characterPresets[keyNumber - 1].value });
+          toastStore.getState().addToast({
+            message: t('Toasts.PresetSwitching', { presetName: t(`Characterpreset${keyNumber}`) }),
+            type: 'info',
+            tag: `character-preset-switching-${keyNumber}`,
+          })
+        }
+      }
+    };
+  
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
 
   return (
     <div className="h-[100svh] bg-cover" style={{ backgroundImage: bgUrl }}>

--- a/website/document/en/guide/character/common.md
+++ b/website/document/en/guide/character/common.md
@@ -15,6 +15,13 @@ NEXT_PUBLIC_MODEL_TYPE=vrm
 
 # System prompt
 NEXT_PUBLIC_SYSTEM_PROMPT="You are an AI assistant named Nike. Please speak in a friendly and cheerful manner. Use the following emotion tags to change your expression and tone of voice as appropriate: [neutral] - normal expression, [happy] - happy expression, [sad] - sad expression, [angry] - angry expression, [relaxed] - relaxed expression"
+
+# character preset
+NEXT_PUBLIC_CHARACTER_PRESET1="You are an AI assistant named Nike."
+NEXT_PUBLIC_CHARACTER_PRESET2="You are an AI assistant named Nike."
+NEXT_PUBLIC_CHARACTER_PRESET3="You are an AI assistant named Nike."
+NEXT_PUBLIC_CHARACTER_PRESET4="You are an AI assistant named Nike."
+NEXT_PUBLIC_CHARACTER_PRESET5="You are an AI assistant named Nike."
 ```
 
 ## Setting the Character Name
@@ -35,6 +42,10 @@ You can select "VRM" or "Live2D" as the character's model type. The setting item
 Set the system prompt that defines the character's personality and response style. This prompt is used when generating AI responses and is an important element that determines the character's individuality.
 
 Be sure to include the character name here.
+
+### character preset
+
+Save multiple character prompts. In addition to direct click recall, shortcuts are available by pressing Cmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows). holding down the Shift key and selecting a preset will save the current character prompt to the preset.
 
 ### Using Emotion Tags
 

--- a/website/document/guide/character/common.md
+++ b/website/document/guide/character/common.md
@@ -15,6 +15,13 @@ NEXT_PUBLIC_MODEL_TYPE=vrm
 
 # システムプロンプト
 NEXT_PUBLIC_SYSTEM_PROMPT="あなたはニケという名前のAIアシスタントです。親しみやすく、明るい性格で話してください。適宜次のような感情タグを使って表情や声のトーンを変えてください。[neutral] - 通常の表情、[happy] - 嬉しい表情、[sad] - 悲しい表情、[angry] - 怒りの表情、[relaxed] - リラックスした表情"
+
+# キャラクタープリセット
+NEXT_PUBLIC_CHARACTER_PRESET1="あなたはニケという名前のAIアシスタントです。"
+NEXT_PUBLIC_CHARACTER_PRESET2="あなたはニケという名前のAIアシスタントです。"
+NEXT_PUBLIC_CHARACTER_PRESET3="あなたはニケという名前のAIアシスタントです。"
+NEXT_PUBLIC_CHARACTER_PRESET4="あなたはニケという名前のAIアシスタントです。"
+NEXT_PUBLIC_CHARACTER_PRESET5="あなたはニケという名前のAIアシスタントです。"
 ```
 
 ## キャラクター名の設定
@@ -35,6 +42,10 @@ NEXT_PUBLIC_SYSTEM_PROMPT="あなたはニケという名前のAIアシスタン
 キャラクターの性格や応答スタイルを定義するシステムプロンプトを設定します。このプロンプトはAIの応答生成時に使用され、キャラクターの個性を決定する重要な要素です。
 
 キャラクター名は必ずここに含めるようにしてください。
+
+### キャラクタープリセット
+
+キャラクタープロンプトを複数保存します。直接クリックして呼び出す他、Cmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows)でショートカットが可能です。Shiftキーを押しながらプリセットを選ぶと、現在のキャラクタープロンプトがプリセットに保存されます。
 
 ### 感情タグの使用
 

--- a/website/document/zh/guide/character/common.md
+++ b/website/document/zh/guide/character/common.md
@@ -15,6 +15,13 @@ NEXT_PUBLIC_MODEL_TYPE=vrm
 
 # 系统提示
 NEXT_PUBLIC_SYSTEM_PROMPT="你是一个名叫Nike的AI助手。请以友好、开朗的性格说话。适当使用以下情感标签来改变表情和语调：[neutral] - 正常表情，[happy] - 高兴表情，[sad] - 悲伤表情，[angry] - 愤怒表情，[relaxed] - 放松表情"
+
+# 字元預設
+NEXT_PUBLIC_CHARACTER_PRESET1="您是一位名叫 Nique 的 AI 助理。"
+NEXT_PUBLIC_CHARACTER_PRESET2="您是一位名叫 Nique 的 AI 助理。"
+NEXT_PUBLIC_CHARACTER_PRESET3="您是一位名叫 Nique 的 AI 助理。"
+NEXT_PUBLIC_CHARACTER_PRESET4="您是一位名叫 Nique 的 AI 助理。"
+NEXT_PUBLIC_CHARACTER_PRESET5="您是一位名叫 Nique 的 AI 助理。"
 ```
 
 ## 设置角色名称
@@ -35,6 +42,10 @@ NEXT_PUBLIC_SYSTEM_PROMPT="你是一个名叫Nike的AI助手。请以友好、�
 设置定义角色性格和回应风格的系统提示。生成AI回应时会使用此提示，它是决定角色个性的重要元素。
 
 请确保在此处包含角色名称。
+
+### 字元預設
+
+儲存多個字元提示。除了直接點選召回外，還可透過 Cmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows) 使用捷徑；按住 Shift 鍵並選擇預設，即可將目前的字元提示儲存在預設中。
 
 ### 使用情感标签
 


### PR DESCRIPTION
取り込みご検討をお願いいたします。

# 関連するイシュー
なし
# やったこと
キャラクタープリセット機能の追加

# できるようになること（ユーザ目線）
設定画面からクリックで呼び出し、キャラクタープロンプトへ上書きできる。
Shiftキーを押しながらプリセットを選ぶと、現在のキャラクタープロンプトがプリセットに保存される。
Cmd + Shift + 1~5 (Mac) / Ctrl + Shift + 1~5 (Windows)でショートカットができる。

![スクリーンショット 2025-03-18 160953](https://github.com/user-attachments/assets/cc41e90c-4a17-40bd-b05d-59e5219485e6)
![スクリーンショット (3)](https://github.com/user-attachments/assets/b9915d72-bf43-4799-8ddc-2badb5b1c849)

# 動作確認
キャラクタープロンプトが上書きされることを確認。キャラクタープリセットが上書きできることを確認
動作確認環境: Windows11 MS Edge localLLM

# その他
ショートカットの実装をindex.tsxで行っています。menu.tsxで実装した際、process.envが呼び出せなかったためです。独自のファイルを作成してもprocess.envを呼び出せず、index.tsxで正常な動作を確認できた形になります。
なにか気づいた点がありましたらメッセージをお願いします。

プリセット名の変更機能は実装していません。ただしtranslation.jsonにあるプリセット名（Characterpreset1など）をいじくれば変更できます。
