### PR TITLE
Canonicalize Custom API header env

### DIFF
--- a/scripts/normalize-cloudflare-env.js
+++ b/scripts/normalize-cloudflare-env.js
@@ -115,12 +115,12 @@ function parseHeaderLines(value) {
 function normalizeJsonEnvValue(key, value) {
   if (!value) return value
 
-  const jsonValue = parseJsonValue(value)
+  const jsonValue = parseJsonValue(key, value)
   if (jsonValue !== undefined) return jsonValue
 
-  const unescapedValue = value.replace(/\\"/g, '"')
+  const unescapedValue = value.replace(/\\+"/g, '"')
   if (unescapedValue !== value) {
-    const unescapedJsonValue = parseJsonValue(unescapedValue)
+    const unescapedJsonValue = parseJsonValue(key, unescapedValue)
     if (unescapedJsonValue !== undefined) return unescapedJsonValue
   }
 
@@ -132,17 +132,59 @@ function normalizeJsonEnvValue(key, value) {
   return JSON.stringify(headers)
 }
 
-function parseJsonValue(value) {
+function parseJsonValue(key, value) {
   try {
     const parsed = JSON.parse(value)
     if (typeof parsed === 'string') {
-      JSON.parse(parsed)
-      return parsed
+      return parseJsonValue(key, parsed)
     }
-    return value
+    if (HEADER_ENV_KEYS.has(key)) {
+      const headers = normalizeHeaderObject(parsed)
+      if (headers === undefined) return undefined
+      return JSON.stringify(headers)
+    }
+    return JSON.stringify(parsed)
   } catch (error) {
     return undefined
   }
+}
+
+function normalizeHeaderObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+
+  const headers = {}
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    const key = normalizeHeaderName(rawKey)
+    if (!isValidHeaderName(key)) return undefined
+
+    headers[key] = normalizeHeaderValue(rawValue)
+  }
+
+  return headers
+}
+
+function normalizeHeaderName(value) {
+  return String(value)
+    .trim()
+    .replace(/\\+"/g, '"')
+    .replace(/^[{\\'"]+/, '')
+    .replace(/[}\\'"]+$/, '')
+    .trim()
+}
+
+function normalizeHeaderValue(value) {
+  return String(value)
+    .trim()
+    .replace(/\\+"/g, '"')
+    .replace(/^[\\'"]+/, '')
+    .replace(/[\\'"]+$/, '')
+    .trim()
+}
+
+function isValidHeaderName(value) {
+  return /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(value)
 }
 
 function validateJsonEnv(values) {


### PR DESCRIPTION
## 概要
- CUSTOM_API_HEADERS / NEXT_PUBLIC_CUSTOM_API_HEADERS の JSON オブジェクトを canonicalize
- ヘッダー名・値に引用符やバックスラッシュが残るケースを正規化
- 不正なヘッダー名は deploy 時に検出

## 背景
PR #547 反映後も本番 /api/ai/custom で Invalid header name. が返ったため、JSON として成立しているがヘッダー名に引用符が残るケースを追加で吸収します。

## 確認
- 引用符込み Authorization キーのローカル正規化確認
- node --check scripts/normalize-cloudflare-env.js
- npm run lint -- --quiet
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 環境変数に含まれる JSON の解釈がより安定し、二重にエスケープされた文字列や不正な形式を正しく扱えるようになりました。
  * ヘッダー形式の値について、名前や値の整形・検証が強化され、設定のばらつきによる不具合を減らしました。
  * JSON の解析に失敗した場合は、従来どおり安全に未処理として扱います。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->