### PR TITLE
Develop => main: v2.57.0

### DIFF
--- a/src/__tests__/features/constants/aiModels.test.ts
+++ b/src/__tests__/features/constants/aiModels.test.ts
@@ -25,6 +25,8 @@ import {
 import { AIService } from '@/features/constants/settings'
 
 describe('aiModels', () => {
+  const openAI56Models = ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']
+
   const allServices: AIService[] = [
     'openai',
     'anthropic',
@@ -79,7 +81,7 @@ describe('aiModels', () => {
 
     it('should include newly released OpenAI and xAI models', () => {
       expect(getModels('openai')).toEqual(
-        expect.arrayContaining(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
+        expect.arrayContaining(openAI56Models)
       )
       expect(getModels('xai')).toContain('grok-4.5')
     })
@@ -144,6 +146,7 @@ describe('aiModels', () => {
       expect(models).toContain('gpt-5.4')
       expect(models).toContain('gpt-4o')
       expect(models).toContain('gpt-4.1')
+      expect(models).toEqual(expect.arrayContaining(openAI56Models))
     })
 
     it('should return all models for anthropic (all are multimodal)', () => {
@@ -169,6 +172,7 @@ describe('aiModels', () => {
       expect(models).not.toContain('grok-4-fast-reasoning')
       expect(models).not.toContain('grok-code-fast-1')
       expect(models).toContain('grok-4')
+      expect(models).toContain('grok-4.5')
     })
 
     it('should return subset for groq (most are not multimodal)', () => {
@@ -305,18 +309,24 @@ describe('aiModels', () => {
     })
 
     it('should treat latest OpenAI and xAI models as reasoning models', () => {
-      expect(isReasoningModel('openai', 'gpt-5.6-terra')).toBe(true)
-      expect(getReasoningEfforts('openai', 'gpt-5.6-terra')).toEqual([
-        'none',
+      for (const model of openAI56Models) {
+        expect(isReasoningModel('openai', model)).toBe(true)
+        expect(getReasoningEfforts('openai', model)).toEqual([
+          'none',
+          'low',
+          'medium',
+          'high',
+          'xhigh',
+          'max',
+        ])
+      }
+
+      expect(isReasoningModel('xai', 'grok-4.5')).toBe(true)
+      expect(getReasoningEfforts('xai', 'grok-4.5')).toEqual([
         'low',
         'medium',
         'high',
-        'xhigh',
-        'max',
       ])
-
-      expect(isReasoningModel('xai', 'grok-4.5')).toBe(true)
-      expect(getReasoningEfforts('xai', 'grok-4.5')).toEqual(['low', 'high'])
     })
   })
 

--- a/src/__tests__/features/constants/aiModels.test.ts
+++ b/src/__tests__/features/constants/aiModels.test.ts
@@ -10,6 +10,7 @@ import {
   getOpenAIAudioModels,
   getOpenAIWhisperModels,
   getOpenAITTSModels,
+  getReasoningEfforts,
   isMultiModalModel,
   isMultiModalModelWithToggle,
   isMultiModalAvailable,
@@ -74,6 +75,13 @@ describe('aiModels', () => {
       allServices.forEach((service) => {
         expect(getModels(service)).toEqual(aiModels[service])
       })
+    })
+
+    it('should include newly released OpenAI and xAI models', () => {
+      expect(getModels('openai')).toEqual(
+        expect.arrayContaining(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
+      )
+      expect(getModels('xai')).toContain('grok-4.5')
     })
   })
 
@@ -294,6 +302,21 @@ describe('aiModels', () => {
           'accounts/fireworks/models/kimi-k2-thinking'
         )
       ).toBe(true)
+    })
+
+    it('should treat latest OpenAI and xAI models as reasoning models', () => {
+      expect(isReasoningModel('openai', 'gpt-5.6-terra')).toBe(true)
+      expect(getReasoningEfforts('openai', 'gpt-5.6-terra')).toEqual([
+        'none',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+        'max',
+      ])
+
+      expect(isReasoningModel('xai', 'grok-4.5')).toBe(true)
+      expect(getReasoningEfforts('xai', 'grok-4.5')).toEqual(['low', 'high'])
     })
   })
 

--- a/src/components/settings/shell/Footer.tsx
+++ b/src/components/settings/shell/Footer.tsx
@@ -1,7 +1,7 @@
 export const Footer = () => {
   return (
     <footer className="theme-surface-contrast shrink-0 border-t border-primary/20 py-1 text-center font-Montserrat text-xs">
-      powered by ChatVRM from Pixiv / ver. 2.56.0
+      powered by ChatVRM from Pixiv / ver. 2.57.0
     </footer>
   )
 }

--- a/src/features/constants/aiModels.ts
+++ b/src/features/constants/aiModels.ts
@@ -27,6 +27,21 @@ interface ModelInfo {
 const modelDefinitions: Record<AIService, ModelInfo[]> = {
   openai: [
     {
+      name: 'gpt-5.6-sol',
+      multiModal: true,
+      reasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+    },
+    {
+      name: 'gpt-5.6-terra',
+      multiModal: true,
+      reasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+    },
+    {
+      name: 'gpt-5.6-luna',
+      multiModal: true,
+      reasoningEfforts: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+    },
+    {
       name: 'gpt-5.5',
       multiModal: true,
       reasoningEfforts: ['minimal', 'low', 'medium', 'high'],
@@ -464,6 +479,10 @@ const modelDefinitions: Record<AIService, ModelInfo[]> = {
   ],
   azure: [],
   xai: [
+    {
+      name: 'grok-4.5',
+      reasoningEfforts: ['low', 'high'],
+    },
     {
       name: 'grok-4-1-fast-reasoning',
       reasoningEfforts: ['low', 'high'],

--- a/src/features/constants/aiModels.ts
+++ b/src/features/constants/aiModels.ts
@@ -481,7 +481,8 @@ const modelDefinitions: Record<AIService, ModelInfo[]> = {
   xai: [
     {
       name: 'grok-4.5',
-      reasoningEfforts: ['low', 'high'],
+      multiModal: true,
+      reasoningEfforts: ['low', 'medium', 'high'],
     },
     {
       name: 'grok-4-1-fast-reasoning',

--- a/src/features/constants/settings.ts
+++ b/src/features/constants/settings.ts
@@ -190,3 +190,4 @@ export type ReasoningEffort =
   | 'medium'
   | 'high'
   | 'xhigh'
+  | 'max'


### PR DESCRIPTION
## 新機能
- OpenAI のモデル一覧に `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` を追加しました。
- xAI のモデル一覧に `grok-4.5` を追加しました。
- `gpt-5.6` 系の reasoning effort に `none`, `low`, `medium`, `high`, `xhigh`, `max` を設定しました。
- `grok-4.5` の reasoning effort に `low`, `medium`, `high` を設定し、マルチモーダル対応として扱うようにしました。

## 改善
- 設定画面のフッター表記を `ver. 2.57.0` に更新しました。

## バグ修正
- なし

## テスト
- `npm test -- src/__tests__/features/constants/aiModels.test.ts --runInBand`
- `npm run build`

## ドキュメント・翻訳
- なし

## その他
- なし