### PR TITLE
Fix Cloudflare runtime secrets for aituberkit.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -212,8 +212,8 @@ NEXT_PUBLIC_CUSTOM_MODEL="false"
 # disabled: default. Allow request-provided API keys only; reject server secrets and protected server resources.
 # protected: Authorization: Bearer AITUBERKIT_SERVER_SECRET_TOKEN が必要 /
 # protected: require Authorization: Bearer AITUBERKIT_SERVER_SECRET_TOKEN.
-# demo: allowed origins / same-origin とサーバー発行demoトークンを要求（レート制限併用推奨） /
-# demo: require allowed origins / same-origin plus a server-issued demo token; pair with rate limits.
+# demo: allowed origins / same-origin を要求。AITUBERKIT_DEMO_ACCESS_TOKEN 設定時はdemoトークンも要求（レート制限併用推奨） /
+# demo: require allowed origins / same-origin. Also require a demo token when AITUBERKIT_DEMO_ACCESS_TOKEN is set; pair with rate limits.
 # unprotected: 従来互換。公開URLでは非推奨 /
 # unprotected: legacy compatibility. Not recommended for public URLs.
 AITUBERKIT_SERVER_SECRET_ACCESS_MODE="disabled"
@@ -226,8 +226,8 @@ AITUBERKIT_SERVER_SECRET_TOKEN=""
 # Comma-separated origins allowed in demo mode. When omitted, only same-host origin is allowed.
 AITUBERKIT_ALLOWED_ORIGINS=""
 
-# demoモードで X-AITuberKit-Demo-Token として要求する専用トークン /
-# Demo-only token required as X-AITuberKit-Demo-Token in demo mode.
+# demoモードで X-AITuberKit-Demo-Token として要求する任意の専用トークン /
+# Optional demo-only token required as X-AITuberKit-Demo-Token in demo mode when set.
 AITUBERKIT_DEMO_ACCESS_TOKEN=""
 
 # demoモードの簡易レート制限（IP・機能ごとの1分あたり回数、プロセス内のbest-effort。本番ではWAF等も併用） /

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -64,11 +64,42 @@ jobs:
 
       - name: Setup environment variables
         run: |
+          : > .env.local
           if [ -n "$CLOUDFLARE_ENV_FILE" ]; then
-            echo "$CLOUDFLARE_ENV_FILE" > .env.local
+            printf '%s\n' "$CLOUDFLARE_ENV_FILE" >> .env.local
           fi
+          if [ -n "$OPENAI_API_KEY" ] && ! grep -q '^OPENAI_API_KEY=' .env.local; then
+            printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" >> .env.local
+          fi
+          if ! grep -q '^AITUBERKIT_SERVER_SECRET_ACCESS_MODE=' .env.local; then
+            printf '%s\n' 'AITUBERKIT_SERVER_SECRET_ACCESS_MODE=demo' >> .env.local
+          fi
+          if ! grep -q '^AITUBERKIT_ALLOWED_ORIGINS=' .env.local; then
+            printf '%s\n' 'AITUBERKIT_ALLOWED_ORIGINS=https://aituberkit.com,https://www.aituberkit.com' >> .env.local
+          fi
+          if ! grep -q '^AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE=' .env.local; then
+            printf '%s\n' 'AITUBERKIT_DEMO_RATE_LIMIT_PER_MINUTE=20' >> .env.local
+          fi
+          if ! grep -q '^AITUBERKIT_TRUST_PROXY_HEADERS=' .env.local; then
+            printf '%s\n' 'AITUBERKIT_TRUST_PROXY_HEADERS=true' >> .env.local
+          fi
+          node <<'NODE'
+          const fs = require('fs')
+          const { parseEnv } = require('node:util')
+          const values = parseEnv(fs.readFileSync('.env.local', 'utf8'))
+          const runtimeSecrets = Object.fromEntries(
+            Object.entries(values).filter(
+              ([key, value]) => !key.startsWith('NEXT_PUBLIC_') && value !== ''
+            )
+          )
+          fs.writeFileSync(
+            '.cloudflare-runtime-secrets.json',
+            JSON.stringify(runtimeSecrets)
+          )
+          NODE
         env:
           CLOUDFLARE_ENV_FILE: ${{ secrets.CLOUDFLARE_ENV_FILE }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Build for Cloudflare
         run: npm run build:cloudflare
@@ -79,4 +110,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+          command: deploy --secrets-file .cloudflare-runtime-secrets.json

--- a/src/__tests__/lib/api-services/serverSecretGuard.test.ts
+++ b/src/__tests__/lib/api-services/serverSecretGuard.test.ts
@@ -76,7 +76,27 @@ describe('serverSecretGuard', () => {
     )
   })
 
-  it('allows demo mode only for same-origin requests with a demo token', () => {
+  it('allows demo mode for same-origin requests without a demo token when no token is configured', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    delete process.env.AITUBERKIT_DEMO_ACCESS_TOKEN
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        host: 'aituberkit.example',
+        origin: 'https://aituberkit.example',
+        'sec-fetch-site': 'same-origin',
+      },
+    })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(true)
+    expect(res._getStatusCode()).toBe(200)
+  })
+
+  it('allows demo mode for same-origin requests with a configured demo token', () => {
     process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
     process.env.AITUBERKIT_DEMO_ACCESS_TOKEN = 'demo-token'
     const { req, res } = createMocks({
@@ -138,10 +158,10 @@ describe('serverSecretGuard', () => {
     expect(res._getStatusCode()).toBe(403)
   })
 
-  it('does not accept the protected bearer token as a demo token fallback', () => {
+  it('does not accept the protected bearer token as a configured demo token fallback', () => {
     process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
     process.env.AITUBERKIT_SERVER_SECRET_TOKEN = 'server-secret-token'
-    delete process.env.AITUBERKIT_DEMO_ACCESS_TOKEN
+    process.env.AITUBERKIT_DEMO_ACCESS_TOKEN = 'demo-token'
     const { req, res } = createMocks({
       method: 'POST',
       headers: {

--- a/src/lib/api-services/serverSecretGuard.ts
+++ b/src/lib/api-services/serverSecretGuard.ts
@@ -104,7 +104,7 @@ function hasValidBearerToken(req: NextApiRequest): boolean {
 
 function hasValidDemoToken(req: NextApiRequest): boolean {
   const expectedToken = process.env.AITUBERKIT_DEMO_ACCESS_TOKEN
-  if (!expectedToken) return false
+  if (!expectedToken) return true
 
   const token = getHeaderValue(req, 'x-aituberkit-demo-token')
   return safeCompare(token, expectedToken)
@@ -237,7 +237,7 @@ export function guardServerSecretAccess(
     rejectServerSecretAccess(
       res,
       options,
-      'Server-side secret settings in demo mode require an allowed same-origin request with a valid demo token.'
+      'Server-side secret settings in demo mode require an allowed same-origin request and, when configured, a valid demo token.'
     )
     return false
   }


### PR DESCRIPTION
## 概要
- Cloudflare deploy でサーバー側環境変数を Worker の runtime secrets として渡すように修正
- aituberkit.com 向けに demo モードの既定値、許可 Origin、レート制限、信頼済みプロキシ設定を補完
- demo トークンは設定時のみ必須にし、公式サイトの同一オリジン利用を通せるように調整

## 検証
- npm test -- src/__tests__/lib/api-services/serverSecretGuard.test.ts --runInBand
- npm run lint -- --quiet
- npm run build:cloudflare
- docs: npm run docs:build