### PR TITLE
Retry Anthropic Custom API auth header

### DIFF
--- a/src/__tests__/lib/api-services/customApi.test.ts
+++ b/src/__tests__/lib/api-services/customApi.test.ts
@@ -173,4 +173,44 @@ describe('handleCustomApi', () => {
       })
     )
   })
+
+  it('retries Anthropic custom API requests with x-api-key after bearer auth fails', async () => {
+    process.env.ANTHROPIC_API_KEY = 'anthropic-secret'
+    const fetchMock = global.fetch as jest.Mock
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { type: 'authentication_error' } }),
+          {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+      .mockResolvedValueOnce(createStreamResponse('data: [DONE]\n\n'))
+
+    const response = await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://api.anthropic.com/v1/messages',
+      '{"Authorization":"Bearer stale"}',
+      '{"model":"claude-sonnet-4-5","max_tokens":128}',
+      true
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-api-key': 'anthropic-secret',
+          'anthropic-version': '2023-06-01',
+        }),
+      })
+    )
+    expect(fetchMock.mock.calls[1][1].headers).not.toHaveProperty(
+      'Authorization'
+    )
+  })
 })

--- a/src/lib/api-services/customApi.ts
+++ b/src/lib/api-services/customApi.ts
@@ -89,6 +89,42 @@ function normalizeParsedHeaders(headers: unknown): Record<string, string> {
   return normalized
 }
 
+function isAnthropicApiUrl(customApiUrl: string): boolean {
+  try {
+    return new URL(customApiUrl).hostname === 'api.anthropic.com'
+  } catch (error) {
+    return false
+  }
+}
+
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const lowerName = name.toLowerCase()
+  return Object.keys(headers).some((key) => key.toLowerCase() === lowerName)
+}
+
+function removeHeader(headers: Record<string, string>, name: string) {
+  const lowerName = name.toLowerCase()
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lowerName) {
+      delete headers[key]
+    }
+  }
+}
+
+function buildAnthropicRetryHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const retryHeaders = { ...headers }
+  removeHeader(retryHeaders, 'authorization')
+  retryHeaders['x-api-key'] = process.env.ANTHROPIC_API_KEY || ''
+
+  if (!hasHeader(retryHeaders, 'anthropic-version')) {
+    retryHeaders['anthropic-version'] = '2023-06-01'
+  }
+
+  return retryHeaders
+}
+
 /**
  * カスタムAPIを使用して応答を取得する
  * @param messages メッセージ
@@ -144,12 +180,27 @@ export async function handleCustomApi(
     messages: processedMessages,
   })
 
-  const apiResponse = await fetch(customApiUrl, {
+  const requestInit = {
     method: 'POST',
     headers: apiHeaders,
     body: apiBody,
     signal: AbortSignal.timeout(180000), // 3分でタイムアウト
-  })
+  }
+
+  let apiResponse = await fetch(customApiUrl, requestInit)
+
+  if (
+    apiResponse.status === 401 &&
+    isAnthropicApiUrl(customApiUrl) &&
+    process.env.ANTHROPIC_API_KEY &&
+    !hasHeader(parsedHeaders, 'x-api-key')
+  ) {
+    console.warn('Retrying Custom API request with Anthropic x-api-key header')
+    apiResponse = await fetch(customApiUrl, {
+      ...requestInit,
+      headers: buildAnthropicRetryHeaders(apiHeaders),
+    })
+  }
 
   if (!apiResponse.ok) {
     console.error(


### PR DESCRIPTION
## Summary
- keep Custom API routing unchanged
- when the Custom API URL is Anthropic and bearer auth returns 401, retry once with x-api-key from ANTHROPIC_API_KEY
- remove Authorization on that Anthropic retry and add anthropic-version when missing

## Verification
- git diff --check
- local Jest could not start because the current local environment reports <rootDir>/jest.resolver.js as missing during config validation, despite the file existing; CI will run the test suite