### PR TITLE
Release v2.55.2

### DIFF
--- a/src/__tests__/lib/api-services/serverSecretGuard.test.ts
+++ b/src/__tests__/lib/api-services/serverSecretGuard.test.ts
@@ -96,6 +96,44 @@ describe('serverSecretGuard', () => {
     expect(res._getStatusCode()).toBe(200)
   })
 
+  it('allows demo mode for same-host requests when Sec-Fetch-Site is unavailable', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    delete process.env.AITUBERKIT_DEMO_ACCESS_TOKEN
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        host: 'aituberkit.example',
+        origin: 'https://aituberkit.example',
+      },
+    })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(true)
+    expect(res._getStatusCode()).toBe(200)
+  })
+
+  it('rejects demo mode cross-host requests when Sec-Fetch-Site is unavailable', () => {
+    process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
+    delete process.env.AITUBERKIT_DEMO_ACCESS_TOKEN
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: {
+        host: 'aituberkit.example',
+        origin: 'https://evil.example',
+      },
+    })
+
+    const allowed = guardServerSecretAccess(req as any, res as any, {
+      featureName: 'test-feature',
+    })
+
+    expect(allowed).toBe(false)
+    expect(res._getStatusCode()).toBe(403)
+  })
+
   it('allows demo mode for same-origin requests with a configured demo token', () => {
     process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'demo'
     process.env.AITUBERKIT_DEMO_ACCESS_TOKEN = 'demo-token'

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -992,7 +992,7 @@ const escapeRegExp = (value: string) =>
 const Footer = () => {
   return (
     <footer className="theme-surface-contrast shrink-0 border-t border-primary/20 py-1 text-center font-Montserrat text-xs">
-      powered by ChatVRM from Pixiv / ver. 2.55.1
+      powered by ChatVRM from Pixiv / ver. 2.55.2
     </footer>
   )
 }

--- a/src/lib/api-services/serverSecretGuard.ts
+++ b/src/lib/api-services/serverSecretGuard.ts
@@ -213,7 +213,11 @@ export function guardServerSecretAccess(
 
   if (mode === 'demo') {
     const fetchSite = getHeaderValue(req, 'sec-fetch-site')
-    const fetchSiteAllowed = fetchSite === 'same-origin' || fetchSite === 'none'
+    const origin = getRequestOrigin(req)
+    const fetchSiteAllowed =
+      fetchSite === 'same-origin' ||
+      fetchSite === 'none' ||
+      (fetchSite === '' && isSameHostOrigin(req, origin))
 
     if (
       fetchSiteAllowed &&


### PR DESCRIPTION
## 概要

v2.55.2 のバグ修正リリースです。

## バグ修正

- 一部のモバイルブラウザで埋め込みウィジェットから会話APIへ送信すると、AI APIエラーになる問題を修正
- demo modeのサーバー側ガードで、`Sec-Fetch-Site` が送信されない同一ホストリクエストを安全に許可するように修正

## テスト

- `mise exec node@24 -- npm test -- --runInBand src/__tests__/lib/api-services/serverSecretGuard.test.ts src/__tests__/pages/api/custom.test.ts src/__tests__/pages/api/vercel.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * デモモードで、`sec-fetch-site` が空の場合でも同一ホストのリクエストを許可するようになりました。
  * 同一ホストは `200`、クロスホストは `403` となる挙動が明確になりました。
* **Tests**
  * デモモードのアクセス判定について、`sec-fetch-site` 未指定時の同一ホスト・クロスホスト両ケースのテストを追加しました。
* **Chores**
  * フッターのバージョン表記を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->