### PR TITLE
Develop => main

### DIFF
--- a/.agents/skills/develop-main-release/SKILL.md
+++ b/.agents/skills/develop-main-release/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: develop-main-release
+description: aituber-kitでdevelop=>mainのPRをマージし、新しいマイナーバージョンをリリースする。フッターのver表記更新、PRチェックとCodeRabbit reviewThreads確認、PRマージ、ローカルmain最新化、軽量タグ作成・push、CodeRabbit文を除外したGitHub Release発行時に使用。
+user-invocable: true
+---
+
+# develop => main マージ&リリーススキル
+
+aituber-kitで `develop => main` PRをマージし、新しいマイナーバージョンのタグとGitHub Releaseを発行する。
+
+## 基本方針
+
+- 次のマイナーバージョンは、最新リリースタグ `vX.Y.Z` から `vX.(Y+1).0` とする。
+- フッターの表示バージョンはPRマージ前に `develop` 側へコミットしてpushする。
+- タグは軽量タグで作成する。
+- GitHub Release本文は `develop => main` PR本文を転記するが、CodeRabbit自動生成ブロックとCodeRabbit由来の文言は含めない。
+- main checkoutに未追跡のネストrepo等がある場合、checkoutせず `git branch -f main origin/main` で参照だけ更新する。
+- 最終報告では、更新内容をできるだけ簡潔なリストで提示する。
+- 更新内容はコードブロックで共有し、次の形式にする。
+
+```markdown
+## vX.Y.0
+
+- XXX
+- XXX
+
+[https://github.com/tegnike/aituber-kit/releases/tag/vX.Y.0](https://github.com/tegnike/aituber-kit/releases/tag/vX.Y.0)
+```
+
+## 手順
+
+1. 対象PRと最新バージョンを確認する。
+
+```bash
+gh pr view <pr-number> --json number,url,title,state,baseRefName,headRefName,mergeStateStatus,body,statusCheckRollup
+gh release list --limit 10
+git ls-remote origin 'refs/tags/v*'
+```
+
+2. 次のマイナーバージョンを決める。
+
+例: 最新が `v2.46.0` なら次は `v2.47.0`。
+
+タグが既にある場合は止める。明示指示なしに既存タグを上書きしない。
+
+```bash
+git ls-remote --exit-code origin refs/tags/vX.Y.0
+```
+
+3. フッターの表示バージョンを更新する。
+
+対象ファイル:
+
+```text
+src/components/settings/index.tsx
+```
+
+検索例:
+
+```bash
+rg -n "powered by ChatVRM from Pixiv / ver\\." src/components/settings/index.tsx
+```
+
+変更後、差分を確認してコミット・pushする。
+
+```bash
+git diff -- src/components/settings/index.tsx
+git diff --check
+git add src/components/settings/index.tsx
+git commit -m "Bump footer version to X.Y.0"
+git push origin HEAD:develop
+```
+
+4. PRチェックとレビュー状態を確認する。
+
+```bash
+gh pr checks <pr-number> --watch=false
+gh pr view <pr-number> --json mergeStateStatus,statusCheckRollup,latestReviews
+```
+
+CodeRabbitはフラットなレビュー本文だけで判断しない。GraphQL `reviewThreads` で `isResolved == false` かつ `isOutdated == false` の現行スレッドが0件であることを確認する。
+
+5. PRをマージする。
+
+すべての必須チェックが通り、`mergeStateStatus` が `CLEAN` で、現行review threadが0件ならマージする。
+
+```bash
+gh pr merge <pr-number> --merge
+gh pr view <pr-number> --json state,mergedAt,mergeCommit,url
+```
+
+6. ローカルmainを最新にする。
+
+```bash
+git fetch origin main develop --prune
+git branch -f main origin/main
+git rev-parse main origin/main
+```
+
+`main` が別worktreeでcheckout中の場合は、そのworktreeを確認してfast-forwardする。未追跡・未コミット変更を巻き込まない。
+
+7. タグを作成してpushする。
+
+マージcommitとフッター表示を確認してから軽量タグを付ける。
+
+```bash
+git show main:src/components/settings/index.tsx | rg -n "ver\\. X.Y.0"
+git tag vX.Y.0 main
+git push origin vX.Y.0
+```
+
+8. Release本文を作る。
+
+PR本文を取得し、CodeRabbit自動生成ブロック以降を削除する。
+
+削除マーカー:
+
+```text
+<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
+```
+
+Release本文にはCodeRabbitコメント本文、CodeRabbit自動サマリー、`CodeRabbitの指摘` のようなボット由来表現を入れない。必要なら具体的な修正内容だけに言い換える。
+
+9. GitHub Releaseを作成する。
+
+```bash
+gh release create vX.Y.0 --title vX.Y.0 --notes-file /tmp/aituber-vX.Y.0-release-notes.md --target <main-sha>
+```
+
+10. 最終確認を行う。
+
+```bash
+gh release view vX.Y.0 --json tagName,name,url,targetCommitish,isDraft,isPrerelease,body
+git ls-remote origin refs/heads/main refs/tags/vX.Y.0
+git rev-parse main origin/main vX.Y.0
+```
+
+`origin/main`、ローカル `main`、`vX.Y.0` が同じSHAを指していることを確認する。

--- a/.claude/skills/develop-main-release/SKILL.md
+++ b/.claude/skills/develop-main-release/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: develop-main-release
+description: aituber-kitでdevelop=>mainのPRをマージし、新しいマイナーバージョンをリリースする。フッターのver表記更新、PRチェックとCodeRabbit reviewThreads確認、PRマージ、ローカルmain最新化、軽量タグ作成・push、CodeRabbit文を除外したGitHub Release発行時に使用。
+user-invocable: true
+---
+
+# develop => main マージ&リリーススキル
+
+aituber-kitで `develop => main` PRをマージし、新しいマイナーバージョンのタグとGitHub Releaseを発行する。
+
+## 基本方針
+
+- 次のマイナーバージョンは、最新リリースタグ `vX.Y.Z` から `vX.(Y+1).0` とする。
+- フッターの表示バージョンはPRマージ前に `develop` 側へコミットしてpushする。
+- タグは軽量タグで作成する。
+- GitHub Release本文は `develop => main` PR本文を転記するが、CodeRabbit自動生成ブロックとCodeRabbit由来の文言は含めない。
+- main checkoutに未追跡のネストrepo等がある場合、checkoutせず `git branch -f main origin/main` で参照だけ更新する。
+- 最終報告では、更新内容をできるだけ簡潔なリストで提示する。
+- 更新内容はコードブロックで共有し、次の形式にする。
+
+```markdown
+## vX.Y.0
+
+- XXX
+- XXX
+
+[https://github.com/tegnike/aituber-kit/releases/tag/vX.Y.0](https://github.com/tegnike/aituber-kit/releases/tag/vX.Y.0)
+```
+
+## 手順
+
+1. 対象PRと最新バージョンを確認する。
+
+```bash
+gh pr view <pr-number> --json number,url,title,state,baseRefName,headRefName,mergeStateStatus,body,statusCheckRollup
+gh release list --limit 10
+git ls-remote origin 'refs/tags/v*'
+```
+
+2. 次のマイナーバージョンを決める。
+
+例: 最新が `v2.46.0` なら次は `v2.47.0`。
+
+タグが既にある場合は止める。明示指示なしに既存タグを上書きしない。
+
+```bash
+git ls-remote --exit-code origin refs/tags/vX.Y.0
+```
+
+3. フッターの表示バージョンを更新する。
+
+対象ファイル:
+
+```text
+src/components/settings/index.tsx
+```
+
+検索例:
+
+```bash
+rg -n "powered by ChatVRM from Pixiv / ver\\." src/components/settings/index.tsx
+```
+
+変更後、差分を確認してコミット・pushする。
+
+```bash
+git diff -- src/components/settings/index.tsx
+git diff --check
+git add src/components/settings/index.tsx
+git commit -m "Bump footer version to X.Y.0"
+git push origin HEAD:develop
+```
+
+4. PRチェックとレビュー状態を確認する。
+
+```bash
+gh pr checks <pr-number> --watch=false
+gh pr view <pr-number> --json mergeStateStatus,statusCheckRollup,latestReviews
+```
+
+CodeRabbitはフラットなレビュー本文だけで判断しない。GraphQL `reviewThreads` で `isResolved == false` かつ `isOutdated == false` の現行スレッドが0件であることを確認する。
+
+5. PRをマージする。
+
+すべての必須チェックが通り、`mergeStateStatus` が `CLEAN` で、現行review threadが0件ならマージする。
+
+```bash
+gh pr merge <pr-number> --merge
+gh pr view <pr-number> --json state,mergedAt,mergeCommit,url
+```
+
+6. ローカルmainを最新にする。
+
+```bash
+git fetch origin main develop --prune
+git branch -f main origin/main
+git rev-parse main origin/main
+```
+
+`main` が別worktreeでcheckout中の場合は、そのworktreeを確認してfast-forwardする。未追跡・未コミット変更を巻き込まない。
+
+7. タグを作成してpushする。
+
+マージcommitとフッター表示を確認してから軽量タグを付ける。
+
+```bash
+git show main:src/components/settings/index.tsx | rg -n "ver\\. X.Y.0"
+git tag vX.Y.0 main
+git push origin vX.Y.0
+```
+
+8. Release本文を作る。
+
+PR本文を取得し、CodeRabbit自動生成ブロック以降を削除する。
+
+削除マーカー:
+
+```text
+<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
+```
+
+Release本文にはCodeRabbitコメント本文、CodeRabbit自動サマリー、`CodeRabbitの指摘` のようなボット由来表現を入れない。必要なら具体的な修正内容だけに言い換える。
+
+9. GitHub Releaseを作成する。
+
+```bash
+gh release create vX.Y.0 --title vX.Y.0 --notes-file /tmp/aituber-vX.Y.0-release-notes.md --target <main-sha>
+```
+
+10. 最終確認を行う。
+
+```bash
+gh release view vX.Y.0 --json tagName,name,url,targetCommitish,isDraft,isPrerelease,body
+git ls-remote origin refs/heads/main refs/tags/vX.Y.0
+git rev-parse main origin/main vX.Y.0
+```
+
+`origin/main`、ローカル `main`、`vX.Y.0` が同じSHAを指していることを確認する。

--- a/src/__tests__/components/captureLifecycle.test.tsx
+++ b/src/__tests__/components/captureLifecycle.test.tsx
@@ -29,6 +29,8 @@ const createMediaStreamMock = () => {
 }
 
 describe('Capture lifecycle', () => {
+  let mediaTrack: ReturnType<typeof createMediaStreamMock>['track']
+
   beforeEach(() => {
     jest.clearAllMocks()
     homeStore.setState({ captureStatus: false })
@@ -38,7 +40,8 @@ describe('Capture lifecycle', () => {
       useVideoAsBackground: true,
     })
 
-    const { stream } = createMediaStreamMock()
+    const { stream, track } = createMediaStreamMock()
+    mediaTrack = track
     Object.defineProperty(navigator, 'mediaDevices', {
       configurable: true,
       value: {
@@ -53,9 +56,12 @@ describe('Capture lifecycle', () => {
     await waitFor(() => {
       expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
     })
+    expect(homeStore.getState().captureStatus).toBe(true)
 
     unmount()
 
+    expect(mediaTrack.stop).toHaveBeenCalledTimes(1)
+    expect(homeStore.getState().captureStatus).toBe(false)
     expect(menuStore.getState().showCapture).toBe(true)
     expect(settingsStore.getState().hideVideoDisplay).toBe(true)
     expect(settingsStore.getState().useVideoAsBackground).toBe(true)
@@ -67,9 +73,12 @@ describe('Capture lifecycle', () => {
     await waitFor(() => {
       expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
     })
+    expect(homeStore.getState().captureStatus).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'stop source' }))
 
+    expect(mediaTrack.stop).toHaveBeenCalledTimes(1)
+    expect(homeStore.getState().captureStatus).toBe(false)
     expect(menuStore.getState().showCapture).toBe(false)
     expect(settingsStore.getState().hideVideoDisplay).toBe(false)
     expect(settingsStore.getState().useVideoAsBackground).toBe(false)

--- a/src/__tests__/components/captureLifecycle.test.tsx
+++ b/src/__tests__/components/captureLifecycle.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import Capture from '@/components/capture'
+import homeStore from '@/features/stores/home'
+import menuStore from '@/features/stores/menu'
+import settingsStore from '@/features/stores/settings'
+
+jest.mock('@/components/common/VideoDisplay', () => ({
+  VideoDisplay: ({ onStopSource }: { onStopSource?: () => void }) => (
+    <button type="button" onClick={onStopSource}>
+      stop source
+    </button>
+  ),
+}))
+
+const createMediaStreamMock = () => {
+  const track = {
+    stop: jest.fn(),
+    addEventListener: jest.fn(),
+  }
+
+  return {
+    track,
+    stream: {
+      getTracks: () => [track],
+      getVideoTracks: () => [track],
+    },
+  }
+}
+
+describe('Capture lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    homeStore.setState({ captureStatus: false })
+    menuStore.setState({ showCapture: true })
+    settingsStore.setState({
+      hideVideoDisplay: true,
+      useVideoAsBackground: true,
+    })
+
+    const { stream } = createMediaStreamMock()
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getDisplayMedia: jest.fn().mockResolvedValue(stream),
+      },
+    })
+  })
+
+  it('does not hide the capture panel during component cleanup', async () => {
+    const { unmount } = render(<Capture />)
+
+    await waitFor(() => {
+      expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
+    })
+
+    unmount()
+
+    expect(menuStore.getState().showCapture).toBe(true)
+    expect(settingsStore.getState().hideVideoDisplay).toBe(true)
+    expect(settingsStore.getState().useVideoAsBackground).toBe(true)
+  })
+
+  it('hides the capture panel only when screen sharing is explicitly stopped', async () => {
+    render(<Capture />)
+
+    await waitFor(() => {
+      expect(navigator.mediaDevices.getDisplayMedia).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'stop source' }))
+
+    expect(menuStore.getState().showCapture).toBe(false)
+    expect(settingsStore.getState().hideVideoDisplay).toBe(false)
+    expect(settingsStore.getState().useVideoAsBackground).toBe(false)
+  })
+})

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -267,6 +267,43 @@ describe('/api/v1 external API', () => {
     )
   })
 
+  it('falls back to text when v1 messages contains an empty messages array', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: {
+          messages: [],
+          text: 'fallback text',
+        },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'fallback text',
+        type: 'direct_send',
+      })
+    )
+  })
+
   it('supports ai_generate through v1 messages requests', () => {
     const v1Messages = require('@/pages/api/v1/messages').default
     const messages = require('@/pages/api/messages').default

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -185,6 +185,134 @@ describe('/api/v1 external API', () => {
     )
   })
 
+  it('queues v1 messages requests with the legacy messages payload shape', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: {
+          messages: ['hello from v1 messages'],
+          type: 'direct_send',
+          emotion: 'happy',
+        },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        ok: true,
+        clientId: 'client1',
+        type: 'direct_send',
+        count: 1,
+      })
+    )
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'hello from v1 messages',
+        type: 'direct_send',
+        emotion: 'happy',
+        source: 'v1',
+      })
+    )
+  })
+
+  it('defaults v1 messages requests to direct_send when type is omitted', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: { messages: ['default direct send'] },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'default direct send',
+        type: 'direct_send',
+      })
+    )
+  })
+
+  it('supports ai_generate through v1 messages requests', () => {
+    const v1Messages = require('@/pages/api/v1/messages').default
+    const messages = require('@/pages/api/messages').default
+
+    const res = createMockRes()
+    v1Messages(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+        body: {
+          text: 'describe this',
+          type: 'ai_generate',
+          useCurrentSystemPrompt: false,
+          systemPrompt: 'Be concise',
+        },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(202)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        type: 'ai_generate',
+      })
+    )
+
+    const getRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'client1' },
+      }),
+      getRes
+    )
+
+    expect((getRes._json as { messages: unknown[] }).messages[0]).toEqual(
+      expect.objectContaining({
+        message: 'describe this',
+        type: 'ai_generate',
+        systemPrompt: 'Be concise',
+        useCurrentSystemPrompt: false,
+      })
+    )
+  })
+
   it('queues chat requests as user_input by default', () => {
     const chat = require('@/pages/api/v1/chat').default
     const messages = require('@/pages/api/messages').default

--- a/src/components/capture.tsx
+++ b/src/components/capture.tsx
@@ -137,9 +137,9 @@ const Capture = () => {
 
   useEffect(() => {
     return () => {
-      stopCapture()
+      cleanupStream()
     }
-  }, [stopCapture])
+  }, [cleanupStream])
 
   return (
     <VideoDisplay

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -966,7 +966,7 @@ const escapeRegExp = (value: string) =>
 const Footer = () => {
   return (
     <footer className="theme-surface-contrast shrink-0 border-t border-primary/20 py-1 text-center font-Montserrat text-xs">
-      powered by ChatVRM from Pixiv / ver. 2.50.0
+      powered by ChatVRM from Pixiv / ver. 2.51.0
     </footer>
   )
 }

--- a/src/pages/api/v1/messages.ts
+++ b/src/pages/api/v1/messages.ts
@@ -1,0 +1,124 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  enqueueMessages,
+  enqueueStopCommand,
+  MessageType,
+} from '@/features/api/messageGateway'
+import {
+  getClientIdFromRequest,
+  normalizeImage,
+  normalizeMessages,
+  requireApiKey,
+  sendMethodNotAllowed,
+} from '@/features/api/http'
+import {
+  isRestrictedMode,
+  createRestrictedModeErrorResponse,
+} from '@/utils/restrictedMode'
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb',
+    },
+  },
+}
+
+const allowedTypes: MessageType[] = ['direct_send', 'ai_generate', 'user_input']
+
+const normalizeMessageType = (value: unknown): MessageType | null => {
+  return allowedTypes.includes(value as MessageType)
+    ? (value as MessageType)
+    : null
+}
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  if (isRestrictedMode()) {
+    return res
+      .status(403)
+      .json(createRestrictedModeErrorResponse('v1/messages'))
+  }
+
+  if (req.method !== 'POST') {
+    return sendMethodNotAllowed(res)
+  }
+
+  if (!requireApiKey(req, res)) return
+
+  const clientId = getClientIdFromRequest(req, req.body?.clientId)
+  if (!clientId) {
+    return res.status(400).json({ error: 'Client ID is required' })
+  }
+
+  const rawType = req.body?.type ?? req.query.type ?? 'direct_send'
+  const type = normalizeMessageType(rawType)
+  if (!type) {
+    return res.status(400).json({ error: 'Invalid type' })
+  }
+
+  const messages = normalizeMessages(req.body?.messages ?? req.body?.text)
+  if (messages.length === 0) {
+    return res.status(400).json({ error: 'Text or messages are required' })
+  }
+
+  if (
+    req.body?.systemPrompt !== undefined &&
+    typeof req.body.systemPrompt !== 'string'
+  ) {
+    return res.status(400).json({ error: 'System prompt is not a string' })
+  }
+
+  if (
+    req.body?.useCurrentSystemPrompt !== undefined &&
+    typeof req.body.useCurrentSystemPrompt !== 'boolean'
+  ) {
+    return res
+      .status(400)
+      .json({ error: 'useCurrentSystemPrompt is not a boolean' })
+  }
+
+  const imageResult = normalizeImage(req.body?.image)
+  if (!imageResult.ok) {
+    return res.status(imageResult.status).json({ error: imageResult.error })
+  }
+
+  const interrupt = req.body?.interrupt === true
+  if (interrupt) {
+    enqueueStopCommand(clientId, 'all', 'interrupt_before_messages')
+  }
+
+  const useCurrentSystemPrompt =
+    typeof req.body?.useCurrentSystemPrompt === 'boolean'
+      ? req.body.useCurrentSystemPrompt
+      : true
+
+  const queuedMessages = enqueueMessages({
+    clientId,
+    messages,
+    type,
+    systemPrompt:
+      type === 'ai_generate' && !useCurrentSystemPrompt
+        ? req.body?.systemPrompt
+        : undefined,
+    useCurrentSystemPrompt:
+      type === 'ai_generate' ? useCurrentSystemPrompt : undefined,
+    image: imageResult.image,
+    emotion:
+      type === 'direct_send' && typeof req.body?.emotion === 'string'
+        ? req.body.emotion
+        : undefined,
+    priority: req.body?.priority === 'high' ? 'high' : 'normal',
+    interrupt,
+    source: 'v1',
+  })
+
+  return res.status(202).json({
+    ok: true,
+    clientId,
+    type,
+    queued: queuedMessages.map((message) => message.id),
+    count: queuedMessages.length,
+  })
+}
+
+export default handler

--- a/src/pages/api/v1/messages.ts
+++ b/src/pages/api/v1/messages.ts
@@ -56,7 +56,9 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(400).json({ error: 'Invalid type' })
   }
 
-  const messages = normalizeMessages(req.body?.messages ?? req.body?.text)
+  const bodyMessages = normalizeMessages(req.body?.messages)
+  const messages =
+    bodyMessages.length > 0 ? bodyMessages : normalizeMessages(req.body?.text)
   if (messages.length === 0) {
     return res.status(400).json({ error: 'Text or messages are required' })
   }

--- a/src/pages/send-message.tsx
+++ b/src/pages/send-message.tsx
@@ -375,19 +375,30 @@ const isRequestBodyObject = (
 ): value is Record<string, unknown> =>
   Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 
-const extractMessageText = (
-  endpoint: EndpointDefinition,
-  body?: Record<string, unknown>
-) => {
-  const value =
-    endpoint.group === 'legacy' || endpoint.id === 'messages'
-      ? body?.messages
-      : body?.text
+const formatMessageInputValue = (value: unknown) => {
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
     return value.filter((item) => typeof item === 'string').join('\n')
   }
   return ''
+}
+
+const extractMessageText = (
+  endpoint: EndpointDefinition,
+  body?: Record<string, unknown>
+) => {
+  if (
+    endpoint.group === 'legacy' ||
+    endpoint.id === 'messages' ||
+    endpoint.id === 'speak' ||
+    endpoint.id === 'chat'
+  ) {
+    return (
+      formatMessageInputValue(body?.messages) ||
+      formatMessageInputValue(body?.text)
+    )
+  }
+  return formatMessageInputValue(body?.text)
 }
 
 const SendMessage = () => {
@@ -576,8 +587,10 @@ print(response.json())`
           .split('\n')
           .map((line) => line.trim())
           .filter(Boolean)
+        delete body.text
       } else {
         body.text = text
+        delete body.messages
       }
       setRequestBody(JSON.stringify(body, null, 2))
     } catch {

--- a/src/pages/send-message.tsx
+++ b/src/pages/send-message.tsx
@@ -16,6 +16,7 @@ import {
 } from '@heroicons/react/24/outline'
 
 type EndpointId =
+  | 'messages'
   | 'speak'
   | 'chat'
   | 'stop'
@@ -45,6 +46,57 @@ type EndpointDefinition = {
 }
 
 const endpoints: EndpointDefinition[] = [
+  {
+    id: 'messages',
+    group: 'v1',
+    label: 'Messages',
+    method: 'POST',
+    path: '/api/v1/messages/',
+    description:
+      'messages と type を指定して、発話・AI生成・通常入力をまとめて送信します。',
+    requiresApiKey: true,
+    defaultBody: {
+      messages: ['こんにちは。外部APIからの発話テストです。'],
+      type: 'direct_send',
+    },
+    fields: [
+      {
+        name: 'messages',
+        type: 'string[]',
+        required: true,
+        description: '送信する本文の配列です。',
+      },
+      {
+        name: 'type',
+        type: '"direct_send" | "ai_generate" | "user_input"',
+        description:
+          'direct_send はそのまま発話、ai_generate はAI生成、user_input は通常入力として処理します。',
+      },
+      {
+        name: 'text',
+        type: 'string',
+        description: 'messages の代わりに単一本文を送る場合に使います。',
+      },
+      {
+        name: 'systemPrompt',
+        type: 'string',
+        description:
+          'type が ai_generate で useCurrentSystemPrompt=false のときに使うシステムプロンプトです。',
+      },
+      {
+        name: 'useCurrentSystemPrompt',
+        type: 'boolean',
+        description:
+          'type が ai_generate のとき、現在のキャラクター設定のシステムプロンプトを使うかどうかです。',
+      },
+      {
+        name: 'image',
+        type: 'string',
+        description:
+          'data URL などの画像文字列です。画像付き入力として処理します。',
+      },
+    ],
+  },
   {
     id: 'speak',
     group: 'v1',
@@ -311,17 +363,39 @@ const codeSampleTabs: Array<{ id: CodeSampleId; label: string }> = [
   { id: 'python', label: 'Python' },
 ]
 
+const defaultEndpoint = endpoints.find(
+  (endpoint) => endpoint.id === 'messages'
+)!
+
 const stringifyBody = (body?: Record<string, unknown>) =>
   body ? JSON.stringify(body, null, 2) : ''
 
+const extractMessageText = (
+  endpoint: EndpointDefinition,
+  body?: Record<string, unknown>
+) => {
+  const value =
+    endpoint.group === 'legacy' || endpoint.id === 'messages'
+      ? body?.messages
+      : body?.text
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === 'string').join('\n')
+  }
+  return ''
+}
+
 const SendMessage = () => {
   const { t } = useTranslation()
-  const [selectedId, setSelectedId] = useState<EndpointId>('speak')
+  const [selectedId, setSelectedId] = useState<EndpointId>(defaultEndpoint.id)
   const [clientId, setClientId] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [baseUrl, setBaseUrl] = useState('')
   const [requestBody, setRequestBody] = useState(
-    stringifyBody(endpoints[0].defaultBody)
+    stringifyBody(defaultEndpoint.defaultBody)
+  )
+  const [messageText, setMessageText] = useState(
+    extractMessageText(defaultEndpoint, defaultEndpoint.defaultBody)
   )
   const [responseText, setResponseText] = useState('')
   const [isSending, setIsSending] = useState(false)
@@ -472,9 +546,39 @@ print(response.json())`
   const handleEndpointChange = (endpoint: EndpointDefinition) => {
     setSelectedId(endpoint.id)
     setRequestBody(stringifyBody(endpoint.defaultBody))
+    setMessageText(extractMessageText(endpoint, endpoint.defaultBody))
     setResponseText('')
     if (window.innerWidth < 1024) {
       setEndpointsOpen(false)
+    }
+  }
+
+  const handleMessageTextChange = (text: string) => {
+    setMessageText(text)
+
+    try {
+      const body = requestBody.trim()
+        ? JSON.parse(requestBody)
+        : { ...(selectedEndpoint.defaultBody ?? {}) }
+      if (
+        selectedEndpoint.group === 'legacy' ||
+        selectedEndpoint.id === 'messages'
+      ) {
+        body.messages = text
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean)
+      } else {
+        body.text = text
+      }
+      setRequestBody(JSON.stringify(body, null, 2))
+    } catch {
+      const body =
+        selectedEndpoint.group === 'legacy' ||
+        selectedEndpoint.id === 'messages'
+          ? { messages: text ? [text] : [] }
+          : { text }
+      setRequestBody(JSON.stringify(body, null, 2))
     }
   }
 
@@ -772,6 +876,25 @@ print(response.json())`
                           に相当します。
                         </div>
                       </div>
+                    )}
+                    {(selectedEndpoint.id === 'messages' ||
+                      selectedEndpoint.id === 'speak' ||
+                      selectedEndpoint.id === 'chat' ||
+                      selectedEndpoint.id.startsWith('legacy_')) && (
+                      <label className="flex min-w-0 flex-col gap-2 text-sm font-bold text-text-primary">
+                        <span className="flex items-center gap-2">
+                          <PaperAirplaneIcon className="h-5 w-5 text-primary" />
+                          Message
+                        </span>
+                        <textarea
+                          value={messageText}
+                          onChange={(event) =>
+                            handleMessageTextChange(event.target.value)
+                          }
+                          className="theme-surface-control min-h-[120px] w-full min-w-0 rounded-lg border p-3 text-sm font-normal leading-6 text-theme-default outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                          spellCheck={false}
+                        />
+                      </label>
                     )}
                     <label className="flex min-w-0 flex-col gap-2 text-sm font-bold text-text-primary">
                       <span className="flex items-center gap-2">

--- a/src/pages/send-message.tsx
+++ b/src/pages/send-message.tsx
@@ -370,6 +370,11 @@ const defaultEndpoint = endpoints.find(
 const stringifyBody = (body?: Record<string, unknown>) =>
   body ? JSON.stringify(body, null, 2) : ''
 
+const isRequestBodyObject = (
+  value: unknown
+): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+
 const extractMessageText = (
   endpoint: EndpointDefinition,
   body?: Record<string, unknown>
@@ -557,8 +562,11 @@ print(response.json())`
     setMessageText(text)
 
     try {
-      const body = requestBody.trim()
+      const parsed = requestBody.trim()
         ? JSON.parse(requestBody)
+        : { ...(selectedEndpoint.defaultBody ?? {}) }
+      const body = isRequestBodyObject(parsed)
+        ? parsed
         : { ...(selectedEndpoint.defaultBody ?? {}) }
       if (
         selectedEndpoint.group === 'legacy' ||
@@ -579,6 +587,26 @@ print(response.json())`
           ? { messages: text ? [text] : [] }
           : { text }
       setRequestBody(JSON.stringify(body, null, 2))
+    }
+  }
+
+  const handleRequestBodyChange = (bodyText: string) => {
+    setRequestBody(bodyText)
+
+    try {
+      if (!bodyText.trim()) {
+        setMessageText('')
+        return
+      }
+
+      const parsed = JSON.parse(bodyText)
+      if (isRequestBodyObject(parsed)) {
+        setMessageText(extractMessageText(selectedEndpoint, parsed))
+      } else {
+        setMessageText('')
+      }
+    } catch {
+      // Keep the current message text while the JSON is invalid.
     }
   }
 
@@ -869,11 +897,11 @@ print(response.json())`
                           <code className="mx-1 rounded bg-base-light px-1.5 py-0.5 font-mono text-xs text-primary">
                             useCurrentSystemPrompt
                           </code>
-                          を指定でき、旧APIの
+                          を指定でき、
                           <code className="mx-1 rounded bg-base-light px-1.5 py-0.5 font-mono text-xs text-primary">
                             type=ai_generate
                           </code>
-                          に相当します。
+                          としてAI生成に渡します。
                         </div>
                       </div>
                     )}
@@ -903,7 +931,9 @@ print(response.json())`
                       </span>
                       <textarea
                         value={requestBody}
-                        onChange={(event) => setRequestBody(event.target.value)}
+                        onChange={(event) =>
+                          handleRequestBodyChange(event.target.value)
+                        }
                         className="theme-surface-control min-h-[260px] w-full min-w-0 rounded-lg border p-3 font-mono text-sm font-normal leading-6 text-theme-default outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
                         spellCheck={false}
                       />


### PR DESCRIPTION
## バグ修正
- ゲーム実況の画面共有コンポーネントがunmount cleanup時にキャプチャUIまで閉じないように修正しました。
- 画面共有の明示停止時だけ、ミニウィンドウ表示設定を閉じる挙動にしました。

## 改善
- 認証付きの `POST /api/v1/messages/` を追加し、外部APIから `messages` / `text` を送信できるようにしました。
- `/send-message` でMessagesエンドポイントを選びやすくし、Message入力欄とRequest Bodyの同期を改善しました。

## テスト
- キャプチャcleanup時に `captureStatus` とmedia track停止が実行されることをテストで固定しました。
- v1 messages APIの送信、デフォルトtype、`messages: []` から `text` へのフォールバック、AI生成モードをテストしました。

## 確認
- PR #535 で lint / test / e2e / e2e-production / CodeRabbit が成功済みです。
- ローカルで `npm test -- --runTestsByPath src/__tests__/pages/api/v1/externalApi.test.ts src/__tests__/components/captureLifecycle.test.tsx src/__tests__/components/videoDisplayControls.test.tsx --runInBand` を実行済みです。
- ローカルで `npm run build` を実行済みです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 画面共有送信UIに、v1 の新メッセージ送信エンドポイント（/api/v1/messages）を追加しました。
  * 入力内容を JSON本文とテキストの両方で同期できるよう拡張しました。
* **Bug Fixes**
  * 画面共有の停止時に、キャプチャUIやビデオ表示設定の切り替え挙動を改善しました。
* **Tests**
  * 画面共有の開始・停止と後片付けの挙動を確認するテストを追加しました。
  * v1 メッセージ送信仕様に関する API テストを追加しました。
* **Chores**
  * 表示バージョンを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->