### PR TITLE
Provide Anthropic key to Cloudflare env

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -74,6 +74,9 @@ jobs:
           if [ -n "$OPENAI_API_KEY" ] && ! grep -q '^OPENAI_API_KEY=' .env.local; then
             printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" >> .env.local
           fi
+          if [ -n "$ANTHROPIC_API_KEY" ] && ! grep -q '^ANTHROPIC_API_KEY=' .env.local; then
+            printf 'ANTHROPIC_API_KEY=%s\n' "$ANTHROPIC_API_KEY" >> .env.local
+          fi
           if ! grep -q '^AITUBERKIT_SERVER_SECRET_ACCESS_MODE=' .env.local; then
             printf '%s\n' 'AITUBERKIT_SERVER_SECRET_ACCESS_MODE=demo' >> .env.local
           fi
@@ -91,6 +94,7 @@ jobs:
           CLOUDFLARE_ENV_FILE: ${{ secrets.CLOUDFLARE_ENV_FILE }}
           CLOUDFLARE_PUBLIC_ENV_APPEND: ${{ secrets.CLOUDFLARE_PUBLIC_ENV_APPEND }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Build for Cloudflare
         run: npm run build:cloudflare

--- a/scripts/normalize-cloudflare-env.js
+++ b/scripts/normalize-cloudflare-env.js
@@ -80,32 +80,66 @@ function readPossiblyMultilineJsonValue(raw, key) {
 function normalizeValues(raw) {
   const values = parseEnv(raw)
 
+  expandEnvReferences(values, JSON_ENV_KEYS)
+
   for (const key of JSON_ENV_KEYS) {
     const value = readPossiblyMultilineJsonValue(raw, key)
-    if (value !== undefined) values[key] = normalizeJsonEnvValue(key, value)
+    if (value !== undefined) {
+      values[key] = normalizeJsonEnvValue(key, value, values)
+    }
   }
-
-  expandEnvReferences(values)
 
   return values
 }
 
-function expandEnvReferences(values) {
-  const envReferencePattern = /\$\{([A-Z0-9_]+)\}|\$([A-Z0-9_]+)/g
-
+function expandEnvReferences(values, skippedKeys = new Set()) {
   for (const [key, value] of Object.entries(values)) {
-    if (typeof value !== 'string' || !value.includes('$')) continue
+    if (skippedKeys.has(key)) continue
+    values[key] = expandEnvReferencesInValue(value, values)
+  }
+}
 
-    values[key] = value.replace(
-      envReferencePattern,
-      (match, bracedKey, bareKey) => {
-        const envKey = bracedKey || bareKey
-        return Object.prototype.hasOwnProperty.call(values, envKey)
-          ? values[envKey]
-          : match
-      }
+function expandEnvReferencesInValue(value, values) {
+  if (typeof value === 'string') {
+    return expandStringEnvReferences(value, values)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => expandEnvReferencesInValue(item, values))
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        expandEnvReferencesInValue(item, values),
+      ])
     )
   }
+
+  return value
+}
+
+function expandStringEnvReferences(value, values) {
+  if (!value.includes('$')) return value
+
+  const envReferencePattern = /\$\{([A-Z0-9_]+)\}|\$([A-Z0-9_]+)/g
+
+  return value.replace(envReferencePattern, (match, bracedKey, bareKey) => {
+    const envKey = bracedKey || bareKey
+    if (!Object.prototype.hasOwnProperty.call(values, envKey)) return match
+
+    const replacement = getEnvReferenceReplacement(values[envKey])
+    return replacement === undefined ? match : replacement
+  })
+}
+
+function getEnvReferenceReplacement(value) {
+  if (['string', 'number', 'boolean', 'bigint'].includes(typeof value)) {
+    return String(value)
+  }
+
+  return undefined
 }
 
 function parseHeaderLines(value) {
@@ -132,15 +166,19 @@ function parseHeaderLines(value) {
   return headers
 }
 
-function normalizeJsonEnvValue(key, value) {
+function normalizeJsonEnvValue(key, value, referenceValues = {}) {
   if (!value) return value
 
-  const jsonValue = parseJsonValue(key, value)
+  const jsonValue = parseJsonValue(key, value, referenceValues)
   if (jsonValue !== undefined) return jsonValue
 
   const unescapedValue = value.replace(/\\+"/g, '"')
   if (unescapedValue !== value) {
-    const unescapedJsonValue = parseJsonValue(key, unescapedValue)
+    const unescapedJsonValue = parseJsonValue(
+      key,
+      unescapedValue,
+      referenceValues
+    )
     if (unescapedJsonValue !== undefined) return unescapedJsonValue
   }
 
@@ -149,21 +187,30 @@ function normalizeJsonEnvValue(key, value) {
   const headers = parseHeaderLines(value)
   if (headers === undefined) return value
 
-  return JSON.stringify(headers)
+  const expandedHeaders = expandEnvReferencesInValue(headers, referenceValues)
+  const normalizedHeaders = normalizeHeaderObject(expandedHeaders)
+  return normalizedHeaders === undefined
+    ? value
+    : JSON.stringify(normalizedHeaders)
 }
 
-function parseJsonValue(key, value) {
+function parseJsonValue(key, value, referenceValues) {
   try {
     const parsed = JSON.parse(value)
     if (typeof parsed === 'string') {
-      return parseJsonValue(key, parsed)
+      return parseJsonValue(
+        key,
+        expandStringEnvReferences(parsed, referenceValues),
+        referenceValues
+      )
     }
+    const expandedValue = expandEnvReferencesInValue(parsed, referenceValues)
     if (HEADER_ENV_KEYS.has(key)) {
-      const headers = normalizeHeaderObject(parsed)
+      const headers = normalizeHeaderObject(expandedValue)
       if (headers === undefined) return undefined
       return JSON.stringify(headers)
     }
-    return JSON.stringify(parsed)
+    return JSON.stringify(expandedValue)
   } catch (error) {
     return undefined
   }

--- a/src/__tests__/scripts/normalizeCloudflareEnv.test.ts
+++ b/src/__tests__/scripts/normalizeCloudflareEnv.test.ts
@@ -1,0 +1,40 @@
+const {
+  normalizeValues,
+  validateJsonEnv,
+} = require('../../../scripts/normalize-cloudflare-env.js')
+
+describe('normalize-cloudflare-env', () => {
+  it('expands references inside JSON env values before stringifying them', () => {
+    const values = normalizeValues(
+      [
+        'ANTHROPIC_API_KEY=sk-ant-test-"quoted"\\value',
+        'CUSTOM_API_HEADERS={',
+        '  "Authorization": "Bearer $ANTHROPIC_API_KEY",',
+        '  "anthropic-version": "2023-06-01"',
+        '}',
+      ].join('\n')
+    )
+
+    validateJsonEnv(values)
+
+    expect(JSON.parse(values.CUSTOM_API_HEADERS)).toEqual({
+      Authorization: 'Bearer sk-ant-test-"quoted"\\value',
+      'anthropic-version': '2023-06-01',
+    })
+  })
+
+  it('escapes referenced JSON-like strings inside JSON env values', () => {
+    const values = normalizeValues(
+      [
+        'CUSTOM_API_BODY={"model":"claude-sonnet-4-5","nested":{"id":"abc"}}',
+        'CUSTOM_API_HEADERS={"x-debug":"$CUSTOM_API_BODY"}',
+      ].join('\n')
+    )
+
+    validateJsonEnv(values)
+
+    expect(JSON.parse(values.CUSTOM_API_HEADERS)).toEqual({
+      'x-debug': '{"model":"claude-sonnet-4-5","nested":{"id":"abc"}}',
+    })
+  })
+})


### PR DESCRIPTION
## 概要
- Cloudflare デプロイ時に ANTHROPIC_API_KEY も .env.local へ補完
- normalize-cloudflare-env.js の `$VAR` / `${VAR}` 展開で CUSTOM_API_HEADERS 内の参照に使えるようにする

## 背景
本番 /api/ai/custom は JSON/ヘッダー形式エラーを解消後、upstream 401 になっているため。repo secrets に ANTHROPIC_API_KEY があり、CUSTOM_API_HEADERS がこれを参照している可能性を吸収します。

## 確認
- git diff --check