### PR TITLE
サーバー側秘匿キー利用のAPI保護を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,38 @@ NEXT_PUBLIC_IMAGE_DISPLAY_POSITION="input"
 # Default state for custom model input feature (true/false)
 NEXT_PUBLIC_CUSTOM_MODEL="false"
 
+#===============================================================================
+# サーバー側秘匿キーのAPI利用制御 / Server-side secret API access control
+#===============================================================================
+
+# サーバー側のAPIキー、CUSTOM_API_*、書き込み/サーバーリソースAPIを匿名APIから使うかどうか /
+# Controls whether anonymous API routes may use server-side API keys, CUSTOM_API_*, write APIs, or server resources.
+# disabled: デフォルト。リクエスト側APIキーのみ許可し、サーバー側秘匿値や保護対象リソースは拒否 /
+# disabled: default. Allow request-provided API keys only; reject server secrets and protected server resources.
+# protected: Authorization: Bearer AITUBERKIT_SERVER_SECRET_TOKEN が必要 /
+# protected: require Authorization: Bearer AITUBERKIT_SERVER_SECRET_TOKEN.
+# demo: allowed origins / same-origin のブラウザリクエストのみ許可（レート制限併用推奨） /
+# demo: allow browser requests from allowed origins / same-origin only; pair with rate limits.
+# unprotected: 従来互換。公開URLでは非推奨 /
+# unprotected: legacy compatibility. Not recommended for public URLs.
+AITUBERKIT_SERVER_SECRET_ACCESS_MODE="disabled"
+
+# protectedモードで使用するBearerトークン /
+# Bearer token used in protected mode
+AITUBERKIT_SERVER_SECRET_TOKEN=""
+
+# demoモードで許可するOrigin（カンマ区切り）。未指定時はHostと同一Originのみ許可 /
+# Comma-separated origins allowed in demo mode. When omitted, only same-host origin is allowed.
+AITUBERKIT_ALLOWED_ORIGINS=""
+
+# demoモードの簡易レート制限（IP・機能ごとの1分あたり回数、本番ではWAF等も併用） /
+# Simple demo-mode rate limit per IP and feature per minute. Pair with WAF/rate limits in production.
+AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE="20"
+
+# Custom APIのreasoningやprovider metadataをクライアントへ転送する（通常はfalse推奨） /
+# Forward Custom API reasoning/provider metadata to clients (false is recommended).
+AITUBERKIT_FORWARD_CUSTOM_API_METADATA="false"
+
 # OpenAI API キー / API key
 OPENAI_API_KEY=""
 

--- a/.env.example
+++ b/.env.example
@@ -212,8 +212,8 @@ NEXT_PUBLIC_CUSTOM_MODEL="false"
 # disabled: default. Allow request-provided API keys only; reject server secrets and protected server resources.
 # protected: Authorization: Bearer AITUBERKIT_SERVER_SECRET_TOKEN が必要 /
 # protected: require Authorization: Bearer AITUBERKIT_SERVER_SECRET_TOKEN.
-# demo: allowed origins / same-origin のブラウザリクエストのみ許可（レート制限併用推奨） /
-# demo: allow browser requests from allowed origins / same-origin only; pair with rate limits.
+# demo: allowed origins / same-origin とサーバー発行demoトークンを要求（レート制限併用推奨） /
+# demo: require allowed origins / same-origin plus a server-issued demo token; pair with rate limits.
 # unprotected: 従来互換。公開URLでは非推奨 /
 # unprotected: legacy compatibility. Not recommended for public URLs.
 AITUBERKIT_SERVER_SECRET_ACCESS_MODE="disabled"
@@ -226,9 +226,17 @@ AITUBERKIT_SERVER_SECRET_TOKEN=""
 # Comma-separated origins allowed in demo mode. When omitted, only same-host origin is allowed.
 AITUBERKIT_ALLOWED_ORIGINS=""
 
+# demoモードで X-AITuberKit-Demo-Token として要求するトークン。未指定時は AITUBERKIT_SERVER_SECRET_TOKEN を使用 /
+# Token required as X-AITuberKit-Demo-Token in demo mode. Falls back to AITUBERKIT_SERVER_SECRET_TOKEN when omitted.
+AITUBERKIT_DEMO_ACCESS_TOKEN=""
+
 # demoモードの簡易レート制限（IP・機能ごとの1分あたり回数、本番ではWAF等も併用） /
 # Simple demo-mode rate limit per IP and feature per minute. Pair with WAF/rate limits in production.
 AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE="20"
+
+# 信頼済みプロキシ配下でのみ true。true の場合だけ x-forwarded-for / cf-connecting-ip をレート制限に使う /
+# Set true only behind trusted proxies. Only then x-forwarded-for / cf-connecting-ip are used for rate limiting.
+AITUBERKIT_TRUST_PROXY_HEADERS="false"
 
 # Custom APIのreasoningやprovider metadataをクライアントへ転送する（通常はfalse推奨） /
 # Forward Custom API reasoning/provider metadata to clients (false is recommended).

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ npm run deploy:cloudflare
 このリポジトリは、個人利用やローカル環境での開発はもちろん、適切なセキュリティ対策を施した上での商用利用も想定しています。ただし、Web環境にデプロイする際は以下の点にご注意ください：
 
 - **APIキーの取り扱い**: バックエンドサーバーを経由してAIサービス（OpenAI, Anthropic等）やTTSサービスのAPIを呼び出す仕様となっているため、APIキーの適切な管理が必要です。
+- **サーバー側秘匿キーの保護**: セキュリティアップデートにより、`OPENAI_API_KEY` や `CUSTOM_API_*` などのサーバー側秘匿値、ログ保存、サーバー側TTS URL等を公開APIから使う場合は `AITUBERKIT_SERVER_SECRET_ACCESS_MODE` の設定が必須です。未設定の場合、一部APIは `403` で拒否されます。詳細と移行手順は [v2.53.0 のリリースノート](https://github.com/tegnike/aituber-kit/releases/tag/v2.53.0) を参照してください。
 
 ### 本番環境での利用について
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -262,6 +262,7 @@ npm run deploy:cloudflare
 This repository is intended for personal use and development in local environments, as well as commercial use with appropriate security measures. However, please note the following when deploying to a web environment:
 
 - **API Key Handling**: The system is designed to call AI services (OpenAI, Anthropic, etc.) and TTS services via a backend server, so proper management of API keys is necessary.
+- **Server-side secret protection**: A security update requires `AITUBERKIT_SERVER_SECRET_ACCESS_MODE` when public API routes use server-side secrets such as `OPENAI_API_KEY` or `CUSTOM_API_*`, chat log saving, or server-side TTS URLs. Without this setting, some APIs return `403`. See the [v2.53.0 release notes](https://github.com/tegnike/aituber-kit/releases/tag/v2.53.0) for details and migration steps.
 
 ### For Production Use
 

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -262,6 +262,7 @@ npm run deploy:cloudflare
 이 리포지토리는 개인 사용과 로컬 환경에서의 개발은 물론, 적절한 보안 대책을 마련한 상업적 사용도 고려하고 있습니다. 단, 웹 환경에 배포할 때는 다음 사항에 주의해 주시기 바랍니다:
 
 - **API 키 취급**: 백엔드 서버를 통해 AI 서비스(OpenAI, Anthropic 등)와 TTS 서비스의 API를 호출하는 사양이므로, API 키의 적절한 관리가 필요합니다.
+- **서버 사이드 시크릿 보호**: 보안 업데이트에 따라 공개 API 라우트에서 `OPENAI_API_KEY` 또는 `CUSTOM_API_*` 같은 서버 사이드 시크릿, 채팅 로그 저장, 서버 사이드 TTS URL을 사용할 때는 `AITUBERKIT_SERVER_SECRET_ACCESS_MODE` 설정이 필요합니다. 설정하지 않으면 일부 API가 `403`을 반환합니다. 자세한 내용과 마이그레이션 절차는 [v2.53.0 릴리스 노트](https://github.com/tegnike/aituber-kit/releases/tag/v2.53.0)를 참조하세요.
 
 ### 프로덕션 환경에서의 사용에 대하여
 

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -262,6 +262,7 @@ npm run deploy:cloudflare
 To repozytorium jest przeznaczone zarówno do użytku osobistego i rozwoju w środowisku lokalnym, jak i do użytku komercyjnego z odpowiednimi środkami bezpieczeństwa. Jednak podczas wdrażania w środowisku internetowym należy zwrócić uwagę na następujące punkty:
 
 - **Obsługa kluczy API**: Ponieważ system jest zaprojektowany do wywoływania API usług AI (OpenAI, Anthropic itp.) i usług TTS poprzez serwer backendowy, wymagane jest odpowiednie zarządzanie kluczami API.
+- **Ochrona sekretów po stronie serwera**: Aktualizacja bezpieczeństwa wymaga ustawienia `AITUBERKIT_SERVER_SECRET_ACCESS_MODE`, gdy publiczne trasy API używają sekretów po stronie serwera, takich jak `OPENAI_API_KEY` lub `CUSTOM_API_*`, zapisu historii rozmów albo serwerowych adresów URL TTS. Bez tej konfiguracji część API zwróci `403`. Szczegóły i kroki migracji znajdziesz w [informacjach o wydaniu v2.53.0](https://github.com/tegnike/aituber-kit/releases/tag/v2.53.0).
 
 ### Użycie w środowisku produkcyjnym
 

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -264,6 +264,7 @@ npm run deploy:cloudflare
 本仓库适用于个人使用和本地环境开发，以及采取适当安全措施的商业用途。但是，在部署到Web环境时，请注意以下几点：
 
 - **API密钥处理**：系统设计为通过后端服务器调用AI服务（OpenAI、Anthropic等）和TTS服务的API，因此需要妥善管理API密钥。
+- **服务器端密钥保护**：安全更新要求在公开API路由使用 `OPENAI_API_KEY` 或 `CUSTOM_API_*` 等服务器端密钥、聊天日志保存、服务器端TTS URL时设置 `AITUBERKIT_SERVER_SECRET_ACCESS_MODE`。未设置时，部分API会返回 `403`。详情和迁移步骤请参阅 [v2.53.0 发布说明](https://github.com/tegnike/aituber-kit/releases/tag/v2.53.0)。
 
 ### 生产环境使用
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -264,6 +264,7 @@ npm run deploy:cloudflare
 本倉庫適用於個人使用和本地環境開發，以及採取適當安全措施的商業用途。但是，在部署到 Web 環境時，請注意以下幾點：
 
 - **API 金鑰處理**：系統設計為透過後端伺服器呼叫 AI 服務（OpenAI、Anthropic 等）和 TTS 服務的 API，因此需要妥善管理 API 金鑰。
+- **伺服器端密鑰保護**：安全更新要求在公開 API 路由使用 `OPENAI_API_KEY` 或 `CUSTOM_API_*` 等伺服器端密鑰、聊天紀錄儲存、伺服器端 TTS URL 時設定 `AITUBERKIT_SERVER_SECRET_ACCESS_MODE`。未設定時，部分 API 會返回 `403`。詳細內容與遷移步驟請參閱 [v2.53.0 發布說明](https://github.com/tegnike/aituber-kit/releases/tag/v2.53.0)。
 
 ### 生產環境使用
 

--- a/src/__tests__/lib/api-services/customApi.test.ts
+++ b/src/__tests__/lib/api-services/customApi.test.ts
@@ -1,0 +1,124 @@
+import { handleCustomApi } from '@/lib/api-services/customApi'
+
+const originalFetch = global.fetch
+const originalEnv = { ...process.env }
+
+if (typeof global.Response === 'undefined') {
+  class TestResponse {
+    public status: number
+    public ok: boolean
+    public headers: Map<string, string>
+    public body: any
+
+    constructor(body?: any, init: { status?: number; headers?: any } = {}) {
+      this.body = body
+      this.status = init.status ?? 200
+      this.ok = this.status >= 200 && this.status < 300
+      this.headers = new Map(Object.entries(init.headers || {}))
+    }
+
+    async text() {
+      if (typeof this.body === 'string') return this.body
+      if (!this.body?.getReader) return ''
+
+      const reader = this.body.getReader()
+      const decoder = new TextDecoder()
+      let result = ''
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        result += decoder.decode(value, { stream: true })
+      }
+      result += decoder.decode()
+      return result
+    }
+
+    async json() {
+      return JSON.parse(await this.text())
+    }
+  }
+
+  // @ts-expect-error – provide Response polyfill for test environment
+  global.Response = TestResponse
+}
+
+function createStreamResponse(body: string): Response {
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(body))
+        controller.close()
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    }
+  )
+}
+
+describe('handleCustomApi', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    global.fetch = jest.fn()
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+    global.fetch = originalFetch
+  })
+
+  it('forwards text deltas while filtering reasoning and provider metadata by default', async () => {
+    const upstream = [
+      'data: {"type":"start","payload":{"id":"internal"}}',
+      'data: {"type":"reasoning-delta","delta":"hidden reasoning"}',
+      'data: {"type":"text-delta","delta":"hello"}',
+      'data: {"type":"step-finish","payload":{"metadata":{"headers":{"x-request-id":"secret"}}}}',
+      'data: [DONE]',
+      '',
+    ].join('\n')
+    ;(global.fetch as jest.Mock).mockResolvedValue(
+      createStreamResponse(upstream)
+    )
+
+    const response = await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://example.com/custom',
+      '{}',
+      '{}',
+      true
+    )
+
+    const text = await response.text()
+    expect(text).toContain('data: {"type":"text-delta","delta":"hello"}')
+    expect(text).toContain('data: [DONE]')
+    expect(text).not.toContain('hidden reasoning')
+    expect(text).not.toContain('x-request-id')
+    expect(text).not.toContain('"type":"start"')
+  })
+
+  it('can forward metadata when explicitly enabled', async () => {
+    process.env.AITUBERKIT_FORWARD_CUSTOM_API_METADATA = 'true'
+    const upstream = [
+      'data: {"type":"reasoning-delta","delta":"visible reasoning"}',
+      'data: {"type":"step-finish","payload":{"metadata":{"id":"response-id"}}}',
+      '',
+    ].join('\n')
+    ;(global.fetch as jest.Mock).mockResolvedValue(
+      createStreamResponse(upstream)
+    )
+
+    const response = await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://example.com/custom',
+      '{}',
+      '{}',
+      true
+    )
+
+    const text = await response.text()
+    expect(text).toContain('visible reasoning')
+    expect(text).toContain('response-id')
+  })
+})

--- a/src/__tests__/lib/api-services/customApi.test.ts
+++ b/src/__tests__/lib/api-services/customApi.test.ts
@@ -98,6 +98,32 @@ describe('handleCustomApi', () => {
     expect(text).not.toContain('"type":"start"')
   })
 
+  it('filters raw SSE metadata lines and trailing buffered metadata by default', async () => {
+    const upstream = [
+      'event: internal-event',
+      'id: upstream-request-id',
+      'data: {"type":"text-delta","delta":"visible"}',
+      'data: {"type":"step-finish","payload":{"metadata":{"secret":"hidden"}}}',
+    ].join('\n')
+    ;(global.fetch as jest.Mock).mockResolvedValue(
+      createStreamResponse(upstream)
+    )
+
+    const response = await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://example.com/custom',
+      '{}',
+      '{}',
+      true
+    )
+
+    const text = await response.text()
+    expect(text).toContain('data: {"type":"text-delta","delta":"visible"}')
+    expect(text).not.toContain('internal-event')
+    expect(text).not.toContain('upstream-request-id')
+    expect(text).not.toContain('hidden')
+  })
+
   it('can forward metadata when explicitly enabled', async () => {
     process.env.AITUBERKIT_FORWARD_CUSTOM_API_METADATA = 'true'
     const upstream = [

--- a/src/__tests__/lib/api-services/serverSecretGuard.test.ts
+++ b/src/__tests__/lib/api-services/serverSecretGuard.test.ts
@@ -1,0 +1,123 @@
+import { createMocks } from 'node-mocks-http'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
+
+const originalEnv = { ...process.env }
+
+describe('serverSecretGuard', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete (globalThis as any).__aituberKitServerSecretRateLimit
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('denies server secret access by default', () => {
+    const { req, res } = createMocks({ method: 'POST' })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(false)
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'test-feature',
+      })
+    )
+  })
+
+  it('allows protected mode with a matching bearer token', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'protected'
+    process.env.AITUBERKIT_SERVER_SECRET_TOKEN = 'secret-token'
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { authorization: 'Bearer secret-token' },
+    })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(true)
+    expect(res._getStatusCode()).toBe(200)
+  })
+
+  it('allows demo mode only for same-origin requests', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        host: 'aituberkit.example',
+        origin: 'https://aituberkit.example',
+        'sec-fetch-site': 'same-origin',
+      },
+    })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(true)
+    expect(res._getStatusCode()).toBe(200)
+  })
+
+  it('rejects demo mode cross-site requests', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        host: 'aituberkit.example',
+        origin: 'https://evil.example',
+        'sec-fetch-site': 'cross-site',
+      },
+    })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(false)
+    expect(res._getStatusCode()).toBe(403)
+  })
+
+  it('rate limits demo mode requests per feature and client IP', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    process.env.AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE = '1'
+
+    const createSameOriginRequest = () =>
+      createMocks({
+        method: 'POST',
+        headers: {
+          host: 'aituberkit.example',
+          origin: 'https://aituberkit.example',
+          'sec-fetch-site': 'same-origin',
+          'x-forwarded-for': '203.0.113.10',
+        },
+      })
+
+    const first = createSameOriginRequest()
+    expect(
+      guardServerSecretAccess(first.req as any, first.res as any, {
+        featureName: 'test-feature',
+      })
+    ).toBe(true)
+
+    const second = createSameOriginRequest()
+    expect(
+      guardServerSecretAccess(second.req as any, second.res as any, {
+        featureName: 'test-feature',
+      })
+    ).toBe(false)
+    expect(second.res._getStatusCode()).toBe(429)
+    expect(second.res._getJSONData()).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretRateLimited',
+        feature: 'test-feature',
+      })
+    )
+  })
+})

--- a/src/__tests__/lib/api-services/serverSecretGuard.test.ts
+++ b/src/__tests__/lib/api-services/serverSecretGuard.test.ts
@@ -46,14 +46,16 @@ describe('serverSecretGuard', () => {
     expect(res._getStatusCode()).toBe(200)
   })
 
-  it('allows demo mode only for same-origin requests', () => {
+  it('allows demo mode only for same-origin requests with a demo token', () => {
     process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    process.env.AITUBERKIT_DEMO_ACCESS_TOKEN = 'demo-token'
     const { req, res } = createMocks({
       method: 'POST',
       headers: {
         host: 'aituberkit.example',
         origin: 'https://aituberkit.example',
         'sec-fetch-site': 'same-origin',
+        'x-aituberkit-demo-token': 'demo-token',
       },
     })
 
@@ -67,12 +69,34 @@ describe('serverSecretGuard', () => {
 
   it('rejects demo mode cross-site requests', () => {
     process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    process.env.AITUBERKIT_DEMO_ACCESS_TOKEN = 'demo-token'
     const { req, res } = createMocks({
       method: 'POST',
       headers: {
         host: 'aituberkit.example',
         origin: 'https://evil.example',
         'sec-fetch-site': 'cross-site',
+        'x-aituberkit-demo-token': 'demo-token',
+      },
+    })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(false)
+    expect(res._getStatusCode()).toBe(403)
+  })
+
+  it('rejects demo mode requests without a demo token', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    process.env.AITUBERKIT_DEMO_ACCESS_TOKEN = 'demo-token'
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        host: 'aituberkit.example',
+        origin: 'https://aituberkit.example',
+        'sec-fetch-site': 'same-origin',
       },
     })
 
@@ -86,6 +110,7 @@ describe('serverSecretGuard', () => {
 
   it('rate limits demo mode requests per feature and client IP', () => {
     process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    process.env.AITUBERKIT_DEMO_ACCESS_TOKEN = 'demo-token'
     process.env.AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE = '1'
 
     const createSameOriginRequest = () =>
@@ -95,8 +120,10 @@ describe('serverSecretGuard', () => {
           host: 'aituberkit.example',
           origin: 'https://aituberkit.example',
           'sec-fetch-site': 'same-origin',
+          'x-aituberkit-demo-token': 'demo-token',
           'x-forwarded-for': '203.0.113.10',
         },
+        socket: { remoteAddress: '198.51.100.20' },
       })
 
     const first = createSameOriginRequest()

--- a/src/__tests__/pages/api/custom.test.ts
+++ b/src/__tests__/pages/api/custom.test.ts
@@ -1,0 +1,121 @@
+import handler from '@/pages/api/ai/custom'
+import { handleCustomApi } from '@/lib/api-services/customApi'
+import { createMocks } from 'node-mocks-http'
+
+if (typeof global.Response === 'undefined') {
+  class MockResponse {
+    public status: number
+    private readonly body: any
+
+    constructor(body?: any, init: { status?: number; headers?: any } = {}) {
+      this.body = body
+      this.status = init.status ?? 200
+    }
+
+    async text() {
+      if (typeof this.body === 'string') return this.body
+      if (this.body == null) return ''
+      return JSON.stringify(this.body)
+    }
+  }
+  // @ts-expect-error – provide Response polyfill for test environment
+  global.Response = MockResponse
+}
+
+jest.mock('@/lib/api-services/customApi', () => ({
+  handleCustomApi: jest.fn(),
+}))
+
+jest.mock('@/utils/pipeResponse', () => ({
+  pipeResponse: jest.fn(async (response: any, res: any) => {
+    res.status(response.status)
+    const text = await response.text()
+    if (text) {
+      res.write(text)
+    }
+    res.end()
+  }),
+}))
+
+const mockHandleCustomApi = handleCustomApi as jest.MockedFunction<
+  typeof handleCustomApi
+>
+
+const originalEnv = { ...process.env }
+
+describe('/api/ai/custom handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('rejects non-POST requests', async () => {
+    const { req, res } = createMocks({ method: 'GET' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(405)
+    expect(res._getJSONData()).toEqual({
+      error: 'Method Not Allowed',
+      errorCode: 'METHOD_NOT_ALLOWED',
+    })
+  })
+
+  it('rejects server-side custom API settings by default', async () => {
+    process.env.CUSTOM_API_URL = 'https://example.com/api'
+    process.env.CUSTOM_API_HEADERS = '{"Authorization":"Bearer secret"}'
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        messages: [{ role: 'user', content: 'hello' }],
+        stream: true,
+      },
+    })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'ai/custom',
+      })
+    )
+    expect(mockHandleCustomApi).not.toHaveBeenCalled()
+  })
+
+  it('allows protected server-side custom API settings with a bearer token', async () => {
+    process.env.CUSTOM_API_URL = 'https://example.com/api'
+    process.env.CUSTOM_API_HEADERS = '{"Authorization":"Bearer secret"}'
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'protected'
+    process.env.AITUBERKIT_SERVER_SECRET_TOKEN = 'server-token'
+    mockHandleCustomApi.mockResolvedValue(new Response('ok', { status: 200 }))
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { authorization: 'Bearer server-token' },
+      body: {
+        messages: [{ role: 'user', content: 'hello' }],
+        stream: true,
+      },
+    })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(mockHandleCustomApi).toHaveBeenCalledWith(
+      [{ role: 'user', content: 'hello' }],
+      'https://example.com/api',
+      '{"Authorization":"Bearer secret"}',
+      '{}',
+      true,
+      false
+    )
+  })
+})

--- a/src/__tests__/pages/api/embedding.test.ts
+++ b/src/__tests__/pages/api/embedding.test.ts
@@ -46,6 +46,7 @@ describe('/api/embedding', () => {
     it('テキストをベクトル化して1536次元のembeddingを返す', async () => {
       // Arrange
       process.env.OPENAI_API_KEY = 'test-api-key'
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
       const mockEmbedding = new Array(1536).fill(0.1)
       mockCreate.mockResolvedValue({
         data: [{ embedding: mockEmbedding }],
@@ -157,9 +158,32 @@ describe('/api/embedding', () => {
       expect(data.code).toBe('API_KEY_MISSING')
     })
 
+    it('サーバー側APIキーはデフォルトで拒否する', async () => {
+      // Arrange
+      process.env.OPENAI_API_KEY = 'test-api-key'
+      delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: 'POST',
+        body: { text: 'テスト' },
+      })
+
+      handler = await importHandler()
+
+      // Act
+      await handler(req, res)
+
+      // Assert
+      expect(res._getStatusCode()).toBe(403)
+      const data = JSON.parse(res._getData())
+      expect(data.errorCode).toBe('ServerSecretAccessDenied')
+      expect(data.feature).toBe('embedding')
+      expect(mockCreate).not.toHaveBeenCalled()
+    })
+
     it('OpenAI APIからレート制限エラーが返された場合は429エラーを返す', async () => {
       // Arrange
       process.env.OPENAI_API_KEY = 'test-api-key'
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
       const rateLimitError = new Error('Rate limit exceeded')
       ;(rateLimitError as any).status = 429
       mockCreate.mockRejectedValue(rateLimitError)
@@ -183,6 +207,7 @@ describe('/api/embedding', () => {
     it('OpenAI API呼び出しが失敗した場合は500エラーを返す', async () => {
       // Arrange
       process.env.OPENAI_API_KEY = 'test-api-key'
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
       mockCreate.mockRejectedValue(new Error('API error'))
 
       const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
@@ -206,6 +231,7 @@ describe('/api/embedding', () => {
     it('text-embedding-3-smallモデルを使用してEmbedding APIを呼び出す', async () => {
       // Arrange
       process.env.OPENAI_API_KEY = 'test-api-key'
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
       const mockEmbedding = new Array(1536).fill(0.1)
       mockCreate.mockResolvedValue({
         data: [{ embedding: mockEmbedding }],

--- a/src/__tests__/pages/api/save-chat-log.test.ts
+++ b/src/__tests__/pages/api/save-chat-log.test.ts
@@ -26,6 +26,8 @@ jest.mock('@/utils/restrictedMode', () => ({
 import type { NextApiRequest, NextApiResponse } from 'next'
 import handler from '@/pages/api/save-chat-log'
 
+const originalEnv = { ...process.env }
+
 function createMockReq(
   overrides: Partial<NextApiRequest> = {}
 ): NextApiRequest {
@@ -58,6 +60,8 @@ function createMockRes() {
 describe('/api/save-chat-log', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     mockIsDemoMode.mockReturnValue(false)
     jest.spyOn(console, 'error').mockImplementation(() => {})
     jest.spyOn(console, 'warn').mockImplementation(() => {})
@@ -65,6 +69,7 @@ describe('/api/save-chat-log', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
+    process.env = originalEnv
   })
 
   it('should return 405 for non-POST requests', async () => {
@@ -94,6 +99,28 @@ describe('/api/save-chat-log', () => {
       error: 'feature_disabled_in_restricted_mode',
       message: 'The feature "save-chat-log" is disabled in restricted mode.',
     })
+  })
+
+  it('should reject chat log writes by default', async () => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const req = createMockReq({
+      body: {
+        messages: [{ role: 'user', content: 'Hello' }],
+        isNewFile: true,
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(403)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'save-chat-log',
+      })
+    )
   })
 
   it('should return 400 for invalid messages data', async () => {
@@ -135,6 +162,21 @@ describe('/api/save-chat-log', () => {
     expect(res._status).toBe(200)
     expect(res._json).toEqual({ message: 'Logs saved successfully' })
     expect(fs.writeFileSync).toHaveBeenCalled()
+  })
+
+  it('should reject unsafe targetFileName values', async () => {
+    const req = createMockReq({
+      body: {
+        messages: [{ role: 'user', content: 'Hello' }],
+        targetFileName: '../outside.json',
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(400)
+    expect(res._json).toEqual({ message: 'Invalid targetFileName' })
   })
 
   it('should return 400 when overwrite=true but targetFileName is missing', async () => {

--- a/src/__tests__/pages/api/save-chat-log.test.ts
+++ b/src/__tests__/pages/api/save-chat-log.test.ts
@@ -179,6 +179,21 @@ describe('/api/save-chat-log', () => {
     expect(res._json).toEqual({ message: 'Invalid targetFileName' })
   })
 
+  it('should reject non-string targetFileName values', async () => {
+    const req = createMockReq({
+      body: {
+        messages: [{ role: 'user', content: 'Hello' }],
+        targetFileName: { name: 'log.json' },
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(400)
+    expect(res._json).toEqual({ message: 'Invalid targetFileName' })
+  })
+
   it('should return 400 when overwrite=true but targetFileName is missing', async () => {
     const req = createMockReq({
       body: {

--- a/src/__tests__/pages/api/tts-aivisspeech.test.ts
+++ b/src/__tests__/pages/api/tts-aivisspeech.test.ts
@@ -10,6 +10,8 @@ jest.mock('axios', () => ({
 import type { NextApiRequest, NextApiResponse } from 'next'
 import handler from '@/pages/api/tts-aivisspeech'
 
+const originalEnv = { ...process.env }
+
 function createMockReq(
   overrides: Partial<NextApiRequest> = {}
 ): NextApiRequest {
@@ -37,6 +39,7 @@ function createMockRes() {
       res._headers[key] = value
       return res
     },
+    end: jest.fn(),
   }
   return res as unknown as NextApiResponse & {
     _status: number
@@ -48,11 +51,14 @@ function createMockRes() {
 describe('/api/tts-aivisspeech', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    delete process.env.AIVIS_SPEECH_SERVER_URL
     jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
+    process.env = originalEnv
   })
 
   it('should call audio_query and synthesis endpoints', async () => {
@@ -133,6 +139,53 @@ describe('/api/tts-aivisspeech', () => {
     await handler(req, res)
 
     expect(mockAxiosPost.mock.calls[0][0]).toContain('http://custom:10101')
+  })
+
+  it('should reject server-configured AivisSpeech URL by default', async () => {
+    process.env.AIVIS_SPEECH_SERVER_URL = 'http://aivis.internal:10101'
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const req = createMockReq({
+      body: {
+        text: 'test',
+        speaker: 1,
+        speed: 1,
+        pitch: 0,
+        intonationScale: 1,
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(403)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'tts-aivisspeech',
+      })
+    )
+    expect(mockAxiosPost).not.toHaveBeenCalled()
+  })
+
+  it('should reject invalid serverUrl protocols', async () => {
+    const req = createMockReq({
+      body: {
+        text: 'test',
+        speaker: 1,
+        speed: 1,
+        pitch: 0,
+        intonationScale: 1,
+        serverUrl: 'file:///tmp/aivis',
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(400)
+    expect(res._json).toEqual({ error: 'Invalid server URL protocol' })
+    expect(mockAxiosPost).not.toHaveBeenCalled()
   })
 
   it('should apply tempoDynamics parameter', async () => {

--- a/src/__tests__/pages/api/tts-aivisspeech.test.ts
+++ b/src/__tests__/pages/api/tts-aivisspeech.test.ts
@@ -62,6 +62,7 @@ describe('/api/tts-aivisspeech', () => {
   })
 
   it('should call audio_query and synthesis endpoints', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     const mockPipe = jest.fn()
     mockAxiosPost
       .mockResolvedValueOnce({
@@ -97,6 +98,7 @@ describe('/api/tts-aivisspeech', () => {
   })
 
   it('should set Content-Type to audio/wav', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     const mockPipe = jest.fn()
     mockAxiosPost
       .mockResolvedValueOnce({ data: {} })
@@ -139,6 +141,32 @@ describe('/api/tts-aivisspeech', () => {
     await handler(req, res)
 
     expect(mockAxiosPost.mock.calls[0][0]).toContain('http://custom:10101')
+  })
+
+  it('should reject default localhost AivisSpeech URL by default', async () => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const req = createMockReq({
+      body: {
+        text: 'test',
+        speaker: 1,
+        speed: 1,
+        pitch: 0,
+        intonationScale: 1,
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(403)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'tts-aivisspeech',
+      })
+    )
+    expect(mockAxiosPost).not.toHaveBeenCalled()
   })
 
   it('should reject server-configured AivisSpeech URL by default', async () => {
@@ -189,6 +217,7 @@ describe('/api/tts-aivisspeech', () => {
   })
 
   it('should apply tempoDynamics parameter', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     const mockPipe = jest.fn()
     mockAxiosPost
       .mockResolvedValueOnce({ data: {} })
@@ -213,6 +242,7 @@ describe('/api/tts-aivisspeech', () => {
   })
 
   it('should return 500 on error', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     mockAxiosPost.mockRejectedValue(new Error('Connection refused'))
 
     const req = createMockReq({

--- a/src/__tests__/pages/api/tts-google.test.ts
+++ b/src/__tests__/pages/api/tts-google.test.ts
@@ -64,6 +64,7 @@ describe('/api/tts-google', () => {
   describe('API Key authentication', () => {
     it('should use API key when GOOGLE_TTS_KEY is set', async () => {
       process.env.GOOGLE_TTS_KEY = 'test-api-key'
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
 
       mockFetch.mockResolvedValue({
         ok: true,
@@ -91,6 +92,7 @@ describe('/api/tts-google', () => {
 
     it('should return 500 on API key fetch failure', async () => {
       process.env.GOOGLE_TTS_KEY = 'test-key'
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
       mockFetch.mockResolvedValue({
         ok: false,
         status: 403,
@@ -104,6 +106,27 @@ describe('/api/tts-google', () => {
       await handler(req, res)
 
       expect(res._status).toBe(500)
+    })
+
+    it('should reject GOOGLE_TTS_KEY usage by default', async () => {
+      process.env.GOOGLE_TTS_KEY = 'test-key'
+      delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+      const req = createMockReq({
+        body: { message: 'test', ttsType: 'en', languageCode: 'en-US' },
+      })
+      const res = createMockRes()
+
+      await handler(req, res)
+
+      expect(res._status).toBe(403)
+      expect(res._json).toEqual(
+        expect.objectContaining({
+          errorCode: 'ServerSecretAccessDenied',
+          feature: 'tts-google',
+        })
+      )
+      expect(mockFetch).not.toHaveBeenCalled()
     })
   })
 

--- a/src/__tests__/pages/api/tts-google.test.ts
+++ b/src/__tests__/pages/api/tts-google.test.ts
@@ -52,6 +52,7 @@ describe('/api/tts-google', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env = { ...originalEnv }
     jest.spyOn(console, 'error').mockImplementation(() => {})
     delete process.env.GOOGLE_TTS_KEY
   })
@@ -132,6 +133,7 @@ describe('/api/tts-google', () => {
 
   describe('Credential authentication', () => {
     it('should use TextToSpeechClient when no API key', async () => {
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
       const audioContent = Buffer.from('audio data')
       mockSynthesizeSpeech.mockResolvedValue([{ audioContent: audioContent }])
 
@@ -158,6 +160,7 @@ describe('/api/tts-google', () => {
     })
 
     it('should return 500 on client error', async () => {
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
       mockSynthesizeSpeech.mockRejectedValue(new Error('Auth error'))
 
       const req = createMockReq({
@@ -170,9 +173,30 @@ describe('/api/tts-google', () => {
       expect(res._status).toBe(500)
       expect(res._json).toEqual({ error: 'Internal Server Error' })
     })
+
+    it('should reject default credential usage by default', async () => {
+      delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+      const req = createMockReq({
+        body: { message: 'test', ttsType: 'en', languageCode: 'en-US' },
+      })
+      const res = createMockRes()
+
+      await handler(req, res)
+
+      expect(res._status).toBe(403)
+      expect(res._json).toEqual(
+        expect.objectContaining({
+          errorCode: 'ServerSecretAccessDenied',
+          feature: 'tts-google',
+        })
+      )
+      expect(mockSynthesizeSpeech).not.toHaveBeenCalled()
+    })
   })
 
   it('should default languageCode to ja-JP', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     const audioContent = Buffer.from('audio')
     mockSynthesizeSpeech.mockResolvedValue([{ audioContent }])
 

--- a/src/__tests__/pages/api/tts-voicevox.test.ts
+++ b/src/__tests__/pages/api/tts-voicevox.test.ts
@@ -10,6 +10,8 @@ jest.mock('axios', () => ({
 import type { NextApiRequest, NextApiResponse } from 'next'
 import handler from '@/pages/api/tts-voicevox'
 
+const originalEnv = { ...process.env }
+
 function createMockReq(
   overrides: Partial<NextApiRequest> = {}
 ): NextApiRequest {
@@ -38,6 +40,7 @@ function createMockRes() {
       res._headers[key] = value
       return res
     },
+    end: jest.fn(),
   }
   return res as unknown as NextApiResponse & {
     _status: number
@@ -49,11 +52,14 @@ function createMockRes() {
 describe('/api/tts-voicevox', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    delete process.env.VOICEVOX_SERVER_URL
     jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
+    process.env = originalEnv
   })
 
   it('should call audio_query and synthesis endpoints', async () => {
@@ -128,6 +134,47 @@ describe('/api/tts-voicevox', () => {
     await handler(req, res)
 
     expect(mockAxiosPost.mock.calls[0][0]).toContain('http://custom:8080')
+  })
+
+  it('should reject server-configured VOICEVOX URL by default', async () => {
+    process.env.VOICEVOX_SERVER_URL = 'http://voicevox.internal:50021'
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const req = createMockReq({
+      body: { text: 'test', speaker: 1, speed: 1, pitch: 0, intonation: 1 },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(403)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'tts-voicevox',
+      })
+    )
+    expect(mockAxiosPost).not.toHaveBeenCalled()
+  })
+
+  it('should reject invalid serverUrl protocols', async () => {
+    const req = createMockReq({
+      body: {
+        text: 'test',
+        speaker: 1,
+        speed: 1,
+        pitch: 0,
+        intonation: 1,
+        serverUrl: 'file:///tmp/voicevox',
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(400)
+    expect(res._json).toEqual({ error: 'Invalid server URL protocol' })
+    expect(mockAxiosPost).not.toHaveBeenCalled()
   })
 
   it('should return 500 on error', async () => {

--- a/src/__tests__/pages/api/tts-voicevox.test.ts
+++ b/src/__tests__/pages/api/tts-voicevox.test.ts
@@ -63,6 +63,7 @@ describe('/api/tts-voicevox', () => {
   })
 
   it('should call audio_query and synthesis endpoints', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     const mockPipe = jest.fn()
     mockAxiosPost
       .mockResolvedValueOnce({
@@ -98,6 +99,7 @@ describe('/api/tts-voicevox', () => {
   })
 
   it('should set Content-Type to audio/wav', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     const mockPipe = jest.fn()
     mockAxiosPost
       .mockResolvedValueOnce({ data: {} })
@@ -134,6 +136,26 @@ describe('/api/tts-voicevox', () => {
     await handler(req, res)
 
     expect(mockAxiosPost.mock.calls[0][0]).toContain('http://custom:8080')
+  })
+
+  it('should reject default localhost VOICEVOX URL by default', async () => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const req = createMockReq({
+      body: { text: 'test', speaker: 1, speed: 1, pitch: 0, intonation: 1 },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(403)
+    expect(res._json).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'tts-voicevox',
+      })
+    )
+    expect(mockAxiosPost).not.toHaveBeenCalled()
   })
 
   it('should reject server-configured VOICEVOX URL by default', async () => {
@@ -178,6 +200,7 @@ describe('/api/tts-voicevox', () => {
   })
 
   it('should return 500 on error', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     mockAxiosPost.mockRejectedValue(new Error('Connection refused'))
 
     const req = createMockReq({

--- a/src/__tests__/pages/api/update-aivis-speakers.test.ts
+++ b/src/__tests__/pages/api/update-aivis-speakers.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment node
+ */
+
+const mockWriteFile = jest.fn()
+jest.mock('fs/promises', () => ({
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+}))
+
+const mockIsRestrictedMode = jest.fn(() => false)
+jest.mock('@/utils/restrictedMode', () => ({
+  isRestrictedMode: () => mockIsRestrictedMode(),
+  createRestrictedModeErrorResponse: (feature: string) => ({
+    error: 'feature_disabled_in_restricted_mode',
+    message: `The feature "${feature}" is disabled in restricted mode.`,
+  }),
+}))
+
+import { createMocks } from 'node-mocks-http'
+import handler from '@/pages/api/update-aivis-speakers'
+
+const originalEnv = { ...process.env }
+
+describe('/api/update-aivis-speakers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    mockIsRestrictedMode.mockReturnValue(false)
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          name: 'Speaker',
+          speaker_uuid: 'speaker-id',
+          styles: [{ name: 'Normal', id: 1, type: 'talk' }],
+        },
+      ],
+    }) as jest.Mock
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('rejects speaker file updates by default', async () => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+    const { req, res } = createMocks({ method: 'POST' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'update-aivis-speakers',
+      })
+    )
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('updates speaker file when server resource access is allowed', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+    const { req, res } = createMocks({ method: 'POST' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:10101/speakers')
+    expect(mockWriteFile).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/pages/api/update-aivis-speakers.test.ts
+++ b/src/__tests__/pages/api/update-aivis-speakers.test.ts
@@ -25,6 +25,7 @@ describe('/api/update-aivis-speakers', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     process.env = { ...originalEnv }
+    delete process.env.AIVIS_SPEECH_SERVER_URL
     mockIsRestrictedMode.mockReturnValue(false)
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -55,6 +56,18 @@ describe('/api/update-aivis-speakers', () => {
         feature: 'update-aivis-speakers',
       })
     )
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-POST requests', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+    const { req, res } = createMocks({ method: 'GET' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(405)
+    expect(res._getJSONData()).toEqual({ error: 'Method Not Allowed' })
     expect(global.fetch).not.toHaveBeenCalled()
     expect(mockWriteFile).not.toHaveBeenCalled()
   })

--- a/src/__tests__/pages/api/update-voicevox-speakers.test.ts
+++ b/src/__tests__/pages/api/update-voicevox-speakers.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment node
+ */
+
+const mockWriteFile = jest.fn()
+jest.mock('fs/promises', () => ({
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+}))
+
+const mockIsRestrictedMode = jest.fn(() => false)
+jest.mock('@/utils/restrictedMode', () => ({
+  isRestrictedMode: () => mockIsRestrictedMode(),
+  createRestrictedModeErrorResponse: (feature: string) => ({
+    error: 'feature_disabled_in_restricted_mode',
+    message: `The feature "${feature}" is disabled in restricted mode.`,
+  }),
+}))
+
+import { createMocks } from 'node-mocks-http'
+import handler from '@/pages/api/update-voicevox-speakers'
+
+const originalEnv = { ...process.env }
+
+describe('/api/update-voicevox-speakers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    mockIsRestrictedMode.mockReturnValue(false)
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          name: 'Speaker',
+          speaker_uuid: 'speaker-id',
+          styles: [{ name: 'Normal', id: 1, type: 'talk' }],
+        },
+      ],
+    }) as jest.Mock
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('rejects speaker file updates by default', async () => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+    const { req, res } = createMocks({ method: 'POST' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'update-voicevox-speakers',
+      })
+    )
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('updates speaker file when server resource access is allowed', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+    const { req, res } = createMocks({ method: 'POST' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:50021/speakers')
+    expect(mockWriteFile).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/pages/api/update-voicevox-speakers.test.ts
+++ b/src/__tests__/pages/api/update-voicevox-speakers.test.ts
@@ -25,6 +25,7 @@ describe('/api/update-voicevox-speakers', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     process.env = { ...originalEnv }
+    delete process.env.VOICEVOX_SERVER_URL
     mockIsRestrictedMode.mockReturnValue(false)
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
@@ -55,6 +56,18 @@ describe('/api/update-voicevox-speakers', () => {
         feature: 'update-voicevox-speakers',
       })
     )
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-POST requests', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+    const { req, res } = createMocks({ method: 'GET' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(405)
+    expect(res._getJSONData()).toEqual({ error: 'Method Not Allowed' })
     expect(global.fetch).not.toHaveBeenCalled()
     expect(mockWriteFile).not.toHaveBeenCalled()
   })

--- a/src/__tests__/pages/api/vercel.test.ts
+++ b/src/__tests__/pages/api/vercel.test.ts
@@ -121,6 +121,33 @@ describe('/api/ai/vercel handler', () => {
     })
   })
 
+  it('rejects server-side API keys by default', async () => {
+    process.env.OPENAI_API_KEY = 'env-openai'
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        messages: [],
+        apiKey: '',
+        aiService: 'openai',
+        model: 'gpt-4.1',
+        stream: true,
+        temperature: 1,
+        maxTokens: 10,
+      },
+    })
+
+    await handler(req as any, res as any)
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'ai/vercel',
+      })
+    )
+  })
+
   it('returns 400 when local services lack a URL', async () => {
     const { req, res } = createMocks({
       method: 'POST',
@@ -146,6 +173,7 @@ describe('/api/ai/vercel handler', () => {
 
   it('streams google responses with search grounding using env API key', async () => {
     process.env.GOOGLE_KEY = 'env-google'
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
     mockModifyMessages.mockReturnValue([
       { role: 'user', content: 'hello' },
     ] as any)

--- a/src/__tests__/pages/api/vercel.test.ts
+++ b/src/__tests__/pages/api/vercel.test.ts
@@ -220,6 +220,38 @@ describe('/api/ai/vercel handler', () => {
     })
   })
 
+  it('does not guard non-azure requests only because AZURE_ENDPOINT is configured', async () => {
+    process.env.AZURE_ENDPOINT =
+      'https://my-resource.openai.azure.com/openai/deployments/my-deploy/chat/completions?api-version=2024-05-01-preview'
+    mockModifyMessages.mockReturnValue([{ role: 'user', content: 'hi' }] as any)
+
+    const generateResponse = new Response('done', { status: 200 })
+    mockGenerateAiText.mockResolvedValue(generateResponse)
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        messages: [],
+        apiKey: 'openai-key',
+        aiService: 'openai',
+        model: 'gpt-4.1',
+        stream: false,
+        temperature: 0.3,
+        maxTokens: 256,
+      },
+    })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).not.toBe(403)
+    expect(mockCreateAIRegistry).toHaveBeenCalledWith('openai', {
+      apiKey: 'openai-key',
+      baseURL: undefined,
+      resourceName: '',
+    })
+    expect(mockGenerateAiText).toHaveBeenCalled()
+  })
+
   it('calls generateAiText for azure requests using deployment name', async () => {
     mockModifyMessages.mockReturnValue([{ role: 'user', content: 'hi' }] as any)
 

--- a/src/__tests__/pages/api/youtube/continuation.test.ts
+++ b/src/__tests__/pages/api/youtube/continuation.test.ts
@@ -25,6 +25,7 @@ const mockCreateAIRegistry = createAIRegistry as jest.MockedFunction<
 const mockGetLanguageModel = getLanguageModel as jest.MockedFunction<
   typeof getLanguageModel
 >
+const originalEnv = { ...process.env }
 
 const buildRequestBody = (overrides: any = {}) => ({
   aiService: 'openai',
@@ -49,8 +50,13 @@ const buildRequestBody = (overrides: any = {}) => ({
 describe('/api/youtube/continuation handler', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env = { ...originalEnv }
     mockCreateAIRegistry.mockReturnValue({ languageModel: jest.fn() } as any)
     mockGetLanguageModel.mockReturnValue('mock-language-model' as any)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
   })
 
   it('rejects non-POST requests', async () => {
@@ -169,6 +175,40 @@ describe('/api/youtube/continuation handler', () => {
     expect(ctx.get('languageModel')).toBe('mock-language-model')
     expect(ctx.get('temperature')).toBe(1.0)
     expect(ctx.get('maxTokens')).toBe(4096)
+  })
+
+  it('does not guard non-azure flow only because AZURE_ENDPOINT is configured', async () => {
+    process.env.AZURE_ENDPOINT =
+      'https://my-resource.openai.azure.com/openai/deployments/my-deploy/chat/completions?api-version=2024-05-01-preview'
+    mockStart.mockResolvedValue({
+      status: 'success',
+      result: {
+        action: 'process_messages',
+        messages: [],
+        stateUpdates: {
+          noCommentCount: 0,
+          continuationCount: 0,
+          sleepMode: false,
+        },
+      },
+    })
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: buildRequestBody({
+        aiService: 'openai',
+        apiKey: 'openai-key',
+      }),
+    })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).not.toBe(403)
+    expect(mockCreateAIRegistry).toHaveBeenCalledWith('openai', {
+      apiKey: 'openai-key',
+      baseURL: '',
+      resourceName: '',
+    })
   })
 
   it('returns send_comment action for comment selection', async () => {

--- a/src/lib/api-services/customApi.ts
+++ b/src/lib/api-services/customApi.ts
@@ -149,6 +149,9 @@ export async function handleCustomApi(
   }
 
   if (stream) {
+    const forwardMetadata =
+      process.env.AITUBERKIT_FORWARD_CUSTOM_API_METADATA === 'true'
+
     // ストリーミングレスポンスを正規化して返す
     // SSEの行をVercel AI SDK形式（text-delta + delta）に変換する
     let buffer = ''
@@ -179,7 +182,9 @@ export async function handleCustomApi(
 
             // 既にVercel AI SDK形式（deltaフィールドあり）ならそのまま
             if (data.delta !== undefined) {
-              controller.enqueue(encoder.encode(line + '\n'))
+              if (forwardMetadata || data.type === 'text-delta') {
+                controller.enqueue(encoder.encode(line + '\n'))
+              }
               continue
             }
 
@@ -197,13 +202,15 @@ export async function handleCustomApi(
 
             // OpenAI互換形式（choices[].delta.reasoning_content）の推論コンテンツ変換
             if (data.choices?.[0]?.delta?.reasoning_content !== undefined) {
-              const normalized = {
-                type: 'reasoning-delta',
-                delta: data.choices[0].delta.reasoning_content,
+              if (forwardMetadata) {
+                const normalized = {
+                  type: 'reasoning-delta',
+                  delta: data.choices[0].delta.reasoning_content,
+                }
+                controller.enqueue(
+                  encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
+                )
               }
-              controller.enqueue(
-                encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
-              )
               // contentも同時に存在する場合があるのでフォールスルー
               if (data.choices[0].delta.content === undefined) {
                 continue
@@ -223,10 +230,14 @@ export async function handleCustomApi(
             }
 
             // その他の形式はそのまま
-            controller.enqueue(encoder.encode(line + '\n'))
+            if (forwardMetadata) {
+              controller.enqueue(encoder.encode(line + '\n'))
+            }
           } catch {
             // JSONパース失敗時はそのまま
-            controller.enqueue(encoder.encode(line + '\n'))
+            if (forwardMetadata) {
+              controller.enqueue(encoder.encode(line + '\n'))
+            }
           }
         }
       },

--- a/src/lib/api-services/customApi.ts
+++ b/src/lib/api-services/customApi.ts
@@ -158,6 +158,87 @@ export async function handleCustomApi(
     const encoder = new TextEncoder()
     const decoder = new TextDecoder()
 
+    const enqueueAllowedLine = (
+      line: string,
+      controller: TransformStreamDefaultController
+    ) => {
+      if (!line.startsWith('data:')) {
+        if (forwardMetadata) {
+          controller.enqueue(encoder.encode(line + '\n'))
+        }
+        return
+      }
+
+      const content = line.substring(5).trim()
+      if (!content || content === '[DONE]') {
+        controller.enqueue(encoder.encode(line + '\n'))
+        return
+      }
+
+      try {
+        const data = JSON.parse(content)
+
+        // 既にVercel AI SDK形式（deltaフィールドあり）ならそのまま
+        if (data.delta !== undefined) {
+          if (forwardMetadata || data.type === 'text-delta') {
+            controller.enqueue(encoder.encode(line + '\n'))
+          }
+          return
+        }
+
+        // payload.textフォーマットをdeltaフォーマットに変換
+        if (data.payload?.text !== undefined) {
+          const normalized = {
+            type: data.type || 'text-delta',
+            delta: data.payload.text,
+          }
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
+          )
+          return
+        }
+
+        // OpenAI互換形式（choices[].delta.reasoning_content）の推論コンテンツ変換
+        if (data.choices?.[0]?.delta?.reasoning_content !== undefined) {
+          if (forwardMetadata) {
+            const normalized = {
+              type: 'reasoning-delta',
+              delta: data.choices[0].delta.reasoning_content,
+            }
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
+            )
+          }
+          // contentも同時に存在する場合があるのでフォールスルー
+          if (data.choices[0].delta.content === undefined) {
+            return
+          }
+        }
+
+        // OpenAI互換形式（choices[].delta.content）の変換
+        if (data.choices?.[0]?.delta?.content !== undefined) {
+          const normalized = {
+            type: 'text-delta',
+            delta: data.choices[0].delta.content,
+          }
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
+          )
+          return
+        }
+
+        // その他の形式はそのまま
+        if (forwardMetadata) {
+          controller.enqueue(encoder.encode(line + '\n'))
+        }
+      } catch {
+        // JSONパース失敗時はそのまま
+        if (forwardMetadata) {
+          controller.enqueue(encoder.encode(line + '\n'))
+        }
+      }
+    }
+
     const transformStream = new TransformStream({
       transform(chunk, controller) {
         buffer += decoder.decode(chunk, { stream: true })
@@ -166,85 +247,13 @@ export async function handleCustomApi(
         buffer = lines.pop() || ''
 
         for (const line of lines) {
-          if (!line.startsWith('data:')) {
-            controller.enqueue(encoder.encode(line + '\n'))
-            continue
-          }
-
-          const content = line.substring(5).trim()
-          if (!content || content === '[DONE]') {
-            controller.enqueue(encoder.encode(line + '\n'))
-            continue
-          }
-
-          try {
-            const data = JSON.parse(content)
-
-            // 既にVercel AI SDK形式（deltaフィールドあり）ならそのまま
-            if (data.delta !== undefined) {
-              if (forwardMetadata || data.type === 'text-delta') {
-                controller.enqueue(encoder.encode(line + '\n'))
-              }
-              continue
-            }
-
-            // payload.textフォーマットをdeltaフォーマットに変換
-            if (data.payload?.text !== undefined) {
-              const normalized = {
-                type: data.type || 'text-delta',
-                delta: data.payload.text,
-              }
-              controller.enqueue(
-                encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
-              )
-              continue
-            }
-
-            // OpenAI互換形式（choices[].delta.reasoning_content）の推論コンテンツ変換
-            if (data.choices?.[0]?.delta?.reasoning_content !== undefined) {
-              if (forwardMetadata) {
-                const normalized = {
-                  type: 'reasoning-delta',
-                  delta: data.choices[0].delta.reasoning_content,
-                }
-                controller.enqueue(
-                  encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
-                )
-              }
-              // contentも同時に存在する場合があるのでフォールスルー
-              if (data.choices[0].delta.content === undefined) {
-                continue
-              }
-            }
-
-            // OpenAI互換形式（choices[].delta.content）の変換
-            if (data.choices?.[0]?.delta?.content !== undefined) {
-              const normalized = {
-                type: 'text-delta',
-                delta: data.choices[0].delta.content,
-              }
-              controller.enqueue(
-                encoder.encode(`data: ${JSON.stringify(normalized)}\n`)
-              )
-              continue
-            }
-
-            // その他の形式はそのまま
-            if (forwardMetadata) {
-              controller.enqueue(encoder.encode(line + '\n'))
-            }
-          } catch {
-            // JSONパース失敗時はそのまま
-            if (forwardMetadata) {
-              controller.enqueue(encoder.encode(line + '\n'))
-            }
-          }
+          enqueueAllowedLine(line, controller)
         }
       },
       flush(controller) {
         // 残りのバッファを処理
         if (buffer.trim()) {
-          controller.enqueue(encoder.encode(buffer + '\n'))
+          enqueueAllowedLine(buffer, controller)
         }
       },
     })

--- a/src/lib/api-services/serverSecretGuard.ts
+++ b/src/lib/api-services/serverSecretGuard.ts
@@ -1,0 +1,209 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export type ServerSecretAccessMode =
+  | 'disabled'
+  | 'protected'
+  | 'demo'
+  | 'unprotected'
+
+export type ServerSecretGuardOptions = {
+  featureName: string
+}
+
+const DEFAULT_ACCESS_MODE: ServerSecretAccessMode = 'disabled'
+const DEFAULT_DEMO_RATE_LIMIT_PER_MINUTE = 20
+
+type RateLimitEntry = {
+  windowStart: number
+  count: number
+}
+
+function getAccessMode(): ServerSecretAccessMode {
+  const mode =
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE || DEFAULT_ACCESS_MODE
+
+  if (
+    mode === 'disabled' ||
+    mode === 'protected' ||
+    mode === 'demo' ||
+    mode === 'unprotected'
+  ) {
+    return mode
+  }
+
+  return DEFAULT_ACCESS_MODE
+}
+
+function getHeaderValue(req: NextApiRequest, name: string): string {
+  const value = req.headers?.[name.toLowerCase()]
+  return Array.isArray(value) ? value[0] || '' : value || ''
+}
+
+function parseAllowedOrigins(): string[] {
+  return (process.env.AITUBERKIT_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+}
+
+function getRequestOrigin(req: NextApiRequest): string {
+  const origin = getHeaderValue(req, 'origin')
+  if (origin) return origin
+
+  const referer = getHeaderValue(req, 'referer')
+  if (!referer) return ''
+
+  try {
+    return new URL(referer).origin
+  } catch {
+    return ''
+  }
+}
+
+function isSameHostOrigin(req: NextApiRequest, origin: string): boolean {
+  if (!origin) return false
+
+  const host = getHeaderValue(req, 'host')
+  if (!host) return false
+
+  try {
+    return new URL(origin).host === host
+  } catch {
+    return false
+  }
+}
+
+function isAllowedDemoOrigin(req: NextApiRequest): boolean {
+  const origin = getRequestOrigin(req)
+  const allowedOrigins = parseAllowedOrigins()
+
+  if (allowedOrigins.length > 0) {
+    return allowedOrigins.includes(origin)
+  }
+
+  return isSameHostOrigin(req, origin)
+}
+
+function hasValidBearerToken(req: NextApiRequest): boolean {
+  const expectedToken = process.env.AITUBERKIT_SERVER_SECRET_TOKEN
+  if (!expectedToken) return false
+
+  const authorization = getHeaderValue(req, 'authorization')
+  const expectedAuthorization = `Bearer ${expectedToken}`
+  return authorization === expectedAuthorization
+}
+
+function getClientIp(req: NextApiRequest): string {
+  const forwardedFor = getHeaderValue(req, 'x-forwarded-for')
+  if (forwardedFor) {
+    return forwardedFor.split(',')[0].trim()
+  }
+
+  const realIp = getHeaderValue(req, 'cf-connecting-ip')
+  if (realIp) return realIp
+
+  return req.socket?.remoteAddress || 'unknown'
+}
+
+function getDemoRateLimitPerMinute(): number {
+  const parsed = Number(process.env.AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE)
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed)
+  }
+
+  return DEFAULT_DEMO_RATE_LIMIT_PER_MINUTE
+}
+
+function isDemoRateLimited(req: NextApiRequest, featureName: string): boolean {
+  const limit = getDemoRateLimitPerMinute()
+  const now = Date.now()
+  const windowMs = 60_000
+  const key = `${featureName}:${getClientIp(req)}`
+  const globalStore = globalThis as typeof globalThis & {
+    __aituberKitServerSecretRateLimit?: Map<string, RateLimitEntry>
+  }
+  const store =
+    globalStore.__aituberKitServerSecretRateLimit ||
+    new Map<string, RateLimitEntry>()
+  globalStore.__aituberKitServerSecretRateLimit = store
+
+  const current = store.get(key)
+  if (!current || now - current.windowStart >= windowMs) {
+    store.set(key, { windowStart: now, count: 1 })
+    return false
+  }
+
+  current.count += 1
+  return current.count > limit
+}
+
+export function rejectServerSecretAccess(
+  res: NextApiResponse,
+  options: ServerSecretGuardOptions,
+  message?: string
+) {
+  return res.status(403).json({
+    error: 'Server secret/resource access is not allowed',
+    errorCode: 'ServerSecretAccessDenied',
+    feature: options.featureName,
+    message:
+      message ||
+      'Server-side secret or resource settings require AITUBERKIT_SERVER_SECRET_ACCESS_MODE to be configured.',
+  })
+}
+
+export function guardServerSecretAccess(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  options: ServerSecretGuardOptions
+): boolean {
+  const mode = getAccessMode()
+
+  if (mode === 'unprotected') {
+    return true
+  }
+
+  if (mode === 'protected') {
+    if (hasValidBearerToken(req)) {
+      return true
+    }
+
+    rejectServerSecretAccess(
+      res,
+      options,
+      'Server-side secret settings require a valid Authorization bearer token.'
+    )
+    return false
+  }
+
+  if (mode === 'demo') {
+    const fetchSite = getHeaderValue(req, 'sec-fetch-site')
+    const fetchSiteAllowed =
+      !fetchSite || fetchSite === 'same-origin' || fetchSite === 'none'
+
+    if (fetchSiteAllowed && isAllowedDemoOrigin(req)) {
+      if (isDemoRateLimited(req, options.featureName)) {
+        res.status(429).json({
+          error: 'Server secret demo rate limit exceeded',
+          errorCode: 'ServerSecretRateLimited',
+          feature: options.featureName,
+          message:
+            'Demo mode server-side secret requests are rate limited. Configure AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE or add deployment-level rate limits.',
+        })
+        return false
+      }
+
+      return true
+    }
+
+    rejectServerSecretAccess(
+      res,
+      options,
+      'Server-side secret settings in demo mode require an allowed same-origin request.'
+    )
+    return false
+  }
+
+  rejectServerSecretAccess(res, options)
+  return false
+}

--- a/src/lib/api-services/serverSecretGuard.ts
+++ b/src/lib/api-services/serverSecretGuard.ts
@@ -12,6 +12,7 @@ export type ServerSecretGuardOptions = {
 
 const DEFAULT_ACCESS_MODE: ServerSecretAccessMode = 'disabled'
 const DEFAULT_DEMO_RATE_LIMIT_PER_MINUTE = 20
+const MAX_RATE_LIMIT_ENTRIES = 10_000
 
 type RateLimitEntry = {
   windowStart: number
@@ -93,14 +94,26 @@ function hasValidBearerToken(req: NextApiRequest): boolean {
   return authorization === expectedAuthorization
 }
 
-function getClientIp(req: NextApiRequest): string {
-  const forwardedFor = getHeaderValue(req, 'x-forwarded-for')
-  if (forwardedFor) {
-    return forwardedFor.split(',')[0].trim()
-  }
+function hasValidDemoToken(req: NextApiRequest): boolean {
+  const expectedToken =
+    process.env.AITUBERKIT_DEMO_ACCESS_TOKEN ||
+    process.env.AITUBERKIT_SERVER_SECRET_TOKEN
+  if (!expectedToken) return false
 
-  const realIp = getHeaderValue(req, 'cf-connecting-ip')
-  if (realIp) return realIp
+  const token = getHeaderValue(req, 'x-aituberkit-demo-token')
+  return token === expectedToken
+}
+
+function getClientIp(req: NextApiRequest): string {
+  if (process.env.AITUBERKIT_TRUST_PROXY_HEADERS === 'true') {
+    const realIp = getHeaderValue(req, 'cf-connecting-ip')
+    if (realIp) return realIp
+
+    const forwardedFor = getHeaderValue(req, 'x-forwarded-for')
+    if (forwardedFor) {
+      return forwardedFor.split(',')[0].trim()
+    }
+  }
 
   return req.socket?.remoteAddress || 'unknown'
 }
@@ -126,6 +139,17 @@ function isDemoRateLimited(req: NextApiRequest, featureName: string): boolean {
     globalStore.__aituberKitServerSecretRateLimit ||
     new Map<string, RateLimitEntry>()
   globalStore.__aituberKitServerSecretRateLimit = store
+
+  for (const [entryKey, entry] of store) {
+    if (now - entry.windowStart >= windowMs) {
+      store.delete(entryKey)
+    }
+  }
+
+  if (store.size >= MAX_RATE_LIMIT_ENTRIES && !store.has(key)) {
+    const oldestKey = store.keys().next().value
+    if (oldestKey) store.delete(oldestKey)
+  }
 
   const current = store.get(key)
   if (!current || now - current.windowStart >= windowMs) {
@@ -178,10 +202,13 @@ export function guardServerSecretAccess(
 
   if (mode === 'demo') {
     const fetchSite = getHeaderValue(req, 'sec-fetch-site')
-    const fetchSiteAllowed =
-      !fetchSite || fetchSite === 'same-origin' || fetchSite === 'none'
+    const fetchSiteAllowed = fetchSite === 'same-origin' || fetchSite === 'none'
 
-    if (fetchSiteAllowed && isAllowedDemoOrigin(req)) {
+    if (
+      fetchSiteAllowed &&
+      isAllowedDemoOrigin(req) &&
+      hasValidDemoToken(req)
+    ) {
       if (isDemoRateLimited(req, options.featureName)) {
         res.status(429).json({
           error: 'Server secret demo rate limit exceeded',
@@ -199,7 +226,7 @@ export function guardServerSecretAccess(
     rejectServerSecretAccess(
       res,
       options,
-      'Server-side secret settings in demo mode require an allowed same-origin request.'
+      'Server-side secret settings in demo mode require an allowed same-origin request with a valid demo token.'
     )
     return false
   }

--- a/src/pages/api/ai/custom.ts
+++ b/src/pages/api/ai/custom.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { handleCustomApi } from '@/lib/api-services/customApi'
 import { pipeResponse } from '@/utils/pipeResponse'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 export const config = {
   api: {
@@ -30,6 +31,19 @@ export default async function handler(
     customApiIncludeMimeType = false,
     threadId,
   } = req.body
+
+  const usesServerSecret = Boolean(
+    process.env.CUSTOM_API_URL ||
+    process.env.CUSTOM_API_HEADERS ||
+    process.env.CUSTOM_API_BODY
+  )
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'ai/custom' })
+  ) {
+    return
+  }
 
   // サーバーサイド環境変数を優先（秘匿設定）
   const apiUrl = process.env.CUSTOM_API_URL || customApiUrl

--- a/src/pages/api/ai/vercel.ts
+++ b/src/pages/api/ai/vercel.ts
@@ -14,6 +14,7 @@ import {
 import { buildReasoningProviderOptions } from '@/lib/api-services/providerOptionsBuilder'
 import { googleSearchGroundingModels } from '@/features/constants/aiModels'
 import { pipeResponse } from '@/utils/pipeResponse'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 export const config = {
   api: {
@@ -52,6 +53,7 @@ export default async function handler(
 
   // APIキーの取得と検証
   let aiApiKey = apiKey
+  let usesServerSecret = false
   if (isVercelCloudAIService(aiService)) {
     if (!aiApiKey) {
       // 環境変数から[サービス名]_KEY または [サービス名]_API_KEY の形式でAPIキーを取得
@@ -60,12 +62,20 @@ export default async function handler(
         process.env[`${servicePrefix}_KEY`] ||
         process.env[`${servicePrefix}_API_KEY`] ||
         ''
+      usesServerSecret = Boolean(aiApiKey)
     }
     if (!aiApiKey) {
       return res
         .status(400)
         .json({ error: 'Empty API Key', errorCode: 'EmptyAPIKey' })
     }
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'ai/vercel' })
+  ) {
+    return
   }
 
   // ローカルLLMのURL検証
@@ -79,15 +89,22 @@ export default async function handler(
   }
 
   // Azureのエンドポイントとデプロイメント名の処理
-  let modifiedAzureEndpoint = (
-    azureEndpoint ||
-    process.env.AZURE_ENDPOINT ||
+  const azureEndpointValue = azureEndpoint || process.env.AZURE_ENDPOINT || ''
+  const usesServerAzureEndpoint =
+    !azureEndpoint && Boolean(process.env.AZURE_ENDPOINT)
+  if (
+    usesServerAzureEndpoint &&
+    !guardServerSecretAccess(req, res, { featureName: 'ai/vercel' })
+  ) {
+    return
+  }
+
+  let modifiedAzureEndpoint = azureEndpointValue.replace(
+    /^https:\/\/|\.openai\.azure\.com.*$/g,
     ''
-  ).replace(/^https:\/\/|\.openai\.azure\.com.*$/g, '')
+  )
   let modifiedAzureDeployment =
-    (azureEndpoint || process.env.AZURE_ENDPOINT || '').match(
-      /\/deployments\/([^\/]+)/
-    )?.[1] || ''
+    azureEndpointValue.match(/\/deployments\/([^\/]+)/)?.[1] || ''
   let modifiedModel = aiService === 'azure' ? modifiedAzureDeployment : model
 
   // モデル名のバリデーション

--- a/src/pages/api/ai/vercel.ts
+++ b/src/pages/api/ai/vercel.ts
@@ -89,9 +89,14 @@ export default async function handler(
   }
 
   // Azureのエンドポイントとデプロイメント名の処理
-  const azureEndpointValue = azureEndpoint || process.env.AZURE_ENDPOINT || ''
+  const azureEndpointValue =
+    aiService === 'azure'
+      ? azureEndpoint || process.env.AZURE_ENDPOINT || ''
+      : ''
   const usesServerAzureEndpoint =
-    !azureEndpoint && Boolean(process.env.AZURE_ENDPOINT)
+    aiService === 'azure' &&
+    !azureEndpoint &&
+    Boolean(process.env.AZURE_ENDPOINT)
   if (
     usesServerAzureEndpoint &&
     !guardServerSecretAccess(req, res, { featureName: 'ai/vercel' })

--- a/src/pages/api/azureOpenAITTS.ts
+++ b/src/pages/api/azureOpenAITTS.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { AzureOpenAI } from 'openai'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 export default async function handler(
   req: NextApiRequest,
@@ -13,9 +14,19 @@ export default async function handler(
 
   const azureTTSKey = apiKey || process.env.AZURE_TTS_KEY
   const azureTTSEndpoint = endpoint || process.env.AZURE_TTS_ENDPOINT
+  const usesServerSecret =
+    (!apiKey && Boolean(process.env.AZURE_TTS_KEY)) ||
+    (!endpoint && Boolean(process.env.AZURE_TTS_ENDPOINT))
 
   if (!message || !voice || !speed || !azureTTSKey || !azureTTSEndpoint) {
     return res.status(400).json({ error: 'Missing required parameters' })
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'azureOpenAITTS' })
+  ) {
+    return
   }
 
   try {
@@ -28,7 +39,7 @@ export default async function handler(
       url.searchParams.get('api-version') || '2024-02-15-preview'
 
     const azureOpenAI = new AzureOpenAI({
-      apiKey: apiKey,
+      apiKey: azureTTSKey,
       endpoint: azureTTSEndpoint,
       apiVersion: apiVersion,
       deployment: deploymentName,

--- a/src/pages/api/cartesia.ts
+++ b/src/pages/api/cartesia.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 type Data = {
   audio?: Buffer
@@ -13,6 +14,9 @@ export default async function handler(
   const message = body.message
   const voiceId = body.voiceId || process.env.CARTESIA_VOICE_ID
   const apiKey = body.apiKey || process.env.CARTESIA_API_KEY
+  const usesServerSecret =
+    (!body.apiKey && Boolean(process.env.CARTESIA_API_KEY)) ||
+    (!body.voiceId && Boolean(process.env.CARTESIA_VOICE_ID))
   const language = body.language
 
   if (!apiKey) {
@@ -32,6 +36,13 @@ export default async function handler(
         headers: { 'Content-Type': 'application/json' },
       }
     )
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'cartesia' })
+  ) {
+    return
   }
 
   try {

--- a/src/pages/api/difyChat.ts
+++ b/src/pages/api/difyChat.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { pipeResponse } from '@/utils/pipeResponse'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 export default async function handler(
   req: NextApiRequest,
@@ -15,6 +16,9 @@ export default async function handler(
   const { query, apiKey, url, conversationId, stream } = req.body
 
   const difyKey = apiKey || process.env.DIFY_KEY || process.env.DIFY_API_KEY
+  const usesServerSecret =
+    (!apiKey && Boolean(process.env.DIFY_KEY || process.env.DIFY_API_KEY)) ||
+    (!url && Boolean(process.env.DIFY_URL))
   if (!difyKey) {
     return res
       .status(400)
@@ -38,6 +42,13 @@ export default async function handler(
       error: 'Dify Empty URL',
       errorCode: 'AIInvalidProperty',
     })
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'difyChat' })
+  ) {
+    return
   }
 
   const headers = {

--- a/src/pages/api/elevenLabs.ts
+++ b/src/pages/api/elevenLabs.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 type Data = {
   audio?: Buffer
@@ -45,6 +46,9 @@ export default async function handler(
   const message = body.message
   const voiceId = body.voiceId || process.env.ELEVENLABS_VOICE_ID
   const apiKey = body.apiKey || process.env.ELEVENLABS_API_KEY
+  const usesServerSecret =
+    (!body.apiKey && Boolean(process.env.ELEVENLABS_API_KEY)) ||
+    (!body.voiceId && Boolean(process.env.ELEVENLABS_VOICE_ID))
   const language = body.language
 
   if (!apiKey) {
@@ -64,6 +68,13 @@ export default async function handler(
         headers: { 'Content-Type': 'application/json' },
       }
     )
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'elevenLabs' })
+  ) {
+    return
   }
 
   try {

--- a/src/pages/api/embedding.ts
+++ b/src/pages/api/embedding.ts
@@ -7,6 +7,7 @@
 
 import { NextApiRequest, NextApiResponse } from 'next'
 import OpenAI from 'openai'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 /** Embeddingモデル名 */
 const EMBEDDING_MODEL = 'text-embedding-3-small'
@@ -52,6 +53,9 @@ export default async function handler(
   // APIキーの取得（リクエスト > 環境変数の優先順位）
   const openaiKey =
     apiKey || process.env.OPENAI_EMBEDDING_KEY || process.env.OPENAI_API_KEY
+  const usesServerSecret =
+    !apiKey &&
+    Boolean(process.env.OPENAI_EMBEDDING_KEY || process.env.OPENAI_API_KEY)
 
   // APIキーの存在確認
   if (!openaiKey) {
@@ -59,6 +63,13 @@ export default async function handler(
       error: 'OpenAI API key is not configured',
       code: 'API_KEY_MISSING',
     })
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'embedding' })
+  ) {
+    return
   }
 
   try {

--- a/src/pages/api/openAITTS.ts
+++ b/src/pages/api/openAITTS.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import OpenAI from 'openai'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 // 感情表現を豊かにする追加指示を行うモデル、念の為リスト形式
 const gpt4oEmotionalInstructionModels = ['gpt-4o']
@@ -15,9 +16,18 @@ export default async function handler(
   const { message, voice, model, speed, apiKey, emotion } = req.body
   const openaiKey =
     apiKey || process.env.OPENAI_TTS_KEY || process.env.OPENAI_API_KEY
+  const usesServerSecret =
+    !apiKey && Boolean(process.env.OPENAI_TTS_KEY || process.env.OPENAI_API_KEY)
 
   if (!message || !voice || !model || !openaiKey) {
     return res.status(400).json({ error: 'Missing required parameters' })
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'openAITTS' })
+  ) {
+    return
   }
 
   try {

--- a/src/pages/api/save-chat-log.ts
+++ b/src/pages/api/save-chat-log.ts
@@ -7,6 +7,7 @@ import {
   isRestrictedMode,
   createRestrictedModeErrorResponse,
 } from '@/utils/restrictedMode'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 // Supabaseクライアントの初期化
 let supabase: SupabaseClient | null = null
@@ -29,6 +30,10 @@ export default async function handler(
     return res
       .status(403)
       .json(createRestrictedModeErrorResponse('save-chat-log'))
+  }
+
+  if (!guardServerSecretAccess(req, res, { featureName: 'save-chat-log' })) {
+    return
   }
 
   try {
@@ -65,9 +70,16 @@ export default async function handler(
 
     // ファイル名の決定: isNewFile → targetFileName → 最新ファイル → 新規作成
     const newFileName = `log_${currentTime.replace(/[:.]/g, '-')}.json`
+    const safeTargetFileName = targetFileName
+      ? getSafeLogFileName(targetFileName)
+      : null
+    if (targetFileName && !safeTargetFileName) {
+      return res.status(400).json({ message: 'Invalid targetFileName' })
+    }
+
     const fileName = isNewFile
       ? newFileName
-      : targetFileName || getLatestLogFile(logsDir) || newFileName
+      : safeTargetFileName || getLatestLogFile(logsDir) || newFileName
 
     const filePath = path.join(logsDir, fileName)
 
@@ -130,6 +142,14 @@ export default async function handler(
     console.error('Error saving chat log:', error)
     res.status(500).json({ message: 'Error saving chat log' })
   }
+}
+
+function getSafeLogFileName(fileName: string): string | null {
+  if (fileName !== path.basename(fileName)) return null
+  if (fileName.includes('/') || fileName.includes('\\')) return null
+  if (fileName === '.' || fileName === '..') return null
+  if (!fileName.endsWith('.json')) return null
+  return fileName
 }
 
 function getLatestLogFile(dir: string): string | null {

--- a/src/pages/api/save-chat-log.ts
+++ b/src/pages/api/save-chat-log.ts
@@ -45,7 +45,7 @@ export default async function handler(
     } = req.body as {
       messages: Message[]
       isNewFile?: boolean
-      targetFileName?: string | null
+      targetFileName?: unknown
       overwrite?: boolean
     }
     const currentTime = new Date().toISOString()
@@ -144,7 +144,8 @@ export default async function handler(
   }
 }
 
-function getSafeLogFileName(fileName: string): string | null {
+function getSafeLogFileName(fileName: unknown): string | null {
+  if (typeof fileName !== 'string') return null
   if (fileName !== path.basename(fileName)) return null
   if (fileName.includes('/') || fileName.includes('\\')) return null
   if (fileName === '.' || fileName === '..') return null

--- a/src/pages/api/stylebertvits2.ts
+++ b/src/pages/api/stylebertvits2.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 type Data = {
   audio?: Buffer
@@ -30,10 +31,21 @@ export default async function handler(
     body.stylebertvits2ServerUrl || process.env.STYLEBERTVITS2_SERVER_URL
   const stylebertvits2ApiKey =
     body.stylebertvits2ApiKey || process.env.STYLEBERTVITS2_API_KEY
+  const usesServerSecret =
+    (!body.stylebertvits2ServerUrl &&
+      Boolean(process.env.STYLEBERTVITS2_SERVER_URL)) ||
+    (!body.stylebertvits2ApiKey && Boolean(process.env.STYLEBERTVITS2_API_KEY))
   const stylebertvits2Style = body.stylebertvits2Style
   const stylebertvits2SdpRatio = body.stylebertvits2SdpRatio
   const stylebertvits2Length = body.stylebertvits2Length
   const selectLanguage = getLanguageCode(body.selectLanguage)
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'stylebertvits2' })
+  ) {
+    return
+  }
 
   try {
     if (!stylebertvits2ServerUrl.includes('https://api.runpod.ai')) {

--- a/src/pages/api/tts-aivis-cloud-api.ts
+++ b/src/pages/api/tts-aivis-cloud-api.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 type Data = {
   audio?: ArrayBuffer
@@ -82,8 +83,16 @@ export default async function handler(
   } = req.body
 
   const aivisCloudApiKey = apiKey || process.env.AIVIS_CLOUD_API_KEY
+  const usesServerSecret = !apiKey && Boolean(process.env.AIVIS_CLOUD_API_KEY)
   if (!aivisCloudApiKey) {
     return res.status(400).json({ error: 'API key is required' })
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'tts-aivis-cloud-api' })
+  ) {
+    return
   }
 
   if (!isValidApiKey(aivisCloudApiKey)) {

--- a/src/pages/api/tts-aivisspeech.ts
+++ b/src/pages/api/tts-aivisspeech.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 type Data = {
   audio?: ArrayBuffer
@@ -21,8 +22,28 @@ export default async function handler(
     prePhonemeLength = 0.1,
     postPhonemeLength = 0.1,
   } = req.body
+  const usesServerConfiguredUrl =
+    !serverUrl && Boolean(process.env.AIVIS_SPEECH_SERVER_URL)
   const apiUrl =
     serverUrl || process.env.AIVIS_SPEECH_SERVER_URL || 'http://localhost:10101'
+
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(apiUrl)
+  } catch {
+    return res.status(400).json({ error: 'Invalid server URL' })
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    return res.status(400).json({ error: 'Invalid server URL protocol' })
+  }
+
+  if (
+    usesServerConfiguredUrl &&
+    !guardServerSecretAccess(req, res, { featureName: 'tts-aivisspeech' })
+  ) {
+    return
+  }
 
   try {
     // 1. Audio Query の生成

--- a/src/pages/api/tts-aivisspeech.ts
+++ b/src/pages/api/tts-aivisspeech.ts
@@ -22,8 +22,7 @@ export default async function handler(
     prePhonemeLength = 0.1,
     postPhonemeLength = 0.1,
   } = req.body
-  const usesServerConfiguredUrl =
-    !serverUrl && Boolean(process.env.AIVIS_SPEECH_SERVER_URL)
+  const usesServerConfiguredUrl = !serverUrl
   const apiUrl =
     serverUrl || process.env.AIVIS_SPEECH_SERVER_URL || 'http://localhost:10101'
 

--- a/src/pages/api/tts-google.ts
+++ b/src/pages/api/tts-google.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import textToSpeech from '@google-cloud/text-to-speech'
 import { google } from '@google-cloud/text-to-speech/build/protos/protos'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 type Data = {
   audio?: string | Uint8Array // Base64 encoded string or Uint8Array
@@ -18,6 +19,10 @@ export default async function handler(
   try {
     // Check if GOOGLE_TTS_KEY exists
     if (process.env.GOOGLE_TTS_KEY) {
+      if (!guardServerSecretAccess(req, res, { featureName: 'tts-google' })) {
+        return
+      }
+
       // Use API Key based authentication
       const response = await fetch(
         `https://texttospeech.googleapis.com/v1/text:synthesize?key=${process.env.GOOGLE_TTS_KEY}`,

--- a/src/pages/api/tts-google.ts
+++ b/src/pages/api/tts-google.ts
@@ -16,13 +16,13 @@ export default async function handler(
   const ttsType = req.body.ttsType
   const languageCode = req.body.languageCode || 'ja-JP'
 
+  if (!guardServerSecretAccess(req, res, { featureName: 'tts-google' })) {
+    return
+  }
+
   try {
     // Check if GOOGLE_TTS_KEY exists
     if (process.env.GOOGLE_TTS_KEY) {
-      if (!guardServerSecretAccess(req, res, { featureName: 'tts-google' })) {
-        return
-      }
-
       // Use API Key based authentication
       const response = await fetch(
         `https://texttospeech.googleapis.com/v1/text:synthesize?key=${process.env.GOOGLE_TTS_KEY}`,

--- a/src/pages/api/tts-voicevox.ts
+++ b/src/pages/api/tts-voicevox.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 type Data = {
   audio?: ArrayBuffer
@@ -11,8 +12,28 @@ export default async function handler(
   res: NextApiResponse<Data>
 ) {
   const { text, speaker, speed, pitch, intonation, serverUrl } = req.body
+  const usesServerConfiguredUrl =
+    !serverUrl && Boolean(process.env.VOICEVOX_SERVER_URL)
   const apiUrl =
     serverUrl || process.env.VOICEVOX_SERVER_URL || 'http://localhost:50021'
+
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(apiUrl)
+  } catch {
+    return res.status(400).json({ error: 'Invalid server URL' })
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    return res.status(400).json({ error: 'Invalid server URL protocol' })
+  }
+
+  if (
+    usesServerConfiguredUrl &&
+    !guardServerSecretAccess(req, res, { featureName: 'tts-voicevox' })
+  ) {
+    return
+  }
 
   try {
     // 1. Audio Query の生成

--- a/src/pages/api/tts-voicevox.ts
+++ b/src/pages/api/tts-voicevox.ts
@@ -12,8 +12,7 @@ export default async function handler(
   res: NextApiResponse<Data>
 ) {
   const { text, speaker, speed, pitch, intonation, serverUrl } = req.body
-  const usesServerConfiguredUrl =
-    !serverUrl && Boolean(process.env.VOICEVOX_SERVER_URL)
+  const usesServerConfiguredUrl = !serverUrl
   const apiUrl =
     serverUrl || process.env.VOICEVOX_SERVER_URL || 'http://localhost:50021'
 

--- a/src/pages/api/update-aivis-speakers.ts
+++ b/src/pages/api/update-aivis-speakers.ts
@@ -5,6 +5,7 @@ import {
   isRestrictedMode,
   createRestrictedModeErrorResponse,
 } from '@/utils/restrictedMode'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 interface Style {
   name: string
@@ -31,6 +32,14 @@ export default async function handler(
     return res
       .status(403)
       .json(createRestrictedModeErrorResponse('update-aivis-speakers'))
+  }
+
+  if (
+    !guardServerSecretAccess(req, res, {
+      featureName: 'update-aivis-speakers',
+    })
+  ) {
+    return
   }
 
   try {

--- a/src/pages/api/update-aivis-speakers.ts
+++ b/src/pages/api/update-aivis-speakers.ts
@@ -28,6 +28,10 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
   if (isRestrictedMode()) {
     return res
       .status(403)

--- a/src/pages/api/update-voicevox-speakers.ts
+++ b/src/pages/api/update-voicevox-speakers.ts
@@ -5,6 +5,7 @@ import {
   isRestrictedMode,
   createRestrictedModeErrorResponse,
 } from '@/utils/restrictedMode'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 interface Style {
   name: string
@@ -31,6 +32,14 @@ export default async function handler(
     return res
       .status(403)
       .json(createRestrictedModeErrorResponse('update-voicevox-speakers'))
+  }
+
+  if (
+    !guardServerSecretAccess(req, res, {
+      featureName: 'update-voicevox-speakers',
+    })
+  ) {
+    return
   }
 
   try {

--- a/src/pages/api/update-voicevox-speakers.ts
+++ b/src/pages/api/update-voicevox-speakers.ts
@@ -28,6 +28,10 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
   if (isRestrictedMode()) {
     return res
       .status(403)

--- a/src/pages/api/whisper.ts
+++ b/src/pages/api/whisper.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import OpenAI from 'openai'
 import { Buffer } from 'buffer'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 // FormDataのパース用に設定を無効化
 export const config = {
@@ -72,9 +73,23 @@ export default async function handler(
       process.env.OPENAI_API_KEY ||
       process.env.NEXT_PUBLIC_OPENAI_API_KEY ||
       process.env.NEXT_PUBLIC_OPENAI_KEY
+    const usesServerSecret =
+      !openaiKey &&
+      Boolean(
+        process.env.OPENAI_API_KEY ||
+        process.env.NEXT_PUBLIC_OPENAI_API_KEY ||
+        process.env.NEXT_PUBLIC_OPENAI_KEY
+      )
 
     if (!apiKey) {
       return res.status(500).json({ error: 'OpenAI API key is not configured' })
+    }
+
+    if (
+      usesServerSecret &&
+      !guardServerSecretAccess(req, res, { featureName: 'whisper' })
+    ) {
+      return
     }
 
     const openai = new OpenAI({

--- a/src/pages/api/whisper.ts
+++ b/src/pages/api/whisper.ts
@@ -73,13 +73,7 @@ export default async function handler(
       process.env.OPENAI_API_KEY ||
       process.env.NEXT_PUBLIC_OPENAI_API_KEY ||
       process.env.NEXT_PUBLIC_OPENAI_KEY
-    const usesServerSecret =
-      !openaiKey &&
-      Boolean(
-        process.env.OPENAI_API_KEY ||
-        process.env.NEXT_PUBLIC_OPENAI_API_KEY ||
-        process.env.NEXT_PUBLIC_OPENAI_KEY
-      )
+    const usesServerSecret = !openaiKey && Boolean(process.env.OPENAI_API_KEY)
 
     if (!apiKey) {
       return res.status(500).json({ error: 'OpenAI API key is not configured' })

--- a/src/pages/api/youtube/continuation.ts
+++ b/src/pages/api/youtube/continuation.ts
@@ -7,6 +7,7 @@ import {
 import { createAIRegistry, getLanguageModel } from '@/lib/api-services/vercelAi'
 import { mastra } from '@/lib/mastra'
 import { RequestContext } from '@mastra/core/request-context'
+import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 export default async function handler(
   req: NextApiRequest,
@@ -41,6 +42,7 @@ export default async function handler(
 
   // APIキーの取得と検証
   let aiApiKey = apiKey
+  let usesServerSecret = false
   if (isVercelCloudAIService(aiService)) {
     if (!aiApiKey) {
       const servicePrefix = aiService.toUpperCase()
@@ -48,12 +50,20 @@ export default async function handler(
         process.env[`${servicePrefix}_KEY`] ||
         process.env[`${servicePrefix}_API_KEY`] ||
         ''
+      usesServerSecret = Boolean(aiApiKey)
     }
     if (!aiApiKey) {
       return res
         .status(400)
         .json({ error: 'Empty API Key', errorCode: 'EmptyAPIKey' })
     }
+  }
+
+  if (
+    usesServerSecret &&
+    !guardServerSecretAccess(req, res, { featureName: 'youtube/continuation' })
+  ) {
+    return
   }
 
   // ローカルLLMのURL検証
@@ -68,15 +78,22 @@ export default async function handler(
   }
 
   // Azureのエンドポイントとデプロイメント名の処理
-  let modifiedAzureEndpoint = (
-    azureEndpoint ||
-    process.env.AZURE_ENDPOINT ||
+  const azureEndpointValue = azureEndpoint || process.env.AZURE_ENDPOINT || ''
+  const usesServerAzureEndpoint =
+    !azureEndpoint && Boolean(process.env.AZURE_ENDPOINT)
+  if (
+    usesServerAzureEndpoint &&
+    !guardServerSecretAccess(req, res, { featureName: 'youtube/continuation' })
+  ) {
+    return
+  }
+
+  let modifiedAzureEndpoint = azureEndpointValue.replace(
+    /^https:\/\/|\.openai\.azure\.com.*$/g,
     ''
-  ).replace(/^https:\/\/|\.openai\.azure\.com.*$/g, '')
+  )
   const modifiedAzureDeployment =
-    (azureEndpoint || process.env.AZURE_ENDPOINT || '').match(
-      /\/deployments\/([^\/]+)/
-    )?.[1] || ''
+    azureEndpointValue.match(/\/deployments\/([^\/]+)/)?.[1] || ''
   const modifiedModel = aiService === 'azure' ? modifiedAzureDeployment : model
 
   if (aiService === 'azure' && !modifiedModel) {

--- a/src/pages/api/youtube/continuation.ts
+++ b/src/pages/api/youtube/continuation.ts
@@ -78,9 +78,14 @@ export default async function handler(
   }
 
   // Azureのエンドポイントとデプロイメント名の処理
-  const azureEndpointValue = azureEndpoint || process.env.AZURE_ENDPOINT || ''
+  const azureEndpointValue =
+    aiService === 'azure'
+      ? azureEndpoint || process.env.AZURE_ENDPOINT || ''
+      : ''
   const usesServerAzureEndpoint =
-    !azureEndpoint && Boolean(process.env.AZURE_ENDPOINT)
+    aiService === 'azure' &&
+    !azureEndpoint &&
+    Boolean(process.env.AZURE_ENDPOINT)
   if (
     usesServerAzureEndpoint &&
     !guardServerSecretAccess(req, res, { featureName: 'youtube/continuation' })


### PR DESCRIPTION
## 概要

サーバー側の秘匿キーやサーバー設定リソースを利用するAPIについて、公開デプロイ時に第三者から直接濫用されないようアクセス制御を追加しました。

- `serverSecretGuard` を追加し、`disabled` / `protected` / `demo` / `unprotected` のアクセスモードを提供
- AI / TTS / STT / Embedding / Custom API / YouTube継続 / チャットログ保存 / 話者更新系エンドポイントへガードを適用
- Custom APIストリーミングのメタデータ転送をデフォルトで抑制
- `.env.example` とREADMEに、公開運用時はAPI保護設定が必須である旨を追記

## 破壊的変更・運用上の注意

サーバー側に `OPENAI_API_KEY` などの秘匿キーを置いて公開運用する場合は、`AITUBERKIT_SERVER_SECRET_ACCESS_MODE` の設定が必須になります。

- 公開デモ用途: `AITUBERKIT_SERVER_SECRET_ACCESS_MODE=demo` と `AITUBERKIT_ALLOWED_ORIGINS` を設定
- クライアントからBearerトークンで守る用途: `AITUBERKIT_SERVER_SECRET_ACCESS_MODE=protected` と `AITUBERKIT_SERVER_SECRET_TOKEN` を設定
- ローカル/自己責任の従来互換: `AITUBERKIT_SERVER_SECRET_ACCESS_MODE=unprotected`
- 未設定または `disabled` の場合、サーバー側秘匿キー利用APIは拒否されます

詳細な移行案内は `v2.53.0` のGitHub Release Notesに記載する想定です。

## 検証

- `volta run npm test -- --runInBand src/__tests__/lib/api-services/serverSecretGuard.test.ts src/__tests__/lib/api-services/customApi.test.ts src/__tests__/pages/api/custom.test.ts src/__tests__/pages/api/vercel.test.ts src/__tests__/pages/api/embedding.test.ts src/__tests__/pages/api/openAITTS.test.ts src/__tests__/pages/api/youtube/continuation.test.ts src/__tests__/pages/api/save-chat-log.test.ts src/__tests__/pages/api/tts-voicevox.test.ts src/__tests__/pages/api/tts-aivisspeech.test.ts src/__tests__/pages/api/tts-google.test.ts src/__tests__/pages/api/update-voicevox-speakers.test.ts src/__tests__/pages/api/update-aivis-speakers.test.ts`
  - 13 suites / 74 tests passed
- `volta run npx eslint ...` on touched files
  - passed
- `volta run npm run build`
  - passed with existing unrelated warnings

## 補足

ドキュメントサイト側の更新は別リポジトリ `aituber-kit-docs` にて `e19be78 docs: API保護設定を追加（日英中）` として反映済みです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * サーバー側秘匿キーの公開API利用可否を、保護・デモ・無制限モードで設定制御。
  * デモ用トークン / 許可Origin / 簡易レート制限、プロキシ経由IP判定に対応。
  * カスタムAPI の推論・メタデータ転送を設定で制御。
* **Bug Fixes**
  * 未設定時は秘匿キー利用APIを 403 で拒否（条件により 429）。
  * 一部 TTS 等でサーバURLの検証を強化し、無効入力は適切にエラー返却。
* **Documentation**
  * セキュリティ注意事項と移行案内を各言語READMEに追記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->