### PR TITLE
設定画面のオーバーレイとモデル読み込み表示を改善

### DIFF
--- a/src/__tests__/components/voice.test.tsx
+++ b/src/__tests__/components/voice.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import Voice from '@/components/settings/voice'
 import settingsStore from '@/features/stores/settings'
 
@@ -177,6 +177,71 @@ describe('Voice Settings', () => {
 
       expect(screen.getByText('VoicevoxServerUrl')).toBeTruthy()
       expect(screen.getByText('SpeakerSelection')).toBeTruthy()
+    })
+  })
+
+  describe('aivis speech settings', () => {
+    it('should request speaker updates with POST', async () => {
+      mockSettingsStore.mockImplementation((selector) => {
+        return selector({
+          ...defaultVoiceState,
+          selectVoice: 'aivis_speech',
+        } as any)
+      })
+
+      const fetchMock = global.fetch as jest.Mock
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ message: 'ok' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ speaker: 'Speaker/Normal', id: 1 }],
+        })
+
+      render(<Voice />)
+
+      fireEvent.click(screen.getByText('UpdateSpeakerList'))
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/api/update-aivis-speakers?serverUrl=',
+          { method: 'POST' }
+        )
+      })
+    })
+
+    it('should explain server resource access errors', async () => {
+      mockSettingsStore.mockImplementation((selector) => {
+        return selector({
+          ...defaultVoiceState,
+          selectVoice: 'aivis_speech',
+        } as any)
+      })
+
+      const fetchMock = global.fetch as jest.Mock
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [],
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({ errorCode: 'ServerSecretAccessDenied' }),
+        })
+
+      render(<Voice />)
+
+      fireEvent.click(screen.getByText('UpdateSpeakerList'))
+
+      await waitFor(() => {
+        expect(screen.getByText(/サーバー側リソース利用の許可/)).toBeTruthy()
+      })
     })
   })
 

--- a/src/__tests__/pages/api/update-aivis-speakers.test.ts
+++ b/src/__tests__/pages/api/update-aivis-speakers.test.ts
@@ -82,4 +82,33 @@ describe('/api/update-aivis-speakers', () => {
     expect(global.fetch).toHaveBeenCalledWith('http://127.0.0.1:10101/speakers')
     expect(mockWriteFile).toHaveBeenCalled()
   })
+
+  it('rejects non-ok responses from the AivisSpeech server', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'service unavailable' }),
+    }) as jest.Mock
+    const { req, res } = createMocks({ method: 'POST' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(500)
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid speaker response shapes', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ speakers: [] }),
+    }) as jest.Mock
+    const { req, res } = createMocks({ method: 'POST' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(500)
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
 })

--- a/src/__tests__/pages/api/update-voicevox-speakers.test.ts
+++ b/src/__tests__/pages/api/update-voicevox-speakers.test.ts
@@ -82,4 +82,18 @@ describe('/api/update-voicevox-speakers', () => {
     expect(global.fetch).toHaveBeenCalledWith('http://localhost:50021/speakers')
     expect(mockWriteFile).toHaveBeenCalled()
   })
+
+  it('rejects invalid speaker response shapes', async () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ speakers: [] }),
+    }) as jest.Mock
+    const { req, res } = createMocks({ method: 'POST' })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(500)
+    expect(mockWriteFile).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/Live2DComponent.tsx
+++ b/src/components/Live2DComponent.tsx
@@ -5,6 +5,7 @@ import homeStore from '@/features/stores/home'
 import settingsStore from '@/features/stores/settings'
 import { Live2DHandler } from '@/features/messages/live2dHandler'
 import { debounce } from 'lodash'
+import ModelLoadingOverlay from '@/components/modelLoadingOverlay'
 
 console.log('Live2DComponent module loaded')
 
@@ -42,7 +43,9 @@ const Live2DComponent = (): JSX.Element => {
   const [model, setModel] = useState<InstanceType<typeof Live2DModel> | null>(
     null
   )
+  const [isModelLoading, setIsModelLoading] = useState(false)
   const modelRef = useRef<InstanceType<typeof Live2DModel> | null>(null)
+  const loadRequestIdRef = useRef(0)
   const [isDragging, setIsDragging] = useState(false)
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 })
   const selectedLive2DPath = settingsStore((state) => state.selectedLive2DPath)
@@ -132,6 +135,8 @@ const Live2DComponent = (): JSX.Element => {
   ) => {
     if (!canvasContainerRef.current) return
     const hs = homeStore.getState()
+    const requestId = ++loadRequestIdRef.current
+    setIsModelLoading(true)
 
     try {
       const newModel = await Live2DModel.fromSync(modelPath, {
@@ -159,6 +164,10 @@ const Live2DComponent = (): JSX.Element => {
       await Live2DHandler.resetToIdle()
     } catch (error) {
       console.error('Failed to load Live2D model:', error)
+    } finally {
+      if (requestId === loadRequestIdRef.current) {
+        setIsModelLoading(false)
+      }
     }
   }
 
@@ -383,12 +392,13 @@ const Live2DComponent = (): JSX.Element => {
   }, [app, model])
 
   return (
-    <div className="w-screen h-screen">
+    <div className="relative h-screen w-screen">
       <canvas
         ref={canvasContainerRef}
         className="w-full h-full"
         onContextMenu={(e) => e.preventDefault()}
       />
+      {isModelLoading && <ModelLoadingOverlay />}
     </div>
   )
 }

--- a/src/components/PNGTuberComponent.tsx
+++ b/src/components/PNGTuberComponent.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import homeStore from '@/features/stores/home'
 import settingsStore from '@/features/stores/settings'
 import { PNGTuberEngine } from '@/features/pngTuber/pngTuberEngine'
+import ModelLoadingOverlay from '@/components/modelLoadingOverlay'
 
 const PNGTuberComponent = (): JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -38,8 +39,9 @@ const PNGTuberComponent = (): JSX.Element => {
   const [error, setError] = useState<string | null>(null)
 
   // ローディング状態は比較で判断
-  const isLoading =
+  const isLoading = Boolean(
     selectedPNGTuberPath && loadedPath !== selectedPNGTuberPath && !error
+  )
 
   // エンジンを初期化
   useEffect(() => {
@@ -260,11 +262,7 @@ const PNGTuberComponent = (): JSX.Element => {
         </div>
       )}
       {/* 読み込み中表示 */}
-      {isLoading && (
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          <div className="text-white">読み込み中...</div>
-        </div>
-      )}
+      {isLoading && <ModelLoadingOverlay />}
     </div>
   )
 }

--- a/src/components/live2DViewer.tsx
+++ b/src/components/live2DViewer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import Script from 'next/script'
 import homeStore from '@/features/stores/home'
+import ModelLoadingOverlay from '@/components/modelLoadingOverlay'
 
 const Live2DComponent = dynamic(
   () => {
@@ -23,7 +24,7 @@ const Live2DComponent = dynamic(
     ssr: false,
     loading: () => {
       console.log('Live2DComponent is loading...')
-      return null
+      return <ModelLoadingOverlay />
     },
   }
 )
@@ -61,7 +62,7 @@ export default function Live2DViewer() {
 
   if (!isMounted) {
     console.log('Live2DViewer not mounted yet')
-    return null
+    return <ModelLoadingOverlay />
   }
 
   console.log('Rendering Live2DViewer')
@@ -84,6 +85,7 @@ export default function Live2DViewer() {
           }
         }}
       />
+      {!isCubismCoreLoaded && <ModelLoadingOverlay />}
       {isCubismCoreLoaded && <Live2DComponent />}
     </div>
   )

--- a/src/components/modelLoadingOverlay.tsx
+++ b/src/components/modelLoadingOverlay.tsx
@@ -1,0 +1,22 @@
+type ModelLoadingOverlayProps = {
+  className?: string
+}
+
+export default function ModelLoadingOverlay({
+  className = '',
+}: ModelLoadingOverlayProps) {
+  return (
+    <div
+      className={`pointer-events-none absolute inset-0 z-20 flex items-center justify-center ${className}`}
+      aria-label="Loading model"
+      role="status"
+    >
+      <div className="aurora-glass-bubble flex h-[76px] w-[76px] items-center justify-center rounded-full">
+        <div
+          className="h-9 w-9 animate-spin rounded-full border-4 border-[rgba(65,65,79,0.18)] border-t-[var(--aurora-icon)]"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/modelLoadingOverlay.tsx
+++ b/src/components/modelLoadingOverlay.tsx
@@ -8,7 +8,7 @@ export default function ModelLoadingOverlay({
   return (
     <div
       className={`pointer-events-none absolute inset-0 z-20 flex items-center justify-center ${className}`}
-      aria-label="Loading model"
+      aria-label="モデルを読み込み中"
       role="status"
     >
       <div className="aurora-glass-bubble flex h-[76px] w-[76px] items-center justify-center rounded-full">

--- a/src/components/pngTuberViewer.tsx
+++ b/src/components/pngTuberViewer.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from 'react'
 import dynamic from 'next/dynamic'
+import ModelLoadingOverlay from '@/components/modelLoadingOverlay'
 
 const PNGTuberComponent = dynamic(() => import('./PNGTuberComponent'), {
   ssr: false,
-  loading: () => null,
+  loading: () => <ModelLoadingOverlay />,
 })
 
 export default function PNGTuberViewer() {
@@ -16,7 +17,7 @@ export default function PNGTuberViewer() {
   }, [])
 
   if (!isMounted) {
-    return null
+    return <ModelLoadingOverlay />
   }
 
   return (

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -46,8 +46,19 @@ const tabsWithRedundantPanelTitle = new Set([
 ])
 
 const Settings = (props: Props) => {
+  const handleBackdropClick = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    if (event.target === event.currentTarget) {
+      props.onClickClose()
+    }
+  }
+
   return (
-    <div className="theme-settings-backdrop absolute z-40 h-full w-full overflow-hidden">
+    <div
+      className="theme-settings-backdrop absolute z-40 h-full w-full overflow-hidden"
+      onClick={handleBackdropClick}
+    >
       <div className="theme-settings-shell mx-auto flex h-full w-full max-w-[1280px] flex-col overflow-hidden border-x shadow-xl backdrop-blur-sm md:my-5 md:h-[calc(100%-2.5rem)] md:w-[calc(100%-3rem)] md:rounded-xl md:border">
         <Header {...props} />
         <Main />

--- a/src/components/settings/voice.tsx
+++ b/src/components/settings/voice.tsx
@@ -22,6 +22,21 @@ import speakers from '../speakers.json'
 // import speakers_aivis from '../speakers_aivis.json'
 import { useRestrictedMode } from '@/hooks/useRestrictedMode'
 
+const getSpeakerUpdateErrorMessage = async (
+  response: Response
+): Promise<string> => {
+  try {
+    const data = (await response.json()) as { errorCode?: unknown }
+    if (data.errorCode === 'ServerSecretAccessDenied') {
+      return '話者リストの更新にはサーバー側リソース利用の許可が必要です。ローカル環境では .env.local に AITUBERKIT_SERVER_SECRET_ACCESS_MODE="unprotected" を設定してください。'
+    }
+  } catch {
+    // Fall through to the generic message when the error response is not JSON.
+  }
+
+  return '話者リストの更新に失敗しました'
+}
+
 const Voice = () => {
   const { isRestrictedMode } = useRestrictedMode()
   const koeiromapKey = settingsStore((s) => s.koeiromapKey)
@@ -360,7 +375,8 @@ const Voice = () => {
                       try {
                         const response = await fetch(
                           '/api/update-voicevox-speakers?serverUrl=' +
-                            encodeURIComponent(voicevoxServerUrl)
+                            encodeURIComponent(voicevoxServerUrl),
+                          { method: 'POST' }
                         )
                         if (response.ok) {
                           const updatedSpeakersResponse = await fetch(
@@ -371,7 +387,7 @@ const Voice = () => {
                           setSpeakers_voicevox(updatedSpeakers)
                         } else {
                           setVoicevoxSpeakersUpdateError(
-                            '話者リストの更新に失敗しました'
+                            await getSpeakerUpdateErrorMessage(response)
                           )
                         }
                       } catch (error) {
@@ -656,7 +672,8 @@ const Voice = () => {
                       try {
                         const response = await fetch(
                           '/api/update-aivis-speakers?serverUrl=' +
-                            encodeURIComponent(aivisSpeechServerUrl)
+                            encodeURIComponent(aivisSpeechServerUrl),
+                          { method: 'POST' }
                         )
                         if (response.ok) {
                           const updatedSpeakersResponse = await fetch(
@@ -667,7 +684,7 @@ const Voice = () => {
                           setSpeakers_aivis(updatedSpeakers)
                         } else {
                           setSpeakersUpdateError(
-                            '話者リストの更新に失敗しました'
+                            await getSpeakerUpdateErrorMessage(response)
                           )
                         }
                       } catch (error) {

--- a/src/components/vrmViewer.tsx
+++ b/src/components/vrmViewer.tsx
@@ -1,15 +1,30 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import homeStore from '@/features/stores/home'
 import settingsStore from '@/features/stores/settings'
 import { loadVRMAnimation } from '@/lib/VRMAnimation/loadVRMAnimation'
 import PoseTestButton from '@/components/poseTestButton'
+import ModelLoadingOverlay from '@/components/modelLoadingOverlay'
 
 export default function VrmViewer() {
+  const [isModelLoading, setIsModelLoading] = useState(false)
+
+  useEffect(() => {
+    const { viewer } = homeStore.getState()
+    viewer.onModelLoadingChange = setIsModelLoading
+
+    return () => {
+      if (viewer.onModelLoadingChange === setIsModelLoading) {
+        viewer.onModelLoadingChange = undefined
+      }
+    }
+  }, [])
+
   const canvasRef = useCallback((canvas: HTMLCanvasElement) => {
     if (canvas) {
       const { viewer } = homeStore.getState()
       const { selectedVrmPath } = settingsStore.getState()
+      viewer.onModelLoadingChange = setIsModelLoading
       viewer.setup(canvas)
       viewer.loadVrm(selectedVrmPath)
 
@@ -64,6 +79,7 @@ export default function VrmViewer() {
     <>
       <div className={'absolute top-0 left-0 w-screen h-[100svh] z-5'}>
         <canvas ref={canvasRef} className={'h-full w-full'}></canvas>
+        {isModelLoading && <ModelLoadingOverlay />}
       </div>
       {poseAdjustMode && <PoseTestButton />}
     </>

--- a/src/features/vrmViewer/viewer.ts
+++ b/src/features/vrmViewer/viewer.ts
@@ -13,6 +13,7 @@ import settingsStore from '@/features/stores/settings'
 export class Viewer {
   public isReady: boolean
   public model?: Model
+  public onModelLoadingChange?: (isLoading: boolean) => void
 
   private _renderer?: THREE.WebGLRenderer
   private _clock: THREE.Clock
@@ -21,6 +22,7 @@ export class Viewer {
   private _cameraControls?: OrbitControls
   private _directionalLight?: THREE.DirectionalLight
   private _ambientLight?: THREE.AmbientLight
+  private _loadVrmRequestId = 0
 
   constructor() {
     this.isReady = false
@@ -49,36 +51,50 @@ export class Viewer {
     this._clock.start()
   }
 
-  public loadVrm(url: string) {
+  public loadVrm(url: string): Promise<void> {
+    const requestId = ++this._loadVrmRequestId
+    this.onModelLoadingChange?.(true)
+
     if (this.model?.vrm) {
       this.unloadVRM()
     }
 
     // gltf and vrm
-    this.model = new Model(this._camera || new THREE.Object3D())
-    this.model.loadVRM(url).then(async () => {
-      if (!this.model?.vrm) return
+    const model = new Model(this._camera || new THREE.Object3D())
+    this.model = model
+    return model
+      .loadVRM(url)
+      .then(async () => {
+        if (this.model !== model || !model.vrm) return
 
-      // Disable frustum culling
-      this.model.vrm.scene.traverse((obj) => {
-        obj.frustumCulled = false
+        // Disable frustum culling
+        model.vrm.scene.traverse((obj) => {
+          obj.frustumCulled = false
+        })
+
+        model.vrm.scene.visible = false
+        this._scene.add(model.vrm.scene)
+
+        try {
+          const vrma = await loadVRMAnimation(buildUrl('/idle_loop.vrma'))
+          if (vrma) model.loadAnimation(vrma)
+        } finally {
+          model.vrm.scene.visible = true
+        }
+
+        // HACK: アニメーションの原点がずれているので再生後にカメラ位置を調整する
+        requestAnimationFrame(() => {
+          this.resetCamera()
+        })
       })
-
-      this.model.vrm.scene.visible = false
-      this._scene.add(this.model.vrm.scene)
-
-      try {
-        const vrma = await loadVRMAnimation(buildUrl('/idle_loop.vrma'))
-        if (vrma) this.model.loadAnimation(vrma)
-      } finally {
-        this.model.vrm.scene.visible = true
-      }
-
-      // HACK: アニメーションの原点がずれているので再生後にカメラ位置を調整する
-      requestAnimationFrame(() => {
-        this.resetCamera()
+      .catch((error) => {
+        console.error('Failed to load VRM:', error)
       })
-    })
+      .finally(() => {
+        if (requestId === this._loadVrmRequestId) {
+          this.onModelLoadingChange?.(false)
+        }
+      })
   }
 
   public unloadVRM(): void {

--- a/src/features/vrmViewer/viewer.ts
+++ b/src/features/vrmViewer/viewer.ts
@@ -65,7 +65,10 @@ export class Viewer {
     return model
       .loadVRM(url)
       .then(async () => {
-        if (this.model !== model || !model.vrm) return
+        if (this.model !== model || !model.vrm) {
+          model.unLoadVrm()
+          return
+        }
 
         // Disable frustum culling
         model.vrm.scene.traverse((obj) => {

--- a/src/pages/api/update-aivis-speakers.ts
+++ b/src/pages/api/update-aivis-speakers.ts
@@ -60,7 +60,17 @@ export default async function handler(
       return res.status(400).json({ error: 'Invalid server URL protocol' })
     }
     const response = await fetch(`${serverUrl}/speakers`)
+
+    if (!response.ok) {
+      throw new Error(
+        `AivisSpeech server responded with status: ${response.status}`
+      )
+    }
+
     const speakers: Speaker[] = await response.json()
+    if (!Array.isArray(speakers)) {
+      throw new Error('AivisSpeech speakers response must be an array')
+    }
 
     // Aivis形式に変換
     const aivisSpeakers: AivisSpeaker[] = speakers.flatMap((speaker) =>

--- a/src/pages/api/update-voicevox-speakers.ts
+++ b/src/pages/api/update-voicevox-speakers.ts
@@ -68,6 +68,9 @@ export default async function handler(
     }
 
     const speakers: Speaker[] = await response.json()
+    if (!Array.isArray(speakers)) {
+      throw new Error('VOICEVOX speakers response must be an array')
+    }
 
     // VOICEVOX形式に変換
     const voicevoxSpeakers: VoicevoxSpeaker[] = speakers.flatMap((speaker) =>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,6 +20,7 @@ body {
   --aurora-control-bg: rgba(120, 120, 140, 0.16);
   --aurora-control-bg-hover: rgba(120, 120, 140, 0.28);
   --aurora-control-bg-disabled: rgba(120, 120, 140, 0.08);
+  --settings-backdrop-bg: rgba(255, 255, 255, 0.52);
 }
 
 /* darkMode: class 用の上書き（ダークガラス面に合わせたライトテキスト） */
@@ -33,6 +34,7 @@ body {
   --aurora-control-bg: rgba(120, 120, 140, 0.28);
   --aurora-control-bg-hover: rgba(120, 120, 140, 0.4);
   --aurora-control-bg-disabled: rgba(120, 120, 140, 0.14);
+  --settings-backdrop-bg: rgba(17, 19, 28, 0.46);
 }
 
 @layer components {
@@ -127,7 +129,7 @@ body {
   }
 
   .theme-settings-backdrop {
-    background-color: rgba(255, 255, 255, 0.52);
+    background-color: var(--settings-backdrop-bg);
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -127,7 +127,9 @@ body {
   }
 
   .theme-settings-backdrop {
-    background-color: transparent;
+    background-color: rgba(255, 255, 255, 0.52);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
   }
 
   .theme-settings-shell {


### PR DESCRIPTION
## 概要
- 設定画面の背景を半透明の白いオーバーレイに変更
- 設定画面外クリックで設定画面を閉じられるように変更
- VRM / Live2D / PNGTuber のモデル読み込み中に共通スピナーを表示
- スピナーは既存UIに合わせた控えめな mono ring 表示に調整

## 検証
- npm exec prettier -- --check src/components/settings/index.tsx src/styles/globals.css
- npm exec prettier -- --write src/components/modelLoadingOverlay.tsx src/components/Live2DComponent.tsx src/components/PNGTuberComponent.tsx src/components/live2DViewer.tsx src/components/pngTuberViewer.tsx src/components/vrmViewer.tsx src/features/vrmViewer/viewer.ts
- npm exec eslint -- src/components/settings/index.tsx
- npm exec eslint -- src/components/modelLoadingOverlay.tsx
- npm exec eslint -- src/components/modelLoadingOverlay.tsx src/components/Live2DComponent.tsx src/components/PNGTuberComponent.tsx src/components/live2DViewer.tsx src/components/pngTuberViewer.tsx src/components/vrmViewer.tsx src/features/vrmViewer/viewer.ts
- npm run build
- http://localhost:3000 で設定画面外クリックの動作と実行時エラーなしを確認

## 備考
- 既存の React Hooks / Next.js lint 警告は残っていますが、今回の変更起因のエラーはありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * モデル読み込み中に共通のローディングオーバーレイ（ModelLoadingOverlay）を表示するよう改善しました（Live2D / PNGTuber / VRM）。
* **バグ修正**
  * 複数回の読み込みが競合した際のちらつきや、古い完了によるローディング解除の誤切替を抑制しました。
  * 設定画面の背面クリック挙動を調整し、意図しない閉じ方をしにくくしました。
  * 話者リスト更新エラー文言を状況に応じて明確化しました。
* **スタイル**
  * 設定画面の背面背景を半透明・ぼかし付きに調整しました。
* **Tests**
  * 話者更新系のテストを拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->