### PR TITLE
Allow appending Cloudflare public env

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -67,8 +67,12 @@ jobs:
           if [ -n "$CLOUDFLARE_ENV_FILE" ]; then
             echo "$CLOUDFLARE_ENV_FILE" > .env.local
           fi
+          if [ -n "$CLOUDFLARE_PUBLIC_ENV_APPEND" ]; then
+            printf '\n%s\n' "$CLOUDFLARE_PUBLIC_ENV_APPEND" >> .env.local
+          fi
         env:
           CLOUDFLARE_ENV_FILE: ${{ secrets.CLOUDFLARE_ENV_FILE }}
+          CLOUDFLARE_PUBLIC_ENV_APPEND: ${{ secrets.CLOUDFLARE_PUBLIC_ENV_APPEND }}
 
       - name: Build for Cloudflare
         run: npm run build:cloudflare


### PR DESCRIPTION
## Summary
- append optional CLOUDFLARE_PUBLIC_ENV_APPEND to .env.local during Cloudflare builds
- keep existing CLOUDFLARE_ENV_FILE behavior unchanged

## Context
This lets us set public build-time embed widget environment variables without replacing the existing Cloudflare env file secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloudflare デプロイ時の環境ファイル生成を改善し、追加設定がある場合のみ内容を末尾に追記するようになりました。
  * 追加設定が未設定でも処理が安定し、不要な改行や空の追記を防ぎます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->