### PR TITLE
Override Cloudflare API key env secrets

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -71,12 +71,19 @@ jobs:
           if [ -n "$CLOUDFLARE_PUBLIC_ENV_APPEND" ]; then
             printf '\n%s\n' "$CLOUDFLARE_PUBLIC_ENV_APPEND" >> .env.local
           fi
-          if [ -n "$OPENAI_API_KEY" ] && ! grep -q '^OPENAI_API_KEY=' .env.local; then
-            printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" >> .env.local
-          fi
-          if [ -n "$ANTHROPIC_API_KEY" ] && ! grep -q '^ANTHROPIC_API_KEY=' .env.local; then
-            printf 'ANTHROPIC_API_KEY=%s\n' "$ANTHROPIC_API_KEY" >> .env.local
-          fi
+          upsert_env_secret() {
+            key="$1"
+            value="$2"
+            if [ -z "$value" ]; then
+              return
+            fi
+            tmp_file="$(mktemp)"
+            grep -v "^${key}=" .env.local > "$tmp_file" || true
+            mv "$tmp_file" .env.local
+            printf '%s=%s\n' "$key" "$value" >> .env.local
+          }
+          upsert_env_secret OPENAI_API_KEY "$OPENAI_API_KEY"
+          upsert_env_secret ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY"
           if ! grep -q '^AITUBERKIT_SERVER_SECRET_ACCESS_MODE=' .env.local; then
             printf '%s\n' 'AITUBERKIT_SERVER_SECRET_ACCESS_MODE=demo' >> .env.local
           fi

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -74,12 +74,12 @@ jobs:
           upsert_env_secret() {
             key="$1"
             value="$2"
-            if [ -z "$value" ]; then
-              return
-            fi
             tmp_file="$(mktemp)"
             grep -v "^${key}=" .env.local > "$tmp_file" || true
             mv "$tmp_file" .env.local
+            if [ -z "$value" ]; then
+              return
+            fi
             printf '%s=%s\n' "$key" "$value" >> .env.local
           }
           upsert_env_secret OPENAI_API_KEY "$OPENAI_API_KEY"


### PR DESCRIPTION
## Summary
- overwrite OPENAI_API_KEY and ANTHROPIC_API_KEY in .env.local from dedicated GitHub secrets during Cloudflare deploy
- prevents stale or placeholder key lines in CLOUDFLARE_ENV_FILE from being used by Custom API header expansion

## Verification
- git diff --check
- shell simulation confirmed existing empty/stale API key lines are replaced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloudflare デプロイ時の環境設定生成で、`OPENAI_API_KEY` と `ANTHROPIC_API_KEY` が既存の設定を上書きできるようになりました。
  * すでに `.env.local` に同名キーがある場合でも、新しい値が反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->