### PR TITLE
OPENAI_TTS_KEYにすべきところのtypoを修正

### DIFF
--- a/src/pages/api/openAITTS.ts
+++ b/src/pages/api/openAITTS.ts
@@ -11,7 +11,7 @@ export default async function handler(
 
   const { message, voice, model, speed, apiKey, emotion } = req.body
   const openaiKey =
-    apiKey || process.env.OPENAI_KEY || process.env.OPENAI_API_KEY
+    apiKey || process.env.OPENAI_TTS_KEY || process.env.OPENAI_API_KEY
 
   if (!message || !voice || !model || !openaiKey) {
     return res.status(400).json({ error: 'Missing required parameters' })


### PR DESCRIPTION
.envでOPENAI_TTS_KEYを設定していますが、パラメータ名がOPENAI_KEYにtypoしていたため設定が利用されない状況になっていました。OPENAI_API_KEYが設定されていた場合はこちらが利用されていたため問題が顕在化しなかったのではないかと思います。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **その他**
  - OpenAIのテキスト読み上げ機能で利用するAPIキーの取得方法が変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->