### PR TITLE
Develop => main

### DIFF
--- a/src/__tests__/lib/api-services/customApi.test.ts
+++ b/src/__tests__/lib/api-services/customApi.test.ts
@@ -213,4 +213,56 @@ describe('handleCustomApi', () => {
       'Authorization'
     )
   })
+
+  it('uses bearer token from Custom API headers as Anthropic x-api-key', async () => {
+    const fetchMock = global.fetch as jest.Mock
+    fetchMock.mockResolvedValueOnce(createStreamResponse('data: [DONE]\n\n'))
+
+    const response = await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://api.anthropic.com/v1/messages',
+      '{"Authorization":"Bearer custom-header-secret"}',
+      '{"model":"claude-sonnet-4-5","max_tokens":128}',
+      true
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-api-key': 'custom-header-secret',
+          'anthropic-version': '2023-06-01',
+        }),
+      })
+    )
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty(
+      'Authorization'
+    )
+  })
+
+  it('strips bearer prefix from Anthropic x-api-key headers', async () => {
+    const fetchMock = global.fetch as jest.Mock
+    fetchMock.mockResolvedValueOnce(createStreamResponse('data: [DONE]\n\n'))
+
+    const response = await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://api.anthropic.com/v1/messages',
+      '{"x-api-key":"Bearer custom-header-secret"}',
+      '{"model":"claude-sonnet-4-5","max_tokens":128}',
+      true
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-api-key': 'custom-header-secret',
+          'anthropic-version': '2023-06-01',
+        }),
+      })
+    )
+  })
 })

--- a/src/lib/api-services/customApi.ts
+++ b/src/lib/api-services/customApi.ts
@@ -102,6 +102,15 @@ function hasHeader(headers: Record<string, string>, name: string): boolean {
   return Object.keys(headers).some((key) => key.toLowerCase() === lowerName)
 }
 
+function getHeader(headers: Record<string, string>, name: string): string {
+  const lowerName = name.toLowerCase()
+  const headerName = Object.keys(headers).find(
+    (key) => key.toLowerCase() === lowerName
+  )
+
+  return headerName ? headers[headerName] : ''
+}
+
 function removeHeader(headers: Record<string, string>, name: string) {
   const lowerName = name.toLowerCase()
   for (const key of Object.keys(headers)) {
@@ -111,18 +120,37 @@ function removeHeader(headers: Record<string, string>, name: string) {
   }
 }
 
-function buildAnthropicRetryHeaders(
-  headers: Record<string, string>
-): Record<string, string> {
-  const retryHeaders = { ...headers }
-  removeHeader(retryHeaders, 'authorization')
-  retryHeaders['x-api-key'] = process.env.ANTHROPIC_API_KEY || ''
+function extractBearerToken(value: string): string {
+  const bearerPrefix = 'Bearer '
+  return value.startsWith(bearerPrefix)
+    ? value.slice(bearerPrefix.length).trim()
+    : value.trim()
+}
 
-  if (!hasHeader(retryHeaders, 'anthropic-version')) {
-    retryHeaders['anthropic-version'] = '2023-06-01'
+function buildAnthropicHeaders(
+  headers: Record<string, string>,
+  fallbackApiKey = ''
+): Record<string, string> {
+  const anthropicHeaders = { ...headers }
+  const xApiKey = getHeader(anthropicHeaders, 'x-api-key')
+  const authorization = getHeader(anthropicHeaders, 'authorization')
+  const apiKey =
+    fallbackApiKey ||
+    extractBearerToken(xApiKey) ||
+    extractBearerToken(authorization) ||
+    ''
+
+  if (apiKey) {
+    removeHeader(anthropicHeaders, 'authorization')
+    removeHeader(anthropicHeaders, 'x-api-key')
+    anthropicHeaders['x-api-key'] = apiKey
   }
 
-  return retryHeaders
+  if (!hasHeader(anthropicHeaders, 'anthropic-version')) {
+    anthropicHeaders['anthropic-version'] = '2023-06-01'
+  }
+
+  return anthropicHeaders
 }
 
 /**
@@ -164,9 +192,13 @@ export async function handleCustomApi(
     )
   }
 
-  const apiHeaders = {
+  let apiHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
     ...parsedHeaders,
+  }
+
+  if (isAnthropicApiUrl(customApiUrl)) {
+    apiHeaders = buildAnthropicHeaders(apiHeaders)
   }
 
   // customApiIncludeMimeTypeが有効な場合は画像にmimeTypeを追加
@@ -198,7 +230,7 @@ export async function handleCustomApi(
     console.warn('Retrying Custom API request with Anthropic x-api-key header')
     apiResponse = await fetch(customApiUrl, {
       ...requestInit,
-      headers: buildAnthropicRetryHeaders(apiHeaders),
+      headers: buildAnthropicHeaders(apiHeaders, process.env.ANTHROPIC_API_KEY),
     })
   }
 


### PR DESCRIPTION
## バグ修正

- Anthropic Custom API で `Authorization: Bearer ...` または `x-api-key: Bearer ...` が設定されている場合、元の custom API 認証情報を `x-api-key` として正規化して送信するように修正
- 初回 401 時のみ `ANTHROPIC_API_KEY` へのフォールバックリトライを維持

## テスト

- custom API の Anthropic 認証ヘッダー正規化テストを追加
- `npm test -- --runTestsByPath src/__tests__/lib/api-services/customApi.test.ts src/__tests__/scripts/normalizeCloudflareEnv.test.ts`
- `git diff --check`
- `npm run build:cloudflare`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anthropic 連携時の認証ヘッダーの扱いを改善し、`Authorization` や `x-api-key` がさまざまな形式で渡されても正しく送信されるようになりました。
  * `Bearer` 付きのトークンが入力された場合でも、不要な文字列を除いたキーとして処理されるようになりました。
  * 認証失敗時の再試行でも、Anthropic が期待するヘッダー形式でリクエストされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->