### PR TITLE
Expand env references for Cloudflare runtime secrets

### DIFF
--- a/scripts/normalize-cloudflare-env.js
+++ b/scripts/normalize-cloudflare-env.js
@@ -85,7 +85,27 @@ function normalizeValues(raw) {
     if (value !== undefined) values[key] = normalizeJsonEnvValue(key, value)
   }
 
+  expandEnvReferences(values)
+
   return values
+}
+
+function expandEnvReferences(values) {
+  const envReferencePattern = /\$\{([A-Z0-9_]+)\}|\$([A-Z0-9_]+)/g
+
+  for (const [key, value] of Object.entries(values)) {
+    if (typeof value !== 'string' || !value.includes('$')) continue
+
+    values[key] = value.replace(
+      envReferencePattern,
+      (match, bracedKey, bareKey) => {
+        const envKey = bracedKey || bareKey
+        return Object.prototype.hasOwnProperty.call(values, envKey)
+          ? values[envKey]
+          : match
+      }
+    )
+  }
 }
 
 function parseHeaderLines(value) {


### PR DESCRIPTION
## 概要
- Cloudflare runtime secrets 生成時に `$VAR` / `${VAR}` を同じ env 値から展開
- CUSTOM_API_HEADERS 内の `Bearer ${OPENAI_API_KEY}` のような参照を実値へ変換

## 背景
本番 /api/ai/custom で Invalid header name は解消したが、upstream 401 が残ったため。CUSTOM_API_HEADERS の Authorization 値に env 参照が残っている可能性を吸収します。

## 確認
- `${OPENAI_API_KEY}` を含む CUSTOM_API_HEADERS のローカル正規化確認
- node --check scripts/normalize-cloudflare-env.js
- npm run lint -- --quiet
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 環境変数の値内にある参照を自動展開するようになりました。
  * `$KEY` や `${KEY}` 形式の参照が同じ設定内に存在する場合、対応する値に置き換えられます。
  * 参照先が見つからない場合は、元の文字列をそのまま保持します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->