### PR TITLE
Fix Cloudflare deploy bundling

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,11 @@ const nextConfig = {
       ],
     },
     outputFileTracingIncludes: {
-      '*': ['./node_modules/@posthog/core/dist/logs/**/*'],
+      '*': [
+        './node_modules/@posthog/core/dist/logs/**/*',
+        './node_modules/unist-util-visit-parents/lib/color*.js',
+        './node_modules/vfile/lib/min*.js',
+      ],
     },
   }),
   env: {

--- a/src/cloudflare-stubs/ast-grep-napi.js
+++ b/src/cloudflare-stubs/ast-grep-napi.js
@@ -1,0 +1,4 @@
+throw new Error('@ast-grep/napi is not available in the Cloudflare runtime')
+
+export const Lang = {}
+export const parse = undefined

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,6 +3,9 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],
+  "alias": {
+    "@ast-grep/napi": "./src/cloudflare-stubs/ast-grep-napi.js",
+  },
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS",


### PR DESCRIPTION
## バグ修正

- Cloudflare Workersへの本番デプロイ時に、Wranglerのbundleがnative optional dependencyを解決しようとして失敗する問題を修正しました。
  - `@ast-grep/napi` をCloudflare runtime用stubへaliasし、native `.node` ファイルがbundle対象にならないようにしました。
  - OpenNextのファイルトレースに、`vfile` と `unist-util-visit-parents` の条件付きexportsで必要になるファイルを明示的に含めました。

## テスト

- `npm run build:cloudflare` が成功することを確認しました。
- `wrangler deploy --dry-run` が成功することを確認しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルド設定を最適化し、複数の依存モジュールのトレース対象を拡張しました。
  * Cloudflareランタイム環境での互換性を向上させるためのモジュールマッピング設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->