### PR TITLE
feat: チャット履歴保存数の入力フィールドを改善

### DIFF
--- a/src/components/settings/modelProvider.tsx
+++ b/src/components/settings/modelProvider.tsx
@@ -1469,15 +1469,15 @@ const ModelProvider = () => {
               <input
                 type="number"
                 min="1"
-                max="100"
-                className="px-4 py-2 w-16 bg-white hover:bg-white-hover rounded-lg"
+                max="9999"
+                className="px-4 py-2 w-24 bg-white hover:bg-white-hover rounded-lg"
                 value={maxPastMessages}
                 onChange={(e) => {
                   const value = parseInt(e.target.value)
                   if (
                     Number.isNaN(value) === false &&
                     value >= 1 &&
-                    value <= 100
+                    value <= 9999
                   ) {
                     settingsStore.setState({ maxPastMessages: value })
                   }


### PR DESCRIPTION
# チャット履歴保存数の入力フィールドを改善

## 概要
保存されるチャット数の設定において、入力フィールドの横幅を拡張し、設定可能な上限値を大幅に増加させました。

## 変更理由
- 入力フィールドが狭く、4桁の数値が見づらい状況でした
- チャット履歴の保存上限が100件と制限的で、より多くの履歴を保存したいユーザーのニーズに対応できませんでした

## 変更内容

### 1. 入力フィールドの横幅拡張
- **変更前**: `w-16` (64px相当)
- **変更後**: `w-24` (96px相当)
- **効果**: 4桁の数値でも視認しやすく入力しやすくなりました

### 2. バリデーション上限の拡張
- **変更前**: 最大100件
- **変更後**: 最大9999件
- **効果**: より多くのチャット履歴を保存可能になり、長期間の会話継続に対応

## 影響範囲
- `src/components/settings/modelProvider.tsx`
- 設定画面の「過去のメッセージ保持数」入力フィールド
- 既存の設定値には影響なし（100以下の値はそのまま維持）

## テスト方法
1. 設定画面を開く
2. 「過去のメッセージ保持数」の入力フィールドを確認
3. 1〜9999の範囲で数値を入力し、正常に保存されることを確認
4. 範囲外の値（0以下、10000以上）で適切にバリデーションされることを確認

## 破壊的変更
なし

## 関連Issue
なし