### PR TITLE
Normalize Custom API headers at runtime

### DIFF
--- a/src/__tests__/lib/api-services/customApi.test.ts
+++ b/src/__tests__/lib/api-services/customApi.test.ts
@@ -151,4 +151,26 @@ describe('handleCustomApi', () => {
     expect(text).toContain('visible payload reasoning')
     expect(text).toContain('response-id')
   })
+
+  it('normalizes quoted custom API header names and values before fetch', async () => {
+    const fetchMock = global.fetch as jest.Mock
+    fetchMock.mockResolvedValue(createStreamResponse('data: [DONE]\n\n'))
+
+    await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://example.com/custom',
+      '{"\\"Authorization\\"":"\\"Bearer token\\""}',
+      '{}',
+      true
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/custom',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token',
+        }),
+      })
+    )
+  })
 })

--- a/src/lib/api-services/customApi.ts
+++ b/src/lib/api-services/customApi.ts
@@ -50,6 +50,45 @@ function processMessagesWithMimeType(messages: Message[]): any[] {
   })
 }
 
+const VALID_HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/
+
+function normalizeHeaderName(value: string): string {
+  return value
+    .trim()
+    .replace(/\\+"/g, '"')
+    .replace(/^[{\\'"]+/, '')
+    .replace(/[}\\'"]+$/, '')
+    .trim()
+}
+
+function normalizeHeaderValue(value: unknown): string {
+  return String(value)
+    .trim()
+    .replace(/\\+"/g, '"')
+    .replace(/^[\\'"]+/, '')
+    .replace(/[\\'"]+$/, '')
+    .trim()
+}
+
+function normalizeParsedHeaders(headers: unknown): Record<string, string> {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    return {}
+  }
+
+  const normalized: Record<string, string> = {}
+  for (const [rawKey, rawValue] of Object.entries(headers)) {
+    const headerName = normalizeHeaderName(rawKey)
+    if (!VALID_HEADER_NAME.test(headerName)) {
+      console.warn('Skipping invalid Custom API header name')
+      continue
+    }
+
+    normalized[headerName] = normalizeHeaderValue(rawValue)
+  }
+
+  return normalized
+}
+
 /**
  * カスタムAPIを使用して応答を取得する
  * @param messages メッセージ
@@ -74,7 +113,7 @@ export async function handleCustomApi(
   let parsedBody: Record<string, any> = {}
 
   try {
-    parsedHeaders = JSON.parse(customApiHeaders)
+    parsedHeaders = normalizeParsedHeaders(JSON.parse(customApiHeaders))
     parsedBody = JSON.parse(customApiBody)
   } catch (error) {
     return new Response(


### PR DESCRIPTION
## 概要
- Custom API 呼び出し時にヘッダー名・値を runtime でも正規化
- 引用符やバックスラッシュが残った Authorization キーを通常の Authorization ヘッダーへ修復
- 修復できない不正ヘッダー名は送信せず、fetch の Invalid header name を防止

## 背景
本番 /api/ai/custom で Invalid header name. が継続したため、デプロイ時の env 正規化だけでなく API 実行時にも防御します。

## 確認
- npm run lint -- --quiet
- git diff --check
- ローカル Jest は resolver validation で起動不可: Module <rootDir>/jest.resolver.js in the resolver option was not found
- CI で追加テストを確認予定