### PR TITLE
Fix OpenAI TTS on Cloudflare

### DIFF
--- a/src/__tests__/pages/api/openAITTS.test.ts
+++ b/src/__tests__/pages/api/openAITTS.test.ts
@@ -2,19 +2,10 @@
  * @jest-environment node
  */
 
-const mockSpeechCreate = jest.fn()
-jest.mock('openai', () => {
-  return jest.fn().mockImplementation(() => ({
-    audio: {
-      speech: {
-        create: mockSpeechCreate,
-      },
-    },
-  }))
-})
-
 import type { NextApiRequest, NextApiResponse } from 'next'
 import handler from '@/pages/api/openAITTS'
+
+const originalFetch = global.fetch
 
 function createMockReq(
   overrides: Partial<NextApiRequest> = {}
@@ -60,6 +51,11 @@ function createMockRes() {
 describe('/api/openAITTS', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    global.fetch = jest.fn()
+  })
+
+  afterAll(() => {
+    global.fetch = originalFetch
   })
 
   it('should return 405 for non-POST methods', async () => {
@@ -127,9 +123,12 @@ describe('/api/openAITTS', () => {
 
   it('should return audio buffer on success', async () => {
     const fakeBuffer = Buffer.from('fake-audio')
-    mockSpeechCreate.mockResolvedValue({
-      arrayBuffer: () => Promise.resolve(fakeBuffer),
-    })
+    ;(global.fetch as jest.Mock).mockResolvedValue(
+      new Response(fakeBuffer, {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      })
+    )
 
     const req = createMockReq({
       body: {
@@ -150,9 +149,12 @@ describe('/api/openAITTS', () => {
 
   it('should add emotional instructions for gpt-4o model', async () => {
     const fakeBuffer = Buffer.from('audio')
-    mockSpeechCreate.mockResolvedValue({
-      arrayBuffer: () => Promise.resolve(fakeBuffer),
-    })
+    ;(global.fetch as jest.Mock).mockResolvedValue(
+      new Response(fakeBuffer, {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      })
+    )
 
     const req = createMockReq({
       body: {
@@ -167,15 +169,20 @@ describe('/api/openAITTS', () => {
 
     await handler(req, res)
 
-    const callArgs = mockSpeechCreate.mock.calls[0][0]
+    const callArgs = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body
+    )
     expect(callArgs.instructions).toContain('rich emotional expression')
   })
 
   it('should not add instructions for non-gpt-4o models', async () => {
     const fakeBuffer = Buffer.from('audio')
-    mockSpeechCreate.mockResolvedValue({
-      arrayBuffer: () => Promise.resolve(fakeBuffer),
-    })
+    ;(global.fetch as jest.Mock).mockResolvedValue(
+      new Response(fakeBuffer, {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      })
+    )
 
     const req = createMockReq({
       body: {
@@ -190,13 +197,22 @@ describe('/api/openAITTS', () => {
 
     await handler(req, res)
 
-    const callArgs = mockSpeechCreate.mock.calls[0][0]
+    const callArgs = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body
+    )
     expect(callArgs.instructions).toBeUndefined()
   })
 
   it('should return 500 on OpenAI API error', async () => {
-    mockSpeechCreate.mockRejectedValue(new Error('API error'))
-    jest.spyOn(console, 'error').mockImplementation(() => {})
+    ;(global.fetch as jest.Mock).mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'API error' } }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
 
     const req = createMockReq({
       body: {
@@ -212,6 +228,11 @@ describe('/api/openAITTS', () => {
     await handler(req, res)
 
     expect(res._status).toBe(500)
-    expect(res._json).toEqual({ error: 'Failed to generate speech' })
+    expect(res._json).toEqual({
+      error: 'Failed to generate speech',
+      errorCode: 'OpenAITTSUpstreamError',
+      status: 401,
+    })
+    consoleErrorSpy.mockRestore()
   })
 })

--- a/src/pages/api/openAITTS.ts
+++ b/src/pages/api/openAITTS.ts
@@ -1,5 +1,4 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import OpenAI from 'openai'
 import { guardServerSecretAccess } from '@/lib/api-services/serverSecretGuard'
 
 // 感情表現を豊かにする追加指示を行うモデル、念の為リスト形式
@@ -31,14 +30,7 @@ export default async function handler(
   }
 
   try {
-    const openai = new OpenAI({ apiKey: openaiKey })
-    const options: {
-      model: any
-      voice: any
-      speed: any
-      input: any
-      instructions?: any
-    } = {
+    const options: Record<string, unknown> = {
       model: model,
       voice: voice,
       speed: speed,
@@ -49,11 +41,37 @@ export default async function handler(
       options.instructions = `Please speak "${message}" with rich emotional expression.`
     }
 
-    const mp3 = await openai.audio.speech.create(options)
+    const speechResponse = await fetch(
+      'https://api.openai.com/v1/audio/speech',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${openaiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(options),
+      }
+    )
 
-    const buffer = Buffer.from(await mp3.arrayBuffer())
+    if (!speechResponse.ok) {
+      const errorText = await speechResponse.text()
+      console.error('OpenAI TTS upstream error:', {
+        status: speechResponse.status,
+        body: errorText,
+      })
+      return res.status(500).json({
+        error: 'Failed to generate speech',
+        errorCode: 'OpenAITTSUpstreamError',
+        status: speechResponse.status,
+      })
+    }
 
-    res.setHeader('Content-Type', 'audio/mpeg')
+    const buffer = Buffer.from(await speechResponse.arrayBuffer())
+
+    res.setHeader(
+      'Content-Type',
+      speechResponse.headers.get('content-type') || 'audio/mpeg'
+    )
     res.send(buffer)
   } catch (error) {
     console.error('OpenAI TTS error:', error)


### PR DESCRIPTION
## 概要
- `/api/openAITTS` を OpenAI SDK 経由から Speech API への direct fetch に変更
- Cloudflare Workers 上で音声バイナリをそのまま返せるように調整
- 上流エラー時に `OpenAITTSUpstreamError` とステータスを返すように変更

## 検証
- npm run lint -- --quiet
- npm test -- src/__tests__/lib/api-services/serverSecretGuard.test.ts --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 音声生成の処理を改善し、TTSのレスポンスをより安定して返せるようになりました。  
  * 失敗時に上流エラー本文を読み取り、明確な `errorCode` を含むJSONとともにエラー情報を返すようになりました。  
  * 音声レスポンスの `Content-Type` を上流の値に合わせ、取得できない場合は既定値で返すようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->