### PR TITLE
Keep OpenAI TTS catch response generic

### DIFF
--- a/src/pages/api/openAITTS.ts
+++ b/src/pages/api/openAITTS.ts
@@ -75,10 +75,6 @@ export default async function handler(
     res.send(buffer)
   } catch (error) {
     console.error('OpenAI TTS error:', error)
-    res.status(500).json({
-      error: 'Failed to generate speech',
-      errorCode: 'OpenAITTSError',
-      message: error instanceof Error ? error.message : 'Unknown error',
-    })
+    res.status(500).json({ error: 'Failed to generate speech' })
   }
 }


### PR DESCRIPTION
## 概要
- 診断用に一時追加した `/api/openAITTS` catch 側の詳細エラー返却を generic response に戻す
- OpenAI Speech API の direct fetch 実装は維持

## 検証
- npm test -- src/__tests__/pages/api/openAITTS.test.ts --runInBand
- npm run lint -- --quiet
- live: `tts-1` / `alloy` で `audio/mpeg` を確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 音声生成に失敗した際のエラーレスポンスを簡素化し、不要な詳細情報を返さないようにしました。
  * 失敗時は統一されたメッセージで応答するため、エラー表示がより一貫します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->