### PR TITLE
fix: relax Node.js engine requirement for Vercel compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "web-streams-polyfill": "^4.2.0"
   },
   "engines": {
-    "node": "^25.2.1"
+    "node": ">=20.0.0"
   },
   "volta": {
     "node": "25.2.1",


### PR DESCRIPTION
## Summary

- `engines.node` を `"^25.2.1"` から `">=20.0.0"` に変更
- Vercelは現在 Node.js 20.x までのサポートのため、`^25.2.1` ではデプロイが失敗します
- Volta設定（ローカル開発用）は 25.2.1 のまま維持

## Test plan

- [x] Node.js 20.x でローカルビルド成功確認
- [x] Vercelデプロイ成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **動作環境の改善**
  * サポートされるNode.jsのバージョン範囲を拡大しました。Node.js 20.0.0以上の幅広いバージョンで実行可能になり、より多くの環境での利用が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->