### PR TITLE
feat: 設定画面の会話履歴で過去のコメントや画像を1クリックで削除可能に

### DIFF
--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -340,5 +340,6 @@
   "ImageLoadError": "画像の読み込みに失敗しました。",
   "FileReadError": "ファイルの読み込みに失敗しました。",
   "FileProcessError": "ファイルの処理中にエラーが発生しました。",
-  "GenerateNew": "新規生成"
+  "GenerateNew": "新規生成",
+  "DeleteMessage": "削除"
 }

--- a/src/components/settings/log.tsx
+++ b/src/components/settings/log.tsx
@@ -88,9 +88,12 @@ const Log = () => {
                   )}
                   <button
                     onClick={() => handleDeleteMessage(index)}
-                    className="ml-2 px-2 py-1 text-red-500 hover:text-red-700 rounded"
+                    className="ml-2 p-1 text-red-500 hover:text-red-700 rounded"
+                    title={t('DeleteMessage')}
                   >
-                    {t('DeleteMessage')}
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M12 4L4 12M4 4L12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
                   </button>
                 </div>
               )

--- a/src/components/settings/log.tsx
+++ b/src/components/settings/log.tsx
@@ -23,6 +23,11 @@ const Log = () => {
     homeStore.setState({ chatLog: newChatLog })
   }
 
+  const handleDeleteMessage = (targetIndex: number) => {
+    const newChatLog = chatLog.filter((_, i) => i !== targetIndex)
+    homeStore.setState({ chatLog: newChatLog })
+  }
+
   return (
     <div className="">
       <div className="mb-2 grid-cols-2">
@@ -58,7 +63,7 @@ const Log = () => {
               value.content && (
                 <div
                   key={index}
-                  className="my-2 grid grid-flow-col grid-cols-[100px_1fr] gap-x-fixed"
+                  className="my-2 grid grid-flow-col grid-cols-[100px_1fr_auto] gap-x-fixed"
                 >
                   <div className="min-w-[100px] py-2 whitespace-nowrap">
                     {value.role === 'user' ? 'You' : 'Character'}
@@ -81,6 +86,12 @@ const Log = () => {
                       height={500}
                     />
                   )}
+                  <button
+                    onClick={() => handleDeleteMessage(index)}
+                    className="ml-2 px-2 py-1 text-red-500 hover:text-red-700 rounded"
+                  >
+                    {t('DeleteMessage')}
+                  </button>
                 </div>
               )
             )

--- a/src/components/settings/log.tsx
+++ b/src/components/settings/log.tsx
@@ -91,8 +91,20 @@ const Log = () => {
                     className="ml-2 p-1 text-red-500 hover:text-red-700 rounded"
                     title={t('DeleteMessage')}
                   >
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M12 4L4 12M4 4L12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 4L4 12M4 4L12 12"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
                     </svg>
                   </button>
                 </div>


### PR DESCRIPTION
- 会話履歴の各アイテムに削除ボタンを追加
- 1クリックで特定のメッセージを削除する機能を実装
- グリッドレイアウトを grid-cols-[100px_1fr] から grid-cols-[100px_1fr_auto] に変更
- 削除ボタンは赤色でホバーエフェクト付き
- 日本語翻訳「削除」を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * チャットメッセージごとに削除ボタンが追加され、個別にメッセージを削除できるようになりました。

* **翻訳**
  * 日本語表示に「削除」メッセージが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->