### PR TITLE
Expose OpenAI TTS runtime error

### DIFF
--- a/src/pages/api/openAITTS.ts
+++ b/src/pages/api/openAITTS.ts
@@ -75,6 +75,10 @@ export default async function handler(
     res.send(buffer)
   } catch (error) {
     console.error('OpenAI TTS error:', error)
-    res.status(500).json({ error: 'Failed to generate speech' })
+    res.status(500).json({
+      error: 'Failed to generate speech',
+      errorCode: 'OpenAITTSError',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    })
   }
 }


### PR DESCRIPTION
## 概要
- `/api/openAITTS` の catch 側で `OpenAITTSError` と安全なエラーメッセージを返す
- aituberkit.com 上のTTS 500原因を特定するための診断用修正

## 検証
- npm test -- src/__tests__/pages/api/openAITTS.test.ts --runInBand
- npm run lint -- --quiet