### PR TITLE
fix: ローカルLLM利用時のチャット履歴永続化負荷を軽減する

### DIFF
--- a/src/__tests__/features/stores/home.test.ts
+++ b/src/__tests__/features/stores/home.test.ts
@@ -32,6 +32,11 @@ describe('homeStore', () => {
   beforeEach(() => {
     jest.spyOn(console, 'log').mockImplementation(() => {})
     jest.spyOn(console, 'error').mockImplementation(() => {})
+    ;(global as typeof globalThis & { fetch: jest.Mock }).fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+      })
     // Reset store state
     homeStore.setState({
       chatLog: [],
@@ -42,6 +47,7 @@ describe('homeStore', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
+    delete (global as typeof globalThis & { fetch?: jest.Mock }).fetch
   })
 
   describe('chatProcessingCount', () => {

--- a/src/__tests__/features/stores/homePersistence.test.ts
+++ b/src/__tests__/features/stores/homePersistence.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('@/features/vrmViewer/viewer', () => ({
+  Viewer: jest.fn().mockImplementation(() => ({
+    model: null,
+  })),
+}))
+jest.mock('pixi-live2d-display-lipsyncpatch', () => ({}))
+jest.mock('@/features/memory/memoryStoreSync', () => ({
+  addEmbeddingsToMessages: jest.fn((msgs: unknown[]) => Promise.resolve(msgs)),
+}))
+jest.mock('@/features/messages/messageSelectors', () => ({
+  messageSelectors: {
+    cutImageMessage: (chatLog: unknown[]) => chatLog,
+    sanitizeMessageForStorage: (msg: unknown) => msg,
+  },
+}))
+
+describe('homeStore persistence debounce', () => {
+  const storageKey = 'aitube-kit-home'
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.useFakeTimers()
+    localStorage.clear()
+    ;(global as typeof globalThis & { fetch: jest.Mock }).fetch = jest
+      .fn()
+      .mockResolvedValue({
+        ok: true,
+      })
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+    localStorage.clear()
+    delete (global as typeof globalThis & { fetch?: jest.Mock }).fetch
+  })
+
+  it('debounces repeated chat log persistence during streaming updates', async () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem')
+    const homeStore = require('@/features/stores/home').default
+
+    homeStore.setState({ chatLog: [] })
+    setItemSpy.mockClear()
+
+    homeStore.getState().upsertMessage({
+      id: 'assistant-stream',
+      role: 'assistant',
+      content: 'a',
+    })
+    homeStore.getState().upsertMessage({
+      id: 'assistant-stream',
+      content: 'ab',
+    })
+    homeStore.getState().upsertMessage({
+      id: 'assistant-stream',
+      content: 'abc',
+    })
+
+    await Promise.resolve()
+    expect(setItemSpy).not.toHaveBeenCalledWith(storageKey, expect.any(String))
+
+    jest.advanceTimersByTime(800)
+
+    expect(setItemSpy).toHaveBeenCalledTimes(1)
+    expect(setItemSpy).toHaveBeenLastCalledWith(
+      storageKey,
+      expect.stringContaining('"content":"abc"')
+    )
+  })
+})

--- a/src/features/stores/home.ts
+++ b/src/features/stores/home.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { createJSONStorage, persist, StateStorage } from 'zustand/middleware'
 
 import { Message } from '@/features/messages/messages'
 import { Viewer } from '../vrmViewer/viewer'
@@ -42,6 +42,98 @@ export interface TransientState {
 }
 
 export type HomeState = PersistedState & TransientState
+
+const HOME_STORAGE_KEY = 'aitube-kit-home'
+const HOME_STORAGE_WRITE_DEBOUNCE_MS = 750
+
+let pendingHomePersistValue: string | null = null
+let homePersistTimer: ReturnType<typeof setTimeout> | null = null
+let homePersistListenersRegistered = false
+
+const flushPendingHomePersist = () => {
+  if (typeof window === 'undefined' || pendingHomePersistValue === null) {
+    return
+  }
+
+  window.localStorage.setItem(HOME_STORAGE_KEY, pendingHomePersistValue)
+  pendingHomePersistValue = null
+}
+
+const scheduleHomePersistWrite = (value: string) => {
+  pendingHomePersistValue = value
+
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (homePersistTimer) {
+    clearTimeout(homePersistTimer)
+  }
+
+  homePersistTimer = setTimeout(() => {
+    homePersistTimer = null
+    flushPendingHomePersist()
+  }, HOME_STORAGE_WRITE_DEBOUNCE_MS)
+}
+
+const clearPendingHomePersist = () => {
+  pendingHomePersistValue = null
+  if (homePersistTimer) {
+    clearTimeout(homePersistTimer)
+    homePersistTimer = null
+  }
+}
+
+const registerHomePersistFlushListeners = () => {
+  if (typeof window === 'undefined' || homePersistListenersRegistered) {
+    return
+  }
+
+  const flush = () => {
+    if (homePersistTimer) {
+      clearTimeout(homePersistTimer)
+      homePersistTimer = null
+    }
+    flushPendingHomePersist()
+  }
+
+  window.addEventListener('pagehide', flush)
+  window.addEventListener('beforeunload', flush)
+  homePersistListenersRegistered = true
+}
+
+const homePersistStorage: StateStorage = {
+  getItem: (name) => {
+    if (typeof window === 'undefined') {
+      return null
+    }
+    return window.localStorage.getItem(name)
+  },
+  setItem: (name, value) => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (name !== HOME_STORAGE_KEY) {
+      window.localStorage.setItem(name, value)
+      return
+    }
+
+    registerHomePersistFlushListeners()
+    scheduleHomePersistWrite(value)
+  },
+  removeItem: (name) => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (name === HOME_STORAGE_KEY) {
+      clearPendingHomePersist()
+    }
+
+    window.localStorage.removeItem(name)
+  },
+}
 
 // 更新の一時的なバッファリングを行うための変数
 let saveDebounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -128,7 +220,6 @@ const homeStore = create<HomeState>()(
               ...message,
               id: messageId,
             }
-            console.log(`Message updated: ID=${messageId}`)
           } else {
             if (!message.role || message.content === undefined) {
               console.error(
@@ -147,7 +238,6 @@ const homeStore = create<HomeState>()(
               ...(message.thinking && { thinking: message.thinking }),
             }
             updatedChatLog = [...currentChatLog, newMessage]
-            console.log(`Message added: ID=${messageId}`)
           }
 
           return { chatLog: updatedChatLog }
@@ -172,7 +262,8 @@ const homeStore = create<HomeState>()(
       lastDetectionTime: null,
     }),
     {
-      name: 'aitube-kit-home',
+      name: HOME_STORAGE_KEY,
+      storage: createJSONStorage(() => homePersistStorage),
       partialize: ({ chatLog, showIntroduction }) => ({
         chatLog: messageSelectors.cutImageMessage(chatLog),
         showIntroduction,
@@ -226,6 +317,11 @@ homeStore.subscribe((state, prevState) => {
         }
 
         console.log(`Saving ${messagesWithEmbedding.length} new messages...`)
+
+        if (typeof fetch !== 'function') {
+          console.warn('fetch is unavailable. Skipping chat log save.')
+          return
+        }
 
         void fetch('/api/save-chat-log', {
           method: 'POST',


### PR DESCRIPTION
## 概要
Windows で Chrome を使用し、ローカル LLM に接続した状態で細粒度ストリーミングが発生すると、CPU 負荷が高くなり会話継続が重くなるケースがありました。

- Edge や API 経由では比較的軽い
- VRM だけでなく PNGTuber でも再現する

## 原因
ストリーミング各チャンクで `chatLog` が更新され、そのたびに Zustand `persist` が `localStorage` へ同期書き込みしていました。Windows + Chrome + 細粒度ローカルストリームの組み合わせで、この同期書き込みが hot path を叩いて CPU 使用率を押し上げていました。

## 変更内容
- `src/features/stores/home.ts` で `chatLog` 永続化の `localStorage` 書き込みをデバウンス化
- `pagehide` / `beforeunload` で未反映分を flush
- ストリーミング中の不要な `console.log` を削減
- テスト環境で `fetch` が未定義でも落ちないようガードを追加
- 永続化まわりのテストを追加・更新

## 変更ファイル
- `src/features/stores/home.ts`
- `src/__tests__/features/stores/home.test.ts`
- `src/__tests__/features/stores/homePersistence.test.ts`

## 検証
- `npm test -- --runInBand --runTestsByPath src/__tests__/features/stores/home.test.ts src/__tests__/features/stores/homePersistence.test.ts`
- 結果: 2 suites / 19 tests passed
- 手動確認観点: Windows/Chrome と Windows/Edge で各 5 回会話テストし、過大な CPU 負荷や会話停止がないことを確認

## 補足
- プライベート情報は含めていません
- 自動 E2E の途中結果は本 PR には含めていません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ページを離れる際のデータ自動保存機能を改善
  * ストレージへの書き込み頻度を最適化し、処理負荷を削減
  * チャットログ保存時のエラーハンドリングを強化

* **テスト**
  * ストレージ永続化機能の動作確認テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->