### PR TITLE
[codex] Fix game commentary capture and v1 messages API

### DIFF
--- a/src/__tests__/components/captureLifecycle.test.tsx
+++ b/src/__tests__/components/captureLifecycle.test.tsx
@@ -29,6 +29,8 @@ const createMediaStreamMock = () => {
 }
 
 describe('Capture lifecycle', () => {
+  let mediaTrack: ReturnType<typeof createMediaStreamMock>['track']
+
   beforeEach(() => {
     jest.clearAllMocks()
     homeStore.setState({ captureStatus: false })
@@ -38,7 +40,8 @@ describe('Capture lifecycle', () => {
       useVideoAsBackground: true,
     })
 
-    const { stream } = createMediaStreamMock()
+    const { stream, track } = createMediaStreamMock()
+    mediaTrack = track
     Object.defineProperty(navigator, 'mediaDevices', {
       configurable: true,
       value: {
@@ -53,9 +56,12 @@ describe('Capture lifecycle', () => {
     await waitFor(() => {
       expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
     })
+    expect(homeStore.getState().captureStatus).toBe(true)
 
     unmount()
 
+    expect(mediaTrack.stop).toHaveBeenCalledTimes(1)
+    expect(homeStore.getState().captureStatus).toBe(false)
     expect(menuStore.getState().showCapture).toBe(true)
     expect(settingsStore.getState().hideVideoDisplay).toBe(true)
     expect(settingsStore.getState().useVideoAsBackground).toBe(true)
@@ -67,9 +73,12 @@ describe('Capture lifecycle', () => {
     await waitFor(() => {
       expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
     })
+    expect(homeStore.getState().captureStatus).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'stop source' }))
 
+    expect(mediaTrack.stop).toHaveBeenCalledTimes(1)
+    expect(homeStore.getState().captureStatus).toBe(false)
     expect(menuStore.getState().showCapture).toBe(false)
     expect(settingsStore.getState().hideVideoDisplay).toBe(false)
     expect(settingsStore.getState().useVideoAsBackground).toBe(false)

--- a/src/__tests__/components/captureLifecycle.test.tsx
+++ b/src/__tests__/components/captureLifecycle.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import Capture from '@/components/capture'
+import homeStore from '@/features/stores/home'
+import menuStore from '@/features/stores/menu'
+import settingsStore from '@/features/stores/settings'
+
+jest.mock('@/components/common/VideoDisplay', () => ({
+  VideoDisplay: ({ onStopSource }: { onStopSource?: () => void }) => (
+    <button type="button" onClick={onStopSource}>
+      stop source
+    </button>
+  ),
+}))
+
+const createMediaStreamMock = () => {
+  const track = {
+    stop: jest.fn(),
+    addEventListener: jest.fn(),
+  }
+
+  return {
+    track,
+    stream: {
+      getTracks: () => [track],
+      getVideoTracks: () => [track],
+    },
+  }
+}
+
+describe('Capture lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    homeStore.setState({ captureStatus: false })
+    menuStore.setState({ showCapture: true })
+    settingsStore.setState({
+      hideVideoDisplay: true,
+      useVideoAsBackground: true,
+    })
+
+    const { stream } = createMediaStreamMock()
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getDisplayMedia: jest.fn().mockResolvedValue(stream),
+      },
+    })
+  })
+
+  it('does not hide the capture panel during component cleanup', async () => {
+    const { unmount } = render(<Capture />)
+
+    await waitFor(() => {
+      expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
+    })
+
+    unmount()
+
+    expect(menuStore.getState().showCapture).toBe(true)
+    expect(settingsStore.getState().hideVideoDisplay).toBe(true)
+    expect(settingsStore.getState().useVideoAsBackground).toBe(true)
+  })
+
+  it('hides the capture panel only when screen sharing is explicitly stopped', async () => {
+    render(<Capture />)
+
+    await waitFor(() => {
+      expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'stop source' }))
+
+    expect(menuStore.getState().showCapture).toBe(false)
+    expect(settingsStore.getState().hideVideoDisplay).toBe(false)
+    expect(settingsStore.getState().useVideoAsBackground).toBe(false)
+  })
+})

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -267,6 +267,43 @@ describe('/api/v1 external API', () => {
     )
   })
 
+  it('falls back to text when v1 messages contains an empty messages array', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: {
+          messages: [],
+          text: 'fallback text',
+        },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'fallback text',
+        type: 'direct_send',
+      })
+    )
+  })
+
   it('supports ai_generate through v1 messages requests', () => {
     const v1Messages = require('@/pages/api/v1/messages').default
     const messages = require('@/pages/api/messages').default

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -185,6 +185,134 @@ describe('/api/v1 external API', () => {
     )
   })
 
+  it('queues v1 messages requests with the legacy messages payload shape', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: {
+          messages: ['hello from v1 messages'],
+          type: 'direct_send',
+          emotion: 'happy',
+        },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        ok: true,
+        clientId: 'client1',
+        type: 'direct_send',
+        count: 1,
+      })
+    )
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'hello from v1 messages',
+        type: 'direct_send',
+        emotion: 'happy',
+        source: 'v1',
+      })
+    )
+  })
+
+  it('defaults v1 messages requests to direct_send when type is omitted', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: { messages: ['default direct send'] },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'default direct send',
+        type: 'direct_send',
+      })
+    )
+  })
+
+  it('supports ai_generate through v1 messages requests', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: {
+          text: 'describe this',
+          type: 'ai_generate',
+          useCurrentSystemPrompt: false,
+          systemPrompt: 'Be concise',
+        },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        type: 'ai_generate',
+      })
+    )
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'describe this',
+        type: 'ai_generate',
+        systemPrompt: 'Be concise',
+        useCurrentSystemPrompt: false,
+      })
+    )
+  })
+
   it('queues chat requests as user_input by default', () => {
     const chat = require('@/pages/api/v1/chat').default
     const messages = require('@/pages/api/messages').default

--- a/src/components/capture.tsx
+++ b/src/components/capture.tsx
@@ -137,9 +137,9 @@ const Capture = () => {
 
   useEffect(() => {
     return () => {
-      stopCapture()
+      cleanupStream()
     }
-  }, [stopCapture])
+  }, [cleanupStream])
 
   return (
     <VideoDisplay

--- a/src/pages/api/v1/messages.ts
+++ b/src/pages/api/v1/messages.ts
@@ -1,0 +1,124 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  enqueueMessages,
+  enqueueStopCommand,
+  MessageType,
+} from '@/features/api/messageGateway'
+import {
+  getClientIdFromRequest,
+  normalizeImage,
+  normalizeMessages,
+  requireApiKey,
+  sendMethodNotAllowed,
+} from '@/features/api/http'
+import {
+  isRestrictedMode,
+  createRestrictedModeErrorResponse,
+} from '@/utils/restrictedMode'
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+}
+
+const allowedTypes: MessageType[] = ['direct_send', 'ai_generate', 'user_input']
+
+const normalizeMessageType = (value: unknown): MessageType | null => {
+  return allowedTypes.includes(value as MessageType)
+    ? (value as MessageType)
+    : null
+}
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  if (isRestrictedMode()) {
+    return res
+      .status(403)
+      .json(createRestrictedModeErrorResponse('v1/messages'))
+  }
+
+  if (req.method !== 'POST') {
+    return sendMethodNotAllowed(res)
+  }
+
+  if (!requireApiKey(req, res)) return
+
+  const clientId = getClientIdFromRequest(req, req.body?.clientId)
+  if (!clientId) {
+    return res.status(400).json({ error: 'Client ID is required' })
+  }
+
+  const rawType = req.body?.type ?? req.query.type ?? 'direct_send'
+  const type = normalizeMessageType(rawType)
+  if (!type) {
+    return res.status(400).json({ error: 'Invalid type' })
+  }
+
+  const messages = normalizeMessages(req.body?.messages ?? req.body?.text)
+  if (messages.length === 0) {
+    return res.status(400).json({ error: 'Text or messages are required' })
+  }
+
+  if (
+    req.body?.systemPrompt !== undefined &&
+    typeof req.body.systemPrompt !== 'string'
+  ) {
+    return res.status(400).json({ error: 'System prompt is not a string' })
+  }
+
+  if (
+    req.body?.useCurrentSystemPrompt !== undefined &&
+    typeof req.body.useCurrentSystemPrompt !== 'boolean'
+  ) {
+    return res
+      .status(400)
+      .json({ error: 'useCurrentSystemPrompt is not a boolean' })
+  }
+
+  const imageResult = normalizeImage(req.body?.image)
+  if (!imageResult.ok) {
+    return res.status(imageResult.status).json({ error: imageResult.error })
+  }
+
+  const interrupt = req.body?.interrupt === true
+  if (interrupt) {
+    enqueueStopCommand(clientId, 'all', 'interrupt_before_messages')
+  }
+
+  const useCurrentSystemPrompt =
+    typeof req.body?.useCurrentSystemPrompt === 'boolean'
+      ? req.body.useCurrentSystemPrompt
+      : true
+
+  const queuedMessages = enqueueMessages({
+    clientId,
+    messages,
+    type,
+    systemPrompt:
+      type === 'ai_generate' && !useCurrentSystemPrompt
+        ? req.body?.systemPrompt
+        : undefined,
+    useCurrentSystemPrompt:
+      type === 'ai_generate' ? useCurrentSystemPrompt : undefined,
+    image: imageResult.image,
+    emotion:
+      type === 'direct_send' && typeof req.body?.emotion === 'string'
+        ? req.body.emotion
+        : undefined,
+    priority: req.body?.priority === 'high' ? 'high' : 'normal',
+    interrupt,
+    source: 'v1',
+  })
+
+  return res.status(202).json({
+    ok: true,
+    clientId,
+    type,
+    queued: queuedMessages.map((message) => message.id),
+    count: queuedMessages.length,
+  })
+}
+
+export default handler

--- a/src/pages/api/v1/messages.ts
+++ b/src/pages/api/v1/messages.ts
@@ -56,7 +56,9 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(400).json({ error: 'Invalid type' })
   }
 
-  const messages = normalizeMessages(req.body?.messages ?? req.body?.text)
+  const bodyMessages = normalizeMessages(req.body?.messages)
+  const messages =
+    bodyMessages.length > 0 ? bodyMessages : normalizeMessages(req.body?.text)
   if (messages.length === 0) {
     return res.status(400).json({ error: 'Text or messages are required' })
   }

--- a/src/pages/send-message.tsx
+++ b/src/pages/send-message.tsx
@@ -16,6 +16,7 @@ import {
 } from '@heroicons/react/24/outline'
 
 type EndpointId =
+  | 'messages'
   | 'speak'
   | 'chat'
   | 'stop'
@@ -45,6 +46,57 @@ type EndpointDefinition = {
 }
 
 const endpoints: EndpointDefinition[] = [
+  {
+    id: 'messages',
+    group: 'v1',
+    label: 'Messages',
+    method: 'POST',
+    path: '/api/v1/messages/',
+    description:
+      'messages と type を指定して、発話・AI生成・通常入力をまとめて送信します。',
+    requiresApiKey: true,
+    defaultBody: {
+      messages: ['こんにちは。外部APIからの発話テストです。'],
+      type: 'direct_send',
+    },
+    fields: [
+      {
+        name: 'messages',
+        type: 'string[]',
+        required: true,
+        description: '送信する本文の配列です。',
+      },
+      {
+        name: 'type',
+        type: '"direct_send" | "ai_generate" | "user_input"',
+        description:
+          'direct_send はそのまま発話、ai_generate はAI生成、user_input は通常入力として処理します。',
+      },
+      {
+        name: 'text',
+        type: 'string',
+        description: 'messages の代わりに単一本文を送る場合に使います。',
+      },
+      {
+        name: 'systemPrompt',
+        type: 'string',
+        description:
+          'type が ai_generate で useCurrentSystemPrompt=false のときに使うシステムプロンプトです。',
+      },
+      {
+        name: 'useCurrentSystemPrompt',
+        type: 'boolean',
+        description:
+          'type が ai_generate のとき、現在のキャラクター設定のシステムプロンプトを使うかどうかです。',
+      },
+      {
+        name: 'image',
+        type: 'string',
+        description:
+          'data URL などの画像文字列です。画像付き入力として処理します。',
+      },
+    ],
+  },
   {
     id: 'speak',
     group: 'v1',
@@ -311,17 +363,39 @@ const codeSampleTabs: Array<{ id: CodeSampleId; label: string }> = [
   { id: 'python', label: 'Python' },
 ]
 
+const defaultEndpoint = endpoints.find(
+  (endpoint) => endpoint.id === 'messages'
+)!
+
 const stringifyBody = (body?: Record<string, unknown>) =>
   body ? JSON.stringify(body, null, 2) : ''
 
+const extractMessageText = (
+  endpoint: EndpointDefinition,
+  body?: Record<string, unknown>
+) => {
+  const value =
+    endpoint.group === 'legacy' || endpoint.id === 'messages'
+      ? body?.messages
+      : body?.text
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === 'string').join('\n')
+  }
+  return ''
+}
+
 const SendMessage = () => {
   const { t } = useTranslation()
-  const [selectedId, setSelectedId] = useState<EndpointId>('speak')
+  const [selectedId, setSelectedId] = useState<EndpointId>(defaultEndpoint.id)
   const [clientId, setClientId] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [baseUrl, setBaseUrl] = useState('')
   const [requestBody, setRequestBody] = useState(
-    stringifyBody(endpoints[0].defaultBody)
+    stringifyBody(defaultEndpoint.defaultBody)
+  )
+  const [messageText, setMessageText] = useState(
+    extractMessageText(defaultEndpoint, defaultEndpoint.defaultBody)
   )
   const [responseText, setResponseText] = useState('')
   const [isSending, setIsSending] = useState(false)
@@ -472,9 +546,39 @@ print(response.json())`
   const handleEndpointChange = (endpoint: EndpointDefinition) => {
     setSelectedId(endpoint.id)
     setRequestBody(stringifyBody(endpoint.defaultBody))
+    setMessageText(extractMessageText(endpoint, endpoint.defaultBody))
     setResponseText('')
     if (window.innerWidth < 1024) {
       setEndpointsOpen(false)
+    }
+  }
+
+  const handleMessageTextChange = (text: string) => {
+    setMessageText(text)
+
+    try {
+      const body = requestBody.trim()
+        ? JSON.parse(requestBody)
+        : { ...(selectedEndpoint.defaultBody ?? {}) }
+      if (
+        selectedEndpoint.group === 'legacy' ||
+        selectedEndpoint.id === 'messages'
+      ) {
+        body.messages = text
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean)
+      } else {
+        body.text = text
+      }
+      setRequestBody(JSON.stringify(body, null, 2))
+    } catch {
+      const body =
+        selectedEndpoint.group === 'legacy' ||
+        selectedEndpoint.id === 'messages'
+          ? { messages: text ? [text] : [] }
+          : { text }
+      setRequestBody(JSON.stringify(body, null, 2))
     }
   }
 
@@ -772,6 +876,25 @@ print(response.json())`
                           に相当します。
                         </div>
                       </div>
+                    )}
+                    {(selectedEndpoint.id === 'messages' ||
+                      selectedEndpoint.id === 'speak' ||
+                      selectedEndpoint.id === 'chat' ||
+                      selectedEndpoint.id.startsWith('legacy_')) && (
+                      <label className="flex min-w-0 flex-col gap-2 text-sm font-bold text-text-primary">
+                        <span className="flex items-center gap-2">
+                          <PaperAirplaneIcon className="h-5 w-5 text-primary" />
+                          Message
+                        </span>
+                        <textarea
+                          value={messageText}
+                          onChange={(event) =>
+                            handleMessageTextChange(event.target.value)
+                          }
+                          className="theme-surface-control min-h-[120px] w-full min-w-0 rounded-lg border p-3 text-sm font-normal leading-6 text-theme-default outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                          spellCheck={false}
+                        />
+                      </label>
                     )}
                     <label className="flex min-w-0 flex-col gap-2 text-sm font-bold text-text-primary">
                       <span className="flex items-center gap-2">

--- a/src/pages/send-message.tsx
+++ b/src/pages/send-message.tsx
@@ -370,6 +370,11 @@ const defaultEndpoint = endpoints.find(
 const stringifyBody = (body?: Record<string, unknown>) =>
   body ? JSON.stringify(body, null, 2) : ''
 
+const isRequestBodyObject = (
+  value: unknown
+): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
 const extractMessageText = (
   endpoint: EndpointDefinition,
   body?: Record<string, unknown>
@@ -557,8 +562,11 @@ print(response.json())`
     setMessageText(text)
 
     try {
-      const body = requestBody.trim()
+      const parsed = requestBody.trim()
         ? JSON.parse(requestBody)
+        : { ...(selectedEndpoint.defaultBody ?? {}) }
+      const body = isRequestBodyObject(parsed)
+        ? parsed
         : { ...(selectedEndpoint.defaultBody ?? {}) }
       if (
         selectedEndpoint.group === 'legacy' ||
@@ -579,6 +587,26 @@ print(response.json())`
           ? { messages: text ? [text] : [] }
           : { text }
       setRequestBody(JSON.stringify(body, null, 2))
+    }
+  }
+
+  const handleRequestBodyChange = (bodyText: string) => {
+    setRequestBody(bodyText)
+
+    try {
+      if (!bodyText.trim()) {
+        setMessageText('')
+        return
+      }
+
+      const parsed = JSON.parse(bodyText)
+      if (isRequestBodyObject(parsed)) {
+        setMessageText(extractMessageText(selectedEndpoint, parsed))
+      } else {
+        setMessageText('')
+      }
+    } catch {
+      // Keep the current message text while the JSON is invalid.
     }
   }
 
@@ -869,11 +897,11 @@ print(response.json())`
                           <code className="mx-1 rounded bg-base-light px-1.5 py-0.5 font-mono text-xs text-primary">
                             useCurrentSystemPrompt
                           </code>
-                          を指定でき、旧APIの
+                          を指定でき、
                           <code className="mx-1 rounded bg-base-light px-1.5 py-0.5 font-mono text-xs text-primary">
                             type=ai_generate
                           </code>
-                          に相当します。
+                          としてAI生成に渡します。
                         </div>
                       </div>
                     )}
@@ -903,7 +931,9 @@ print(response.json())`
                       </span>
                       <textarea
                         value={requestBody}
-                        onChange={(event) => setRequestBody(event.target.value)}
+                        onChange={(event) =>
+                          handleRequestBodyChange(event.target.value)
+                        }
                         className="theme-surface-control min-h-[260px] w-full min-w-0 rounded-lg border p-3 font-mono text-sm font-normal leading-6 text-theme-default outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
                         spellCheck={false}
                       />


### PR DESCRIPTION
## Summary
- Keep the game commentary capture panel visible when the capture component is remounted by React StrictMode cleanup.
- Add authenticated `POST /api/v1/messages/` support for external text/image message submission.
- Update the external API test page so text can be entered directly and sent through the v1 endpoints.

## Root Cause
`Capture` used the full `stopCapture()` path from its unmount cleanup. In development/runtime remount flows, that cleanup also hid the capture panel and reset display settings, so a successful screen share could lose the mini window and skip subsequent captures.

## Impact
- Screen share cleanup now stops tracks and timers without hiding the capture UI unless the user explicitly stops capture.
- External API users can submit `messages`/`text` to the v1 messages endpoint with the existing API key authentication.
- The send-message page exposes the messages endpoint and a plain text input for easier manual operation checks.

## Checks
- `npm test -- --runTestsByPath src/__tests__/pages/api/v1/externalApi.test.ts src/__tests__/components/captureLifecycle.test.tsx src/__tests__/components/videoDisplayControls.test.tsx --runInBand`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * メッセージ送信の新しい送信先（v1 `/api/v1/messages`）を追加し、タイプや本文内容を指定して送信できるようにしました。
  * 送信UIでエンドポイント/入力モードに応じた入力欄の切り替えと同期を強化しました。
* **Bug Fixes**
  * 画面キャプチャ終了時の後処理を見直し、停止後の表示・状態リセットをより正確にしました。
* **Tests**
  * キャプチャ開始/停止のUI状態、およびv1メッセージ投入の反映内容を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->