### PR TITLE
Develop => main

### DIFF
--- a/docs/access-policy-design.md
+++ b/docs/access-policy-design.md
@@ -185,8 +185,8 @@ function withAccessPolicy(
    - `kind: 'pairs'`: `computeUsesServerSecret(pairs)` または `isProtectedServerResource` が真なら `guardServerSecretAccess()`
    - `kind: 'always'`: 無条件で `guardServerSecretAccess()`
    - `kind: 'dynamic'`: ここでは何もしない。ルートが `gate.guardServerSecret()` を呼ぶ（呼んでいることを静的テストで強制 — §7.2-3）
-   - ただし `allowLocalLoopback` を宣言したルートは、`disabled` かつリクエスト元Host・ソケット接続元・接続先URLがすべてループバックで、`Forwarded` / `X-Forwarded-*` などのプロキシ転送ヘッダーがない直接接続の場合のみガードを省略する
-   - リバースプロキシ経由ではソケット接続元がプロキシのループバックアドレスに見え、Hostや転送ヘッダーも構成次第で信頼できないため、`allowLocalLoopback` を安全境界として扱わない。プロキシ経由の要求ではこの例外を無効化し、`protected` / `demo` / `unprotected` の明示的な運用モードを使用する
+   - ただし `allowLocalLoopback` を宣言したルートは、`disabled` かつリクエスト元Host・ソケット接続元・接続先URLがすべてループバックの場合のみガードを省略する。Next.jsが直接接続にも補完する `X-Forwarded-For` / `X-Forwarded-Host` は、値がすべてループバックの場合に限り許容する
+   - 外部IPを含む `X-Forwarded-For`、非ループバックの `X-Forwarded-Host`、Next.jsが補完しない `Forwarded` / `X-Real-IP` / `CF-Connecting-IP` がある場合はプロキシ経由と判断して例外を無効化する。リバースプロキシ環境では `protected` / `demo` / `unprotected` の明示的な運用モードを使用する
 6. すべて通過 → `handler(req, res, gate)` を実行
 
 エラーレスポンスのシェイプは既存関数（`createRestrictedModeErrorResponse` / `rejectServerSecretAccess` / `requireApiKey`）をそのまま呼ぶことで保存する。

--- a/src/__tests__/lib/api-services/serverUrlGuard.test.ts
+++ b/src/__tests__/lib/api-services/serverUrlGuard.test.ts
@@ -13,6 +13,7 @@ describe('serverUrlGuard', () => {
       expect(isLoopbackHost('::ffff:127.0.0.1')).toBe(true)
       expect(isLoopbackHost('192.168.1.10')).toBe(false)
       expect(isLoopbackHost('::ffff:10.0.0.1')).toBe(false)
+      expect(isLoopbackHost('127.attacker.example')).toBe(false)
     })
   })
 
@@ -39,6 +40,11 @@ describe('serverUrlGuard', () => {
       expect(isLocalOrPrivateHost('fe90::1')).toBe(true)
       expect(isLocalOrPrivateHost('febf::1')).toBe(true)
       expect(isLocalOrPrivateHost('fec0::1')).toBe(false)
+    })
+
+    it('does not treat IP-prefixed hostnames as private addresses', () => {
+      expect(isLocalOrPrivateHost('127.attacker.example')).toBe(false)
+      expect(isLocalOrPrivateHost('192.168.attacker.example')).toBe(false)
     })
   })
 })

--- a/src/__tests__/pages/api/tts-voicevox.test.ts
+++ b/src/__tests__/pages/api/tts-voicevox.test.ts
@@ -178,6 +178,30 @@ describe('/api/tts-voicevox', () => {
     expect(mockAxiosPost).toHaveBeenCalledTimes(2)
   })
 
+  it('should allow Next.js synthesized forwarding headers for a local request', async () => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+    mockAxiosPost
+      .mockResolvedValueOnce({ data: {} })
+      .mockResolvedValueOnce({ data: Buffer.from([]) })
+
+    const req = createMockReq({
+      body: { text: 'test', speaker: 1, speed: 1, pitch: 0, intonation: 1 },
+      headers: {
+        host: 'localhost:3000',
+        'x-forwarded-for': '127.0.0.1',
+        'x-forwarded-host': 'localhost:3000',
+        'x-forwarded-port': '3000',
+        'x-forwarded-proto': 'http',
+      },
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(200)
+    expect(mockAxiosPost).toHaveBeenCalledTimes(2)
+  })
+
   it('should reject the default localhost VOICEVOX URL for a remote request', async () => {
     delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
 
@@ -244,6 +268,26 @@ describe('/api/tts-voicevox', () => {
         host: 'localhost:3000',
         'x-forwarded-for': '198.51.100.20',
         'x-forwarded-host': 'localhost:3000',
+      },
+      socket: { remoteAddress: '127.0.0.1' } as NextApiRequest['socket'],
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(403)
+    expect(mockAxiosPost).not.toHaveBeenCalled()
+  })
+
+  it('should reject a proxied request with a non-loopback forwarded host', async () => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const req = createMockReq({
+      body: { text: 'test', speaker: 1, speed: 1, pitch: 0, intonation: 1 },
+      headers: {
+        host: 'localhost:3000',
+        'x-forwarded-for': '127.0.0.1',
+        'x-forwarded-host': 'aituberkit.example.com',
       },
       socket: { remoteAddress: '127.0.0.1' } as NextApiRequest['socket'],
     })

--- a/src/__tests__/pages/api/tts-voicevox.test.ts
+++ b/src/__tests__/pages/api/tts-voicevox.test.ts
@@ -299,6 +299,54 @@ describe('/api/tts-voicevox', () => {
     expect(mockAxiosPost).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['an empty forwarded address', { 'x-forwarded-for': '' }],
+    [
+      'an empty forwarded address token',
+      { 'x-forwarded-for': '127.0.0.1, , ::1' },
+    ],
+    ['a malformed forwarded address', { 'x-forwarded-for': 'localhost' }],
+    [
+      'a deceptive loopback-prefixed address',
+      { 'x-forwarded-for': '127.attacker.example' },
+    ],
+    [
+      'an empty forwarded host token',
+      {
+        'x-forwarded-for': '127.0.0.1',
+        'x-forwarded-host': 'localhost:3000,',
+      },
+    ],
+    [
+      'a malformed forwarded host',
+      {
+        'x-forwarded-for': '127.0.0.1',
+        'x-forwarded-host': 'localhost:invalid-port',
+      },
+    ],
+    [
+      'a deceptive loopback-prefixed host',
+      {
+        'x-forwarded-for': '127.0.0.1',
+        'x-forwarded-host': '127.attacker.example',
+      },
+    ],
+  ])('should reject a proxied request with %s', async (_label, headers) => {
+    delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
+
+    const req = createMockReq({
+      body: { text: 'test', speaker: 1, speed: 1, pitch: 0, intonation: 1 },
+      headers: { host: 'localhost:3000', ...headers },
+      socket: { remoteAddress: '127.0.0.1' } as NextApiRequest['socket'],
+    })
+    const res = createMockRes()
+
+    await handler(req, res)
+
+    expect(res._status).toBe(403)
+    expect(mockAxiosPost).not.toHaveBeenCalled()
+  })
+
   it('should still require authentication in protected mode locally', async () => {
     process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'protected'
     process.env.AITUBERKIT_SERVER_SECRET_TOKEN = 'test-token'

--- a/src/components/settings/shell/Footer.tsx
+++ b/src/components/settings/shell/Footer.tsx
@@ -1,7 +1,7 @@
 export const Footer = () => {
   return (
     <footer className="theme-surface-contrast shrink-0 border-t border-primary/20 py-1 text-center font-Montserrat text-xs">
-      powered by ChatVRM from Pixiv / ver. 2.58.0
+      powered by ChatVRM from Pixiv / ver. 2.59.0
     </footer>
   )
 }

--- a/src/lib/accessPolicy/withAccessPolicy.ts
+++ b/src/lib/accessPolicy/withAccessPolicy.ts
@@ -11,6 +11,7 @@
  * 設計ドキュメント: docs/access-policy-design.md §4.2
  */
 
+import { isIP } from 'node:net'
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
 import {
   guardServerSecretAccess,
@@ -64,18 +65,29 @@ const EXPLICIT_PROXY_HEADER_NAMES = [
 
 function getCommaSeparatedHeaderValues(
   value: string | string[] | undefined
-): string[] {
-  if (!value) return []
+): string[] | undefined {
+  if (value === undefined) return undefined
 
   return (Array.isArray(value) ? value : [value])
     .flatMap((entry) => entry.split(','))
     .map((entry) => entry.trim())
-    .filter(Boolean)
+}
+
+function isStrictLoopbackIpAddress(value: string): boolean {
+  return isIP(value) !== 0 && isLoopbackHost(value)
 }
 
 function isLoopbackForwardedHost(value: string): boolean {
   try {
-    return isLoopbackHost(new URL(`http://${value}`).hostname)
+    const parsed = new URL(`http://${value}`)
+    return (
+      !parsed.username &&
+      !parsed.password &&
+      parsed.pathname === '/' &&
+      !parsed.search &&
+      !parsed.hash &&
+      isLoopbackHost(parsed.hostname)
+    )
   } catch {
     return false
   }
@@ -93,14 +105,22 @@ function hasExternalProxyEvidence(req: NextApiRequest): boolean {
   const forwardedAddresses = getCommaSeparatedHeaderValues(
     req.headers?.['x-forwarded-for']
   )
-  if (forwardedAddresses.some((address) => !isLoopbackHost(address))) {
+  if (
+    forwardedAddresses !== undefined &&
+    (forwardedAddresses.length === 0 ||
+      forwardedAddresses.some((address) => !isStrictLoopbackIpAddress(address)))
+  ) {
     return true
   }
 
   const forwardedHosts = getCommaSeparatedHeaderValues(
     req.headers?.['x-forwarded-host']
   )
-  return forwardedHosts.some((host) => !isLoopbackForwardedHost(host))
+  return (
+    forwardedHosts !== undefined &&
+    (forwardedHosts.length === 0 ||
+      forwardedHosts.some((host) => !isLoopbackForwardedHost(host)))
+  )
 }
 
 function isSameMachineLoopbackRequest(req: NextApiRequest): boolean {

--- a/src/lib/accessPolicy/withAccessPolicy.ts
+++ b/src/lib/accessPolicy/withAccessPolicy.ts
@@ -56,21 +56,55 @@ export type PolicyGuardedHandler = (
   gate: PolicyGate
 ) => unknown | Promise<unknown>
 
-const PROXY_HEADER_NAMES = [
+const EXPLICIT_PROXY_HEADER_NAMES = [
   'forwarded',
-  'x-forwarded-for',
-  'x-forwarded-host',
-  'x-forwarded-proto',
   'x-real-ip',
   'cf-connecting-ip',
 ] as const
 
-function hasProxyHeaders(req: NextApiRequest): boolean {
-  return PROXY_HEADER_NAMES.some((name) => req.headers?.[name] !== undefined)
+function getCommaSeparatedHeaderValues(
+  value: string | string[] | undefined
+): string[] {
+  if (!value) return []
+
+  return (Array.isArray(value) ? value : [value])
+    .flatMap((entry) => entry.split(','))
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function isLoopbackForwardedHost(value: string): boolean {
+  try {
+    return isLoopbackHost(new URL(`http://${value}`).hostname)
+  } catch {
+    return false
+  }
+}
+
+function hasExternalProxyEvidence(req: NextApiRequest): boolean {
+  if (
+    EXPLICIT_PROXY_HEADER_NAMES.some(
+      (name) => req.headers?.[name] !== undefined
+    )
+  ) {
+    return true
+  }
+
+  const forwardedAddresses = getCommaSeparatedHeaderValues(
+    req.headers?.['x-forwarded-for']
+  )
+  if (forwardedAddresses.some((address) => !isLoopbackHost(address))) {
+    return true
+  }
+
+  const forwardedHosts = getCommaSeparatedHeaderValues(
+    req.headers?.['x-forwarded-host']
+  )
+  return forwardedHosts.some((host) => !isLoopbackForwardedHost(host))
 }
 
 function isSameMachineLoopbackRequest(req: NextApiRequest): boolean {
-  if (hasProxyHeaders(req)) return false
+  if (hasExternalProxyEvidence(req)) return false
 
   const hostHeader = req.headers?.host
   if (!hostHeader) return false

--- a/src/lib/api-services/serverUrlGuard.ts
+++ b/src/lib/api-services/serverUrlGuard.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net'
+
 const PRIVATE_IPV4_RANGES = [
   /^10\./,
   /^127\./,
@@ -43,16 +45,21 @@ function getIpv4MappedAddress(normalizedHost: string): string | undefined {
 
 export function isLoopbackHost(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) {
+    return true
+  }
+
+  const addressKind = isIP(normalized)
+  if (addressKind === 0) return false
+
   const ipv4MappedAddress = getIpv4MappedAddress(normalized)
 
   if (ipv4MappedAddress) {
-    return /^127\./.test(ipv4MappedAddress)
+    return isIP(ipv4MappedAddress) === 4 && /^127\./.test(ipv4MappedAddress)
   }
 
   return (
-    normalized === 'localhost' ||
-    normalized.endsWith('.localhost') ||
-    /^127\./.test(normalized) ||
+    (addressKind === 4 && /^127\./.test(normalized)) ||
     normalized === '::1' ||
     normalized === '0:0:0:0:0:0:0:1'
   )
@@ -62,6 +69,9 @@ export function isLocalOrPrivateHost(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
   if (isLoopbackHost(normalized)) return true
 
+  const addressKind = isIP(normalized)
+  if (addressKind === 0) return false
+
   const ipv4MappedAddress = getIpv4MappedAddress(normalized)
   if (ipv4MappedAddress) {
     return (
@@ -70,11 +80,14 @@ export function isLocalOrPrivateHost(hostname: string): boolean {
     )
   }
 
-  if (PRIVATE_IPV4_RANGES.some((range) => range.test(normalized))) {
+  if (
+    addressKind === 4 &&
+    PRIVATE_IPV4_RANGES.some((range) => range.test(normalized))
+  ) {
     return true
   }
 
-  if (!normalized.includes(':')) return false
+  if (addressKind !== 6) return false
 
   const firstHextet = Number.parseInt(normalized.split(':')[0], 16)
   if (!Number.isFinite(firstHextet)) return false


### PR DESCRIPTION
## 改善

- 設定画面のフッター表記を `ver. 2.59.0` に更新しました。

## バグ修正

- デフォルトの `AITUBERKIT_SERVER_SECRET_ACCESS_MODE=disabled` で、ローカルVOICEVOXのボイステストが403になる問題を修正しました。
- Next.jsがローカル直アクセスにも補完する `X-Forwarded-For` / `X-Forwarded-Host` を、値がすべてループバックの場合のみ許可するようにしました。
- 転送ヘッダーの空要素、不正なIP・ホスト、`127.attacker.example`のようなループバック偽装値をfail-closedで拒否するようにしました。
- 外部IPや非ループバックホストを含むプロキシ経由の要求は、引き続き403で拒否します。

## テスト

- Next.jsの自動付与ヘッダーを再現するVOICEVOX回帰テストを追加しました。
- 空・不正・偽装された転送ヘッダーと、IP接頭辞を持つ外部ホストに対する境界テストを追加しました。
- VOICEVOX音声合成、話者一覧更新、URLガード、共通アクセスポリシーの関連テスト69件が成功しています。
- 実際のNext.js開発サーバーとローカルVOICEVOXを使用し、デフォルト設定で `200 / audio/wav`、偽装値を含む要求で `403` になることを確認しました。
- `npm run build` の成功を確認しました。

## ドキュメント・翻訳

- ローカルループバック接続で許容する転送ヘッダーと、プロキシ経由として拒否する条件をアクセス制御設計へ追記しました。
