### PR TITLE
Develop => main

### DIFF
--- a/src/__tests__/lib/api-services/customApi.test.ts
+++ b/src/__tests__/lib/api-services/customApi.test.ts
@@ -265,4 +265,41 @@ describe('handleCustomApi', () => {
       })
     )
   })
+
+  it('retries Anthropic custom API requests with environment key after stale x-api-key fails', async () => {
+    process.env.ANTHROPIC_API_KEY = 'anthropic-secret'
+    const fetchMock = global.fetch as jest.Mock
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: { type: 'authentication_error' } }),
+          {
+            status: 401,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+      .mockResolvedValueOnce(createStreamResponse('data: [DONE]\n\n'))
+
+    const response = await handleCustomApi(
+      [{ role: 'user', content: 'hi' } as any],
+      'https://api.anthropic.com/v1/messages',
+      '{"x-api-key":"stale-custom-secret"}',
+      '{"model":"claude-sonnet-4-5","max_tokens":128}',
+      true
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-api-key': 'anthropic-secret',
+          'anthropic-version': '2023-06-01',
+        }),
+      })
+    )
+  })
 })

--- a/src/lib/api-services/customApi.ts
+++ b/src/lib/api-services/customApi.ts
@@ -225,7 +225,7 @@ export async function handleCustomApi(
     apiResponse.status === 401 &&
     isAnthropicApiUrl(customApiUrl) &&
     process.env.ANTHROPIC_API_KEY &&
-    !hasHeader(parsedHeaders, 'x-api-key')
+    getHeader(apiHeaders, 'x-api-key') !== process.env.ANTHROPIC_API_KEY
   ) {
     console.warn('Retrying Custom API request with Anthropic x-api-key header')
     apiResponse = await fetch(customApiUrl, {


### PR DESCRIPTION
## 新機能

- なし

## 改善

- Anthropic向けCustom APIで古い`x-api-key`が残って401になった場合、Workerに設定済みの`ANTHROPIC_API_KEY`で再試行するようにしました。

## バグ修正

- Cloudflare側のCustom APIヘッダーが古い認証情報を含む場合に、aituberkit.comのCustom API会話が認証エラーのまま復旧しない問題を修正しました。

## テスト

- `npm test -- --runTestsByPath src/__tests__/lib/api-services/customApi.test.ts src/__tests__/scripts/normalizeCloudflareEnv.test.ts`
- `git diff --check`
- `npm run build:cloudflare`

## ドキュメント・翻訳

- なし

## その他

- なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anthropic向けのカスタムAPIリクエストで、APIキーが一致しない場合に自動で再試行するようになりました。
  * 再試行時は最新の環境変数に基づく認証情報へ切り替わるため、認証失敗が起きにくくなります。
  * 失敗時の再送では、必要な追加ヘッダーも正しく含まれることを確認しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->