### PR TITLE
feat: 画像表示位置に「アイコンのみ表示」オプションを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,7 +114,7 @@ NEXT_PUBLIC_DYNAMIC_RETRIEVAL_THRESHOLD=""
 # Setting to enable multimodal functionality (true/false)
 NEXT_PUBLIC_ENABLE_MULTIMODAL="true"
 
-# 画像表示位置設定（input: 入力エリア, side: サイドエリア） /
+# 画像表示位置設定（input: 入力エリア, side: サイドパネル） /
 # Image display position setting (input: input area, side: side area)
 NEXT_PUBLIC_IMAGE_DISPLAY_POSITION="input"
 

--- a/.env.example
+++ b/.env.example
@@ -114,8 +114,8 @@ NEXT_PUBLIC_DYNAMIC_RETRIEVAL_THRESHOLD=""
 # Setting to enable multimodal functionality (true/false)
 NEXT_PUBLIC_ENABLE_MULTIMODAL="true"
 
-# 画像表示位置設定（input: 入力エリア, side: サイドパネル） /
-# Image display position setting (input: input area, side: side area)
+# 画像表示位置設定（input: 入力エリア, side: サイドパネル, icon: アイコン） /
+# Image display position setting (input: input area, side: side panel, icon: icon)
 NEXT_PUBLIC_IMAGE_DISPLAY_POSITION="input"
 
 # OpenAI API キー / API key

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -333,6 +333,7 @@
   "ImageDisplayPositionDescription": "アップロードした画像を表示する位置を選択してください",
   "InputArea": "入力エリア",
   "SideArea": "サイドエリア",
+  "NoDisplay": "アイコンのみ表示",
   "PasteImageSupported": "画像ペースト対応",
   "FileSizeError": "ファイルサイズが最大{{maxSize}}MBを超えています。",
   "FileTypeError": "サポートされていないファイル形式です。画像ファイル（PNG、JPEG、GIF、WebP）のみアップロード可能です。",

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -334,6 +334,7 @@
   "InputArea": "入力エリア",
   "SideArea": "サイドエリア",
   "NoDisplay": "アイコンのみ表示",
+  "RemoveImage": "画像を削除",
   "PasteImageSupported": "画像ペースト対応",
   "FileSizeError": "ファイルサイズが最大{{maxSize}}MBを超えています。",
   "FileTypeError": "サポートされていないファイル形式です。画像ファイル（PNG、JPEG、GIF、WebP）のみアップロード可能です。",

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -332,7 +332,7 @@
   "ImageDisplayPosition": "画像表示位置",
   "ImageDisplayPositionDescription": "アップロードした画像を表示する位置を選択してください",
   "InputArea": "入力エリア",
-  "SideArea": "サイドエリア",
+  "SideArea": "サイドパネル",
   "NoDisplay": "アイコンのみ表示",
   "RemoveImage": "画像を削除",
   "PasteImageSupported": "画像ペースト対応",

--- a/src/components/messageInput.tsx
+++ b/src/components/messageInput.tsx
@@ -58,6 +58,7 @@ export const MessageInput = ({
   const [loadingDots, setLoadingDots] = useState('')
   const [showPermissionModal, setShowPermissionModal] = useState(false)
   const [fileError, setFileError] = useState<string>('')
+  const [showImageActions, setShowImageActions] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const realtimeAPIMode = settingsStore((s) => s.realtimeAPIMode)
   const showSilenceProgressBar = settingsStore((s) => s.showSilenceProgressBar)
@@ -427,7 +428,45 @@ export const MessageInput = ({
                 onClick={handleMicClick}
               />
             </div>
-            <div className="flex-1">
+            <div className="flex-1 relative">
+              {/* 画像添付インジケーター - アイコンのみ表示設定の場合 */}
+              {modalImage && imageDisplayPosition === 'icon' && (
+                <div className="absolute left-3 top-3 z-10">
+                  <div
+                    className="relative cursor-pointer"
+                    onClick={() => setShowImageActions(!showImageActions)}
+                    onMouseEnter={() => setShowImageActions(true)}
+                    onMouseLeave={() => setShowImageActions(false)}
+                  >
+                    <svg
+                      className="w-4 h-4 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+                      />
+                    </svg>
+                    {showImageActions && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleRemoveImage()
+                          setShowImageActions(false)
+                        }}
+                        className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 text-white rounded-full flex items-center justify-center text-xs hover:bg-red-600 transition-colors"
+                        title="画像を削除"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
               <textarea
                 ref={textareaRef}
                 placeholder={
@@ -450,7 +489,10 @@ export const MessageInput = ({
                 rows={rows}
                 style={{
                   lineHeight: '1.5',
-                  padding: '8px 16px',
+                  padding:
+                    modalImage && imageDisplayPosition === 'icon'
+                      ? '8px 16px 8px 32px'
+                      : '8px 16px',
                   resize: 'none',
                   whiteSpace: 'pre-wrap',
                 }}

--- a/src/components/messageInput.tsx
+++ b/src/components/messageInput.tsx
@@ -72,6 +72,9 @@ export const MessageInput = ({
     enableMultiModal
   )
 
+  // アイコン表示の条件
+  const showIconDisplay = modalImage && imageDisplayPosition === 'icon'
+
   useEffect(() => {
     if (chatProcessing) {
       const interval = setInterval(() => {
@@ -430,13 +433,17 @@ export const MessageInput = ({
             </div>
             <div className="flex-1 relative">
               {/* 画像添付インジケーター - アイコンのみ表示設定の場合 */}
-              {modalImage && imageDisplayPosition === 'icon' && (
+              {showIconDisplay && (
                 <div className="absolute left-3 top-3 z-10">
                   <div
                     className="relative cursor-pointer"
-                    onClick={() => setShowImageActions(!showImageActions)}
                     onMouseEnter={() => setShowImageActions(true)}
                     onMouseLeave={() => setShowImageActions(false)}
+                    onFocus={() => setShowImageActions(true)}
+                    onBlur={() => setShowImageActions(false)}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={t('RemoveImage')}
                   >
                     <svg
                       className="w-4 h-4 text-gray-500"
@@ -459,7 +466,7 @@ export const MessageInput = ({
                           setShowImageActions(false)
                         }}
                         className="absolute -top-1 -right-1 w-4 h-4 bg-red-500 text-white rounded-full flex items-center justify-center text-xs hover:bg-red-600 transition-colors"
-                        title="画像を削除"
+                        title={t('RemoveImage')}
                       >
                         ×
                       </button>
@@ -489,10 +496,7 @@ export const MessageInput = ({
                 rows={rows}
                 style={{
                   lineHeight: '1.5',
-                  padding:
-                    modalImage && imageDisplayPosition === 'icon'
-                      ? '8px 16px 8px 32px'
-                      : '8px 16px',
+                  padding: showIconDisplay ? '8px 16px 8px 32px' : '8px 16px',
                   resize: 'none',
                   whiteSpace: 'pre-wrap',
                 }}

--- a/src/components/settings/modelProvider.tsx
+++ b/src/components/settings/modelProvider.tsx
@@ -1568,12 +1568,16 @@ const ModelProvider = () => {
               value={imageDisplayPosition}
               onChange={(e) =>
                 settingsStore.setState({
-                  imageDisplayPosition: e.target.value as 'input' | 'side',
+                  imageDisplayPosition: e.target.value as
+                    | 'input'
+                    | 'side'
+                    | 'icon',
                 })
               }
             >
               <option value="input">{t('InputArea')}</option>
               <option value="side">{t('SideArea')}</option>
+              <option value="icon">{t('NoDisplay')}</option>
             </select>
           </div>
         </div>

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -189,7 +189,7 @@ interface General {
   whisperTranscriptionModel: WhisperTranscriptionModel
   initialSpeechTimeout: number
   chatLogWidth: number
-  imageDisplayPosition: 'input' | 'side'
+  imageDisplayPosition: 'input' | 'side' | 'icon'
   autoSendImagesInMultiModal: boolean
   enableMultiModal: boolean
 }
@@ -418,10 +418,10 @@ const getInitialValuesFromEnv = (): SettingsState => ({
   chatLogWidth:
     parseFloat(process.env.NEXT_PUBLIC_CHAT_LOG_WIDTH || '400') || 400,
   imageDisplayPosition: (() => {
-    const validPositions = ['input', 'side'] as const
+    const validPositions = ['input', 'side', 'icon'] as const
     const envPosition = process.env.NEXT_PUBLIC_IMAGE_DISPLAY_POSITION
     return validPositions.includes(envPosition as any)
-      ? (envPosition as 'input' | 'side')
+      ? (envPosition as 'input' | 'side' | 'icon')
       : 'input'
   })(),
   autoSendImagesInMultiModal:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 画像表示位置の設定に「アイコンのみ表示」オプションを追加しました。これにより、画像を入力欄内のアイコンとして表示できるようになりました。
  * 画像が「アイコンのみ表示」設定時、入力欄に画像アイコンが表示され、クリックまたはホバーで画像削除ボタンが表示されます。

* **翻訳**
  * 「サイドエリア」を「サイドパネル」に名称変更しました。
  * 日本語に「アイコンのみ表示」と「画像を削除」の翻訳を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->