### PR TITLE
Normalize escaped Custom API env JSON

### DIFF
--- a/scripts/normalize-cloudflare-env.js
+++ b/scripts/normalize-cloudflare-env.js
@@ -115,16 +115,33 @@ function parseHeaderLines(value) {
 function normalizeJsonEnvValue(key, value) {
   if (!value) return value
 
+  const jsonValue = parseJsonValue(value)
+  if (jsonValue !== undefined) return jsonValue
+
+  const unescapedValue = value.replace(/\\"/g, '"')
+  if (unescapedValue !== value) {
+    const unescapedJsonValue = parseJsonValue(unescapedValue)
+    if (unescapedJsonValue !== undefined) return unescapedJsonValue
+  }
+
+  if (!HEADER_ENV_KEYS.has(key)) return value
+
+  const headers = parseHeaderLines(value)
+  if (headers === undefined) return value
+
+  return JSON.stringify(headers)
+}
+
+function parseJsonValue(value) {
   try {
-    JSON.parse(value)
+    const parsed = JSON.parse(value)
+    if (typeof parsed === 'string') {
+      JSON.parse(parsed)
+      return parsed
+    }
     return value
   } catch (error) {
-    if (!HEADER_ENV_KEYS.has(key)) return value
-
-    const headers = parseHeaderLines(value)
-    if (headers === undefined) return value
-
-    return JSON.stringify(headers)
+    return undefined
   }
 }
 


### PR DESCRIPTION
## 概要
- Cloudflare secret に入る CUSTOM_API_HEADERS / CUSTOM_API_BODY が \" を含むエスケープ済み JSON の場合も通常 JSON に正規化
- Authorization: Bearer ... のようなヘッダー行形式と複数行 JSON のサポートは維持

## 背景
PR #546 反映後、InvalidJSON は解消したが、本番 /api/ai/custom で Invalid header name. が返ったため。CUSTOM_API_HEADERS のキーにエスケープ残りが入るケースを追加で吸収します。

## 確認
- エスケープ済み CUSTOM_API_HEADERS / CUSTOM_API_BODY のローカル正規化確認
- node --check scripts/normalize-cloudflare-env.js
- npm run lint -- --quiet
- git diff --check