### PR TITLE
fix: LM Studioのマシン名接続を復旧

### DIFF
--- a/.agents/skills/develop-main-release/SKILL.md
+++ b/.agents/skills/develop-main-release/SKILL.md
@@ -21,11 +21,12 @@ aituber-kitで `develop => main` PRをマージし、新しいマイナーバー
 
 ```markdown
 ## vX.Y.0
+
 - XXXを改善
   - XXXに対応
   - XXXを修正
 - XXXを追加
-https://github.com/tegnike/aituber-kit/releases/tag/vX.Y.0
+  https://github.com/tegnike/aituber-kit/releases/tag/vX.Y.0
 ```
 
 ## 手順

--- a/docs/access-policy-design.md
+++ b/docs/access-policy-design.md
@@ -185,7 +185,7 @@ function withAccessPolicy(
    - env設定URL（`envVar`）が存在してパース不能 → 400（現行 `tts-voicevox.ts` の挙動を保存 — レビューm8）
    - クライアント提供URLを `isHttpUrl` で検証 → 不正は400
    - `isAllowedConfiguredOrListedUrl` で `isProtectedServerResource` / `isAllowedPublicUrl` を判定 → 許可外のpublic URLは400
-   - LM Studio / Ollamaは、プライベートIPに加えて単一ラベルのLANマシン名と`.local` mDNS名も保護対象URLとして扱う。公開FQDNはallowlist未登録なら400
+   - LM Studio / Ollamaは、プライベートIPに加えて単一ラベルのLANマシン名、`.local` mDNS名、同一マシンのOSホスト名も保護対象URLとして扱う。それ以外の公開FQDNはallowlist未登録なら400
 5. **server-secret**:
    - `kind: 'pairs'`: `computeUsesServerSecret(pairs)` または `isProtectedServerResource` が真なら `guardServerSecretAccess()`
    - `kind: 'always'`: 無条件で `guardServerSecretAccess()`

--- a/docs/access-policy-design.md
+++ b/docs/access-policy-design.md
@@ -185,11 +185,12 @@ function withAccessPolicy(
    - env設定URL（`envVar`）が存在してパース不能 → 400（現行 `tts-voicevox.ts` の挙動を保存 — レビューm8）
    - クライアント提供URLを `isHttpUrl` で検証 → 不正は400
    - `isAllowedConfiguredOrListedUrl` で `isProtectedServerResource` / `isAllowedPublicUrl` を判定 → 許可外のpublic URLは400
+   - LM Studio / Ollamaは、プライベートIPに加えて単一ラベルのLANマシン名と`.local` mDNS名も保護対象URLとして扱う。公開FQDNはallowlist未登録なら400
 5. **server-secret**:
    - `kind: 'pairs'`: `computeUsesServerSecret(pairs)` または `isProtectedServerResource` が真なら `guardServerSecretAccess()`
    - `kind: 'always'`: 無条件で `guardServerSecretAccess()`
    - `kind: 'dynamic'`: ここでは何もしない。ルートが `gate.guardServerSecret()` を呼ぶ（呼んでいることを静的テストで強制 — §7.2-3）。動的な接続先URLを扱うルートは、検証済みURLを `allowLocalLoopbackUrl` として渡せる
-   - ただし `allowLocalLoopback` を宣言したルートは、`disabled` かつリクエスト元Host・ソケット接続元・接続先URLがすべてループバックの場合のみガードを省略する。Next.jsが直接接続にも補完する `X-Forwarded-For` / `X-Forwarded-Host` は、値がすべてループバックの場合に限り許容する
+   - ただし `allowLocalLoopback` を宣言したルートは、`disabled` かつリクエスト元Host・ソケット接続元がループバックで、接続先URLが同一マシン（ループバック、NICのIP、OSホスト名）を指す場合のみガードを省略する。Next.jsが直接接続にも補完する `X-Forwarded-For` / `X-Forwarded-Host` は、値がすべてループバックの場合に限り許容する
    - 外部IPを含む `X-Forwarded-For`、非ループバックの `X-Forwarded-Host`、Next.jsが補完しない `Forwarded` / `X-Real-IP` / `CF-Connecting-IP` がある場合はプロキシ経由と判断して例外を無効化する。リバースプロキシ環境では `protected` / `demo` / `unprotected` の明示的な運用モードを使用する
 6. すべて通過 → `handler(req, res, gate)` を実行
 

--- a/src/__tests__/lib/api-services/serverUrlGuard.test.ts
+++ b/src/__tests__/lib/api-services/serverUrlGuard.test.ts
@@ -1,6 +1,8 @@
 import {
+  isLocalLlmHost,
   isLocalOrPrivateHost,
   isLoopbackHost,
+  isSameMachineHost,
 } from '@/lib/api-services/serverUrlGuard'
 
 describe('serverUrlGuard', () => {
@@ -45,6 +47,58 @@ describe('serverUrlGuard', () => {
     it('does not treat IP-prefixed hostnames as private addresses', () => {
       expect(isLocalOrPrivateHost('127.attacker.example')).toBe(false)
       expect(isLocalOrPrivateHost('192.168.attacker.example')).toBe(false)
+    })
+  })
+
+  describe('isLocalLlmHost', () => {
+    it('accepts LAN machine names used by LM Studio and Ollama', () => {
+      expect(isLocalLlmHost('STUDIO-PC')).toBe(true)
+      expect(isLocalLlmHost('studio-mac.local')).toBe(true)
+      expect(isLocalLlmHost('studio-mac.local.')).toBe(true)
+    })
+
+    it('keeps public hostnames outside the local LLM boundary', () => {
+      expect(isLocalLlmHost('llm.example.com')).toBe(false)
+      expect(isLocalLlmHost('127.attacker.example')).toBe(false)
+      expect(isLocalLlmHost('')).toBe(false)
+    })
+  })
+
+  describe('isSameMachineHost', () => {
+    const machineHostname = 'studio-pc.local'
+    const localInterfaceAddresses = ['192.168.1.20', 'fe80::1234']
+
+    it('accepts the OS hostname, its short name, and local interface addresses', () => {
+      expect(
+        isSameMachineHost(
+          'studio-pc.local',
+          machineHostname,
+          localInterfaceAddresses
+        )
+      ).toBe(true)
+      expect(
+        isSameMachineHost('STUDIO-PC', machineHostname, localInterfaceAddresses)
+      ).toBe(true)
+      expect(
+        isSameMachineHost(
+          '192.168.1.20',
+          machineHostname,
+          localInterfaceAddresses
+        )
+      ).toBe(true)
+    })
+
+    it('rejects other LAN machine names and addresses', () => {
+      expect(
+        isSameMachineHost('other-pc', machineHostname, localInterfaceAddresses)
+      ).toBe(false)
+      expect(
+        isSameMachineHost(
+          '192.168.1.21',
+          machineHostname,
+          localInterfaceAddresses
+        )
+      ).toBe(false)
     })
   })
 })

--- a/src/__tests__/lib/api-services/serverUrlGuard.test.ts
+++ b/src/__tests__/lib/api-services/serverUrlGuard.test.ts
@@ -88,6 +88,16 @@ describe('serverUrlGuard', () => {
       ).toBe(true)
     })
 
+    it('accepts a .local alias when the OS hostname has no suffix', () => {
+      expect(
+        isSameMachineHost(
+          'studio-pc.local',
+          'STUDIO-PC',
+          localInterfaceAddresses
+        )
+      ).toBe(true)
+    })
+
     it('rejects other LAN machine names and addresses', () => {
       expect(
         isSameMachineHost('other-pc', machineHostname, localInterfaceAddresses)

--- a/src/__tests__/pages/api/vercel.test.ts
+++ b/src/__tests__/pages/api/vercel.test.ts
@@ -8,6 +8,11 @@ import { modifyMessages } from '@/lib/api-services/utils'
 import { createMocks } from 'node-mocks-http'
 import { hostname as getHostname } from 'node:os'
 
+jest.mock('node:os', () => ({
+  ...jest.requireActual('node:os'),
+  hostname: jest.fn(() => 'STUDIO-PC'),
+}))
+
 // テスト環境でResponseが未定義の場合のポリフィル
 if (typeof global.Response === 'undefined') {
   class MockResponse {
@@ -73,6 +78,7 @@ const mockGenerateAiText = generateAiText as jest.MockedFunction<
 const mockModifyMessages = modifyMessages as jest.MockedFunction<
   typeof modifyMessages
 >
+const mockGetHostname = getHostname as jest.MockedFunction<typeof getHostname>
 
 const originalEnv = { ...process.env }
 
@@ -82,6 +88,7 @@ describe('/api/ai/vercel handler', () => {
     process.env = { ...originalEnv }
     delete process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE
     delete process.env.AITUBERKIT_ALLOWED_LLM_SERVER_ORIGINS
+    mockGetHostname.mockReturnValue('STUDIO-PC')
     mockCreateAIRegistry.mockReturnValue(mockRegistry as any)
   })
 
@@ -212,37 +219,43 @@ describe('/api/ai/vercel handler', () => {
     }
   )
 
-  it('allows the same-machine LM Studio hostname by default', async () => {
-    mockModifyMessages.mockReturnValue([
-      { role: 'user', content: 'hello' },
-    ] as any)
-    mockGenerateAiText.mockResolvedValue(new Response('done', { status: 200 }))
-    const localLlmUrl = `http://${getHostname()}:1234/v1`
-    const { req, res } = createMocks({
-      method: 'POST',
-      headers: { host: 'localhost:3000' },
-      body: {
-        messages: [],
+  it.each(['STUDIO-PC', 'studio-pc.corp.example'])(
+    'allows the same-machine LM Studio hostname %s by default',
+    async (machineHostname) => {
+      mockGetHostname.mockReturnValue(machineHostname)
+      mockModifyMessages.mockReturnValue([
+        { role: 'user', content: 'hello' },
+      ] as any)
+      mockGenerateAiText.mockResolvedValue(
+        new Response('done', { status: 200 })
+      )
+      const localLlmUrl = `http://${getHostname()}:1234/v1`
+      const { req, res } = createMocks({
+        method: 'POST',
+        headers: { host: 'localhost:3000' },
+        body: {
+          messages: [],
+          apiKey: '',
+          aiService: 'lmstudio',
+          model: 'local-model',
+          localLlmUrl,
+          stream: false,
+          temperature: 1,
+          maxTokens: 10,
+        },
+      })
+      req.socket.remoteAddress = '127.0.0.1'
+
+      await handler(req as any, res as any)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(mockCreateAIRegistry).toHaveBeenCalledWith('lmstudio', {
         apiKey: '',
-        aiService: 'lmstudio',
-        model: 'local-model',
-        localLlmUrl,
-        stream: false,
-        temperature: 1,
-        maxTokens: 10,
-      },
-    })
-    req.socket.remoteAddress = '127.0.0.1'
-
-    await handler(req as any, res as any)
-
-    expect(res._getStatusCode()).toBe(200)
-    expect(mockCreateAIRegistry).toHaveBeenCalledWith('lmstudio', {
-      apiKey: '',
-      baseURL: localLlmUrl,
-      resourceName: '',
-    })
-  })
+        baseURL: localLlmUrl,
+        resourceName: '',
+      })
+    }
+  )
 
   it('rejects remote requests to local LLM loopback URLs by default', async () => {
     const { req, res } = createMocks({

--- a/src/__tests__/pages/api/vercel.test.ts
+++ b/src/__tests__/pages/api/vercel.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/api-services/vercelAi'
 import { modifyMessages } from '@/lib/api-services/utils'
 import { createMocks } from 'node-mocks-http'
+import { hostname as getHostname } from 'node:os'
 
 // テスト環境でResponseが未定義の場合のポリフィル
 if (typeof global.Response === 'undefined') {
@@ -211,6 +212,38 @@ describe('/api/ai/vercel handler', () => {
     }
   )
 
+  it('allows the same-machine LM Studio hostname by default', async () => {
+    mockModifyMessages.mockReturnValue([
+      { role: 'user', content: 'hello' },
+    ] as any)
+    mockGenerateAiText.mockResolvedValue(new Response('done', { status: 200 }))
+    const localLlmUrl = `http://${getHostname()}:1234/v1`
+    const { req, res } = createMocks({
+      method: 'POST',
+      headers: { host: 'localhost:3000' },
+      body: {
+        messages: [],
+        apiKey: '',
+        aiService: 'lmstudio',
+        model: 'local-model',
+        localLlmUrl,
+        stream: false,
+        temperature: 1,
+        maxTokens: 10,
+      },
+    })
+    req.socket.remoteAddress = '127.0.0.1'
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(200)
+    expect(mockCreateAIRegistry).toHaveBeenCalledWith('lmstudio', {
+      apiKey: '',
+      baseURL: localLlmUrl,
+      resourceName: '',
+    })
+  })
+
   it('rejects remote requests to local LLM loopback URLs by default', async () => {
     const { req, res } = createMocks({
       method: 'POST',
@@ -287,6 +320,68 @@ describe('/api/ai/vercel handler', () => {
       error: 'Local LLM URL is not allowed',
       errorCode: 'AIInvalidProperty',
     })
+    expect(mockCreateAIRegistry).not.toHaveBeenCalled()
+  })
+
+  it.each(['http://STUDIO-PC:1234/v1', 'http://studio-mac.local:1234/v1'])(
+    'allows LM Studio LAN machine-name URL %s',
+    async (localLlmUrl) => {
+      process.env.AITUBERKIT_SERVER_SECRET_ACCESS_MODE = 'unprotected'
+      mockModifyMessages.mockReturnValue([
+        { role: 'user', content: 'hi' },
+      ] as any)
+      mockGenerateAiText.mockResolvedValue(
+        new Response('done', { status: 200 })
+      )
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: {
+          messages: [],
+          apiKey: '',
+          aiService: 'lmstudio',
+          model: 'local-model',
+          localLlmUrl,
+          stream: false,
+          temperature: 1,
+          maxTokens: 10,
+        },
+      })
+
+      await handler(req as any, res as any)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(mockCreateAIRegistry).toHaveBeenCalledWith('lmstudio', {
+        apiKey: '',
+        baseURL: localLlmUrl,
+        resourceName: '',
+      })
+    }
+  )
+
+  it('guards LM Studio machine-name URLs as protected resources', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        messages: [],
+        apiKey: '',
+        aiService: 'lmstudio',
+        model: 'local-model',
+        localLlmUrl: 'http://STUDIO-PC:1234/v1',
+        stream: false,
+        temperature: 1,
+        maxTokens: 10,
+      },
+    })
+
+    await handler(req as any, res as any)
+
+    expect(res._getStatusCode()).toBe(403)
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        errorCode: 'ServerSecretAccessDenied',
+        feature: 'ai/vercel',
+      })
+    )
     expect(mockCreateAIRegistry).not.toHaveBeenCalled()
   })
 

--- a/src/lib/accessPolicy/guardLocalLlmUrl.ts
+++ b/src/lib/accessPolicy/guardLocalLlmUrl.ts
@@ -3,6 +3,7 @@ import type { PolicyGate } from '@/lib/accessPolicy/withAccessPolicy'
 import {
   isAllowedConfiguredOrListedUrl,
   isHttpUrl,
+  isLocalLlmHost,
 } from '@/lib/api-services/serverUrlGuard'
 
 export function guardLocalLlmUrl(
@@ -29,12 +30,16 @@ export function guardLocalLlmUrl(
     return false
   }
 
-  const { isProtectedServerResource, isAllowedPublicUrl } =
-    isAllowedConfiguredOrListedUrl(
-      parsedUrl,
-      undefined,
-      process.env.AITUBERKIT_ALLOWED_LLM_SERVER_ORIGINS || ''
-    )
+  const {
+    isProtectedServerResource: isProtectedByAddress,
+    isAllowedPublicUrl,
+  } = isAllowedConfiguredOrListedUrl(
+    parsedUrl,
+    undefined,
+    process.env.AITUBERKIT_ALLOWED_LLM_SERVER_ORIGINS || ''
+  )
+  const isProtectedServerResource =
+    isProtectedByAddress || isLocalLlmHost(parsedUrl.hostname)
 
   if (!isProtectedServerResource && !isAllowedPublicUrl) {
     res.status(400).json({

--- a/src/lib/accessPolicy/guardLocalLlmUrl.ts
+++ b/src/lib/accessPolicy/guardLocalLlmUrl.ts
@@ -4,6 +4,7 @@ import {
   isAllowedConfiguredOrListedUrl,
   isHttpUrl,
   isLocalLlmHost,
+  isSameMachineHost,
 } from '@/lib/api-services/serverUrlGuard'
 
 export function guardLocalLlmUrl(
@@ -39,7 +40,9 @@ export function guardLocalLlmUrl(
     process.env.AITUBERKIT_ALLOWED_LLM_SERVER_ORIGINS || ''
   )
   const isProtectedServerResource =
-    isProtectedByAddress || isLocalLlmHost(parsedUrl.hostname)
+    isProtectedByAddress ||
+    isLocalLlmHost(parsedUrl.hostname) ||
+    isSameMachineHost(parsedUrl.hostname)
 
   if (!isProtectedServerResource && !isAllowedPublicUrl) {
     res.status(400).json({

--- a/src/lib/accessPolicy/types.ts
+++ b/src/lib/accessPolicy/types.ts
@@ -69,7 +69,7 @@ export type ServerUrlPolicy = {
   key: string
   envVar: string
   defaultUrl: string
-  /** プロキシを介さない同一マシンのループバック接続に限り、disabledでも利用を許可する */
+  /** プロキシを介さない同一マシンのローカル接続に限り、disabledでも利用を許可する */
   allowLocalLoopback?: true
 }
 

--- a/src/lib/accessPolicy/withAccessPolicy.ts
+++ b/src/lib/accessPolicy/withAccessPolicy.ts
@@ -21,6 +21,7 @@ import {
   isAllowedConfiguredOrListedUrl,
   isHttpUrl,
   isLoopbackHost,
+  isSameMachineHost,
 } from '@/lib/api-services/serverUrlGuard'
 import {
   isRestrictedMode,
@@ -51,7 +52,7 @@ export interface PolicyGate {
   guardServerSecret(
     usesServerSecret: boolean,
     options?: {
-      /** 動的URLルートで、同一マシンのループバック接続だけdisabledでも許可する */
+      /** 動的URLルートで、同一マシンのローカル接続だけdisabledでも許可する */
       allowLocalLoopbackUrl?: URL
     }
   ): boolean
@@ -150,7 +151,7 @@ function isSameMachineLoopbackRequest(req: NextApiRequest): boolean {
   )
 }
 
-function allowsLocalLoopbackAccess(
+function allowsSameMachineAccess(
   policy: RoutePolicy,
   req: NextApiRequest,
   resolvedServerUrl: ResolvedServerUrl | undefined
@@ -159,7 +160,7 @@ function allowsLocalLoopbackAccess(
     policy.serverUrl?.allowLocalLoopback === true &&
     isServerSecretAccessDisabled() &&
     Boolean(resolvedServerUrl) &&
-    isLoopbackHost(resolvedServerUrl?.parsed.hostname || '') &&
+    isSameMachineHost(resolvedServerUrl?.parsed.hostname || '') &&
     isSameMachineLoopbackRequest(req)
   )
 }
@@ -244,7 +245,7 @@ export function withAccessPolicy(
 
     // 5. サーバー秘匿リソースガード
     let usesServerSecret = false
-    const allowsLocalLoopback = allowsLocalLoopbackAccess(
+    const allowsSameMachine = allowsSameMachineAccess(
       policy,
       req,
       resolvedServerUrl
@@ -252,7 +253,7 @@ export function withAccessPolicy(
     if (policy.secret.kind === 'pairs') {
       usesServerSecret = evaluateSecretPairs(req, policy.secret.pairs)
       const mustGuard =
-        !allowsLocalLoopback &&
+        !allowsSameMachine &&
         (usesServerSecret ||
           Boolean(resolvedServerUrl?.isProtectedServerResource))
       if (
@@ -264,7 +265,7 @@ export function withAccessPolicy(
     } else if (policy.secret.kind === 'always') {
       usesServerSecret = true
       if (
-        !allowsLocalLoopback &&
+        !allowsSameMachine &&
         !guardServerSecretAccess(req, res, { featureName: policy.featureName })
       ) {
         return
@@ -280,12 +281,12 @@ export function withAccessPolicy(
             `guardServerSecret() is only available for secret.kind === 'dynamic' routes (${policy.path})`
           )
         }
-        const allowsDynamicLocalLoopback =
+        const allowsDynamicSameMachine =
           Boolean(options?.allowLocalLoopbackUrl) &&
           isServerSecretAccessDisabled() &&
-          isLoopbackHost(options?.allowLocalLoopbackUrl?.hostname || '') &&
+          isSameMachineHost(options?.allowLocalLoopbackUrl?.hostname || '') &&
           isSameMachineLoopbackRequest(req)
-        if (allowsDynamicLocalLoopback) {
+        if (allowsDynamicSameMachine) {
           return true
         }
         if (!dynamicUsesServerSecret) {

--- a/src/lib/api-services/serverUrlGuard.ts
+++ b/src/lib/api-services/serverUrlGuard.ts
@@ -1,4 +1,5 @@
 import { isIP } from 'node:net'
+import { hostname as getHostname, networkInterfaces } from 'node:os'
 
 const PRIVATE_IPV4_RANGES = [
   /^10\./,
@@ -93,6 +94,61 @@ export function isLocalOrPrivateHost(hostname: string): boolean {
   if (!Number.isFinite(firstHextet)) return false
 
   return (firstHextet & 0xfe00) === 0xfc00 || (firstHextet & 0xffc0) === 0xfe80
+}
+
+/**
+ * LM Studio / Ollamaで使われるLAN内のホスト名を判定する。
+ *
+ * 単一ラベル名はOSのDNS検索サフィックスやNetBIOSで解決されるマシン名、
+ * `.local` はmDNS名として扱う。公開FQDNは許可しない。
+ */
+export function isLocalLlmHost(hostname: string): boolean {
+  const normalized = hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .replace(/\.$/, '')
+
+  if (!normalized) return false
+  if (isLocalOrPrivateHost(normalized)) return true
+  if (isIP(normalized) !== 0) return false
+
+  return !normalized.includes('.') || normalized.endsWith('.local')
+}
+
+function getLocalInterfaceAddresses(): string[] {
+  return Object.values(networkInterfaces()).flatMap((addresses) =>
+    (addresses || []).map(({ address }) => address.toLowerCase())
+  )
+}
+
+/** 同一マシンを指すループバック、NICのIPアドレス、OSホスト名を判定する。 */
+export function isSameMachineHost(
+  hostname: string,
+  machineHostname = getHostname(),
+  localInterfaceAddresses = getLocalInterfaceAddresses()
+): boolean {
+  const normalized = hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '')
+    .replace(/\.$/, '')
+  if (!normalized) return false
+  if (isLoopbackHost(normalized)) return true
+
+  if (isIP(normalized) !== 0) {
+    return localInterfaceAddresses.includes(normalized)
+  }
+
+  const normalizedMachineHostname = machineHostname
+    .toLowerCase()
+    .replace(/\.$/, '')
+  if (!normalizedMachineHostname) return false
+
+  const machineLabel = normalizedMachineHostname.split('.')[0]
+  return (
+    normalized === normalizedMachineHostname ||
+    normalized === machineLabel ||
+    normalized === `${machineLabel}.local`
+  )
 }
 
 export function isAllowedConfiguredOrListedUrl(


### PR DESCRIPTION
## Summary

- v2.60.0で追加されたローカルLLM URL検証が、プライベートIPは受理する一方でLANのマシン名を拒否していた問題を修正
- 単一ラベルのマシン名と .local 名をローカルLLM接続先として扱い、同一マシンのOSホスト名・短縮名・NIC IPにはVOICEVOXと同じローカル例外を適用
- 公開FQDNや別マシンを無条件には許可せず、既存のアクセス制御を維持
- 共通URLガードとAPIテスト、アクセス制御設計ドキュメントを更新

## Verification

- npm test -- --runInBand src/__tests__/lib/api-services/serverUrlGuard.test.ts src/__tests__/lib/accessPolicy/withAccessPolicy.test.ts src/__tests__/pages/api/vercel.test.ts src/__tests__/pages/api/youtube/continuation.test.ts src/__tests__/pages/api/tts-voicevox.test.ts
  - 5 suites / 100 tests passed
- npx eslint src/lib/api-services/serverUrlGuard.ts src/lib/accessPolicy/withAccessPolicy.ts src/lib/accessPolicy/types.ts src/__tests__/lib/api-services/serverUrlGuard.test.ts src/__tests__/pages/api/vercel.test.ts
  - passed
- npm run build
  - passed（既存のReact Hook・画像関連warningのみ）

## Notes

- デフォルトの同一マシン例外は、AITuberKitへのリクエスト元Hostとソケット接続元がループバックで、外部プロキシの証跡がない場合に限定しています
- 別PC上のLM Studioは、従来どおりサーバーアクセスモードなど既存の保護設定に従います
- 作業ツリーに元から存在する未追跡ファイルはPRに含めていません

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **機能改善**
  * ローカルLLM接続の判定を拡張し、同一マシンとしてホスト名・単一ラベルLAN名・`.local` を許可、公開FQDNは未許可なら拒否。
  * サーバー秘匿リソースのガード条件を「同一マシン」基準へ更新。
* **テスト**
  * 判定ケースと設定別挙動を追加。
* **ドキュメント**
  * アクセスポリシーの条件記載を更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->