### PR TITLE
Develop => main

### DIFF
--- a/src/__tests__/components/embedAppFocus.test.tsx
+++ b/src/__tests__/components/embedAppFocus.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+
+import { EmbedApp } from '@/components/embed/EmbedApp'
+
+jest.mock('next/head', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@/components/form', () => ({
+  Form: ({ focusOnMount }: { focusOnMount?: boolean }) => (
+    <div data-testid="embed-form" data-focus-on-mount={focusOnMount} />
+  ),
+}))
+
+jest.mock('@/components/assistantText', () => ({ AssistantText: () => null }))
+jest.mock('@/components/ImageOverlay', () => () => null)
+jest.mock('@/components/live2DViewer', () => () => null)
+jest.mock('@/components/memoryServiceInitializer', () => ({
+  MemoryServiceInitializer: () => null,
+}))
+jest.mock('@/components/modalImage', () => () => null)
+jest.mock('@/components/pngTuberViewer', () => () => null)
+jest.mock('@/components/toasts', () => ({ Toasts: () => null }))
+jest.mock('@/components/vrmViewer', () => () => null)
+
+jest.mock('@/features/embed/embedConfig', () => ({
+  getEmbedConfig: () => ({ id: 'default' }),
+  getEmbedOverridesFromSearchParams: () => ({}),
+  isEmbedOriginAllowed: () => true,
+  mergeEmbedConfig: (config: object) => config,
+  toPresetQuestions: (questions: unknown) => questions,
+}))
+
+jest.mock('@/features/stores/home', () => ({
+  __esModule: true,
+  default: Object.assign(
+    jest.fn((selector) =>
+      selector({
+        webcamStatus: false,
+        captureStatus: false,
+        backgroundImageUrl: 'green',
+        chatLog: [],
+      })
+    ),
+    {
+      getInitialState: jest.fn(() => ({ backgroundImageUrl: 'green' })),
+      setState: jest.fn(),
+    }
+  ),
+}))
+
+jest.mock('@/features/stores/settings', () => ({
+  __esModule: true,
+  default: Object.assign(
+    jest.fn((selector) =>
+      selector({
+        useVideoAsBackground: false,
+        modelType: 'vrm',
+        showAssistantText: false,
+      })
+    ),
+    {
+      getInitialState: jest.fn(() => ({
+        characterName: 'Character',
+        userDisplayName: 'User',
+        systemPrompt: '',
+        modelType: 'vrm',
+        selectedVrmPath: '',
+        selectedLive2DPath: '',
+        selectedPNGTuberPath: '',
+        showAssistantText: false,
+        showCharacterName: true,
+        showPresetQuestions: false,
+        presetQuestions: [],
+        colorTheme: 'default',
+      })),
+      setState: jest.fn(),
+    }
+  ),
+}))
+
+jest.mock('@/hooks/useLive2DEnabled', () => ({
+  useLive2DEnabled: () => ({ isLive2DEnabled: false }),
+}))
+jest.mock('@/features/presets/usePresetLoader', () => ({
+  usePresetLoader: () => undefined,
+}))
+jest.mock('@/utils/assistantMessageUtils', () => ({
+  getLatestAssistantMessage: () => null,
+}))
+jest.mock('@/utils/buildUrl', () => ({ buildUrl: (value: string) => value }))
+jest.mock('@/lib/i18n', () => ({}))
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+describe('EmbedApp focus contract', () => {
+  it('disables initial input focus for the embedded form', async () => {
+    const { getByTestId } = render(<EmbedApp embedId="default" />)
+
+    await waitFor(() => expect(getByTestId('embed-form')).toBeInTheDocument())
+    expect(getByTestId('embed-form')).toHaveAttribute(
+      'data-focus-on-mount',
+      'false'
+    )
+  })
+})

--- a/src/__tests__/components/messageInputFocus.test.tsx
+++ b/src/__tests__/components/messageInputFocus.test.tsx
@@ -123,6 +123,37 @@ describe('MessageInput focus contract', () => {
     expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
   })
 
+  it('focuses non-touch desktop browsers that expose touch event APIs', () => {
+    Object.defineProperty(window, 'ontouchstart', {
+      configurable: true,
+      value: null,
+    })
+
+    render(<MessageInput {...defaultProps} />)
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('does not clear a draft when focusOnMount changes after mounting', () => {
+    const { getByTestId, rerender } = render(
+      <MessageInput {...defaultProps} focusOnMount={false} />
+    )
+    rerender(
+      <MessageInput
+        {...defaultProps}
+        userMessage="draft"
+        focusOnMount={false}
+      />
+    )
+
+    rerender(
+      <MessageInput {...defaultProps} userMessage="draft" focusOnMount={true} />
+    )
+
+    expect(getByTestId('chat-message-input')).toHaveValue('draft')
+    expect(focusSpy).not.toHaveBeenCalled()
+  })
+
   it('restores focus after chat processing even when mount focus is disabled', () => {
     mockChatProcessing = true
     const { rerender } = render(

--- a/src/__tests__/components/messageInputFocus.test.tsx
+++ b/src/__tests__/components/messageInputFocus.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { MessageInput } from '@/components/messageInput'
+
+let mockChatProcessing = false
+
+type MockIconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  'data-testid'?: string
+}
+
+jest.mock('@/features/stores/home', () => ({
+  __esModule: true,
+  default: jest.fn((selector) =>
+    selector({
+      chatProcessing: mockChatProcessing,
+      modalImage: '',
+    })
+  ),
+}))
+
+jest.mock('@/features/stores/settings', () => ({
+  __esModule: true,
+  default: jest.fn((selector) =>
+    selector({
+      selectAIService: 'openai',
+      selectAIModel: 'gpt-4o',
+      imageDisplayPosition: 'input',
+      enableMultiModal: false,
+      customModel: '',
+      realtimeAPIMode: false,
+      showSilenceProgressBar: false,
+    })
+  ),
+}))
+
+jest.mock('@/features/stores/slide', () => ({
+  __esModule: true,
+  default: jest.fn((selector) => selector({ isPlaying: false })),
+}))
+
+jest.mock('@/hooks/useKioskMode', () => ({
+  useKioskMode: () => ({
+    isKioskMode: false,
+    validateInput: () => ({ valid: true }),
+    maxInputLength: undefined,
+  }),
+}))
+
+jest.mock('@/components/iconButton', () => ({
+  IconButton: (props: MockIconButtonProps) => (
+    <button
+      className={props.className}
+      disabled={props.disabled}
+      onClick={props.onClick}
+      data-testid={props['data-testid']}
+    />
+  ),
+}))
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt ?? ''} {...props} />
+  ),
+}))
+
+const defaultProps = {
+  userMessage: '',
+  isMicRecording: false,
+  onChangeUserMessage: jest.fn(),
+  onClickSendButton: jest.fn(),
+  onClickMicButton: jest.fn(),
+  onClickStopButton: jest.fn(),
+  isSpeaking: false,
+  silenceTimeoutRemaining: null,
+  continuousMicListeningMode: false,
+  onToggleContinuousMode: jest.fn(),
+}
+
+describe('MessageInput focus contract', () => {
+  let focusSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    mockChatProcessing = false
+    delete (window as Window & { ontouchstart?: unknown }).ontouchstart
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      configurable: true,
+      value: 0,
+    })
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: jest.fn(() => ({
+        matches: true,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    })
+    focusSpy = jest
+      .spyOn(HTMLTextAreaElement.prototype, 'focus')
+      .mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    focusSpy.mockRestore()
+  })
+
+  it('does not focus on initial mount when focusOnMount is false', () => {
+    render(<MessageInput {...defaultProps} focusOnMount={false} />)
+
+    expect(focusSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves initial focus for the normal screen by default', () => {
+    render(<MessageInput {...defaultProps} />)
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('restores focus after chat processing even when mount focus is disabled', () => {
+    mockChatProcessing = true
+    const { rerender } = render(
+      <MessageInput {...defaultProps} focusOnMount={false} />
+    )
+
+    expect(focusSpy).not.toHaveBeenCalled()
+
+    mockChatProcessing = false
+    rerender(<MessageInput {...defaultProps} focusOnMount={false} />)
+
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+})

--- a/src/components/embed/EmbedApp.tsx
+++ b/src/components/embed/EmbedApp.tsx
@@ -168,7 +168,7 @@ export const EmbedApp = ({ embedId }: Props) => {
         {showAssistantText && latestAssistantMessage && (
           <AssistantText message={latestAssistantMessage} />
         )}
-        <Form />
+        <Form focusOnMount={false} />
         <ModalImage />
         <Toasts />
         <MemoryServiceInitializer />

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -10,7 +10,11 @@ import { SlideText } from './slideText'
 import { isMultiModalAvailable } from '@/features/constants/aiModels'
 import { AIService } from '@/features/constants/settings'
 
-export const Form = () => {
+type Props = {
+  focusOnMount?: boolean
+}
+
+export const Form = ({ focusOnMount = true }: Props) => {
   const modalImage = homeStore((s) => s.modalImage)
   const webcamStatus = homeStore((s) => s.webcamStatus)
   const captureStatus = homeStore((s) => s.captureStatus)
@@ -98,7 +102,10 @@ export const Form = () => {
   ) : (
     <>
       <PresetQuestionButtons onSelectQuestion={hookSendChat} />
-      <MessageInputContainer onChatProcessStart={hookSendChat} />
+      <MessageInputContainer
+        focusOnMount={focusOnMount}
+        onChatProcessStart={hookSendChat}
+      />
     </>
   )
 }

--- a/src/components/messageInput.tsx
+++ b/src/components/messageInput.tsx
@@ -66,6 +66,9 @@ export const MessageInput = ({
   const [inputValidationError, setInputValidationError] = useState<string>('')
   const [isSmallScreen, setIsSmallScreen] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  // Mount focus is an initialization contract; later prop changes must not
+  // retrigger the chat-processing effect or clear an in-progress draft.
+  const focusOnMountRef = useRef(focusOnMount)
   const previousChatProcessingRef = useRef<boolean | null>(null)
   const realtimeAPIMode = settingsStore((s) => s.realtimeAPIMode)
   const showSilenceProgressBar = settingsStore((s) => s.showSilenceProgressBar)
@@ -114,7 +117,6 @@ export const MessageInput = ({
       const isTouchDevice = () => {
         if (typeof window === 'undefined') return false
         return (
-          'ontouchstart' in window ||
           navigator.maxTouchPoints > 0 ||
           // @ts-expect-error: msMaxTouchPoints is IE-specific
           navigator.msMaxTouchPoints > 0
@@ -125,12 +127,12 @@ export const MessageInput = ({
 
       if (
         !isTouchDevice() &&
-        ((isInitialMount && focusOnMount) || hasCompletedProcessing)
+        ((isInitialMount && focusOnMountRef.current) || hasCompletedProcessing)
       ) {
         textareaRef.current.focus({ preventScroll: true })
       }
     }
-  }, [chatProcessing, focusOnMount])
+  }, [chatProcessing])
 
   // テキスト内容に基づいて適切な行数を計算
   const calculateRows = useCallback((text: string): number => {

--- a/src/components/messageInput.tsx
+++ b/src/components/messageInput.tsx
@@ -23,6 +23,7 @@ const FILE_VALIDATION = {
 } as const
 
 type Props = {
+  focusOnMount?: boolean
   userMessage: string
   isMicRecording: boolean
   onChangeUserMessage: (
@@ -38,6 +39,7 @@ type Props = {
 }
 
 export const MessageInput = ({
+  focusOnMount = true,
   userMessage,
   isMicRecording,
   onChangeUserMessage,
@@ -64,6 +66,7 @@ export const MessageInput = ({
   const [inputValidationError, setInputValidationError] = useState<string>('')
   const [isSmallScreen, setIsSmallScreen] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const previousChatProcessingRef = useRef<boolean | null>(null)
   const realtimeAPIMode = settingsStore((s) => s.realtimeAPIMode)
   const showSilenceProgressBar = settingsStore((s) => s.showSilenceProgressBar)
 
@@ -92,6 +95,9 @@ export const MessageInput = ({
   const showIconDisplay = modalImage && imageDisplayPosition === 'icon'
 
   useEffect(() => {
+    const previousChatProcessing = previousChatProcessingRef.current
+    previousChatProcessingRef.current = chatProcessing
+
     if (chatProcessing) {
       const interval = setInterval(() => {
         setLoadingDots((prev) => {
@@ -101,24 +107,30 @@ export const MessageInput = ({
       }, 200)
 
       return () => clearInterval(interval)
-    } else {
-      if (textareaRef.current) {
-        textareaRef.current.value = ''
-        const isTouchDevice = () => {
-          if (typeof window === 'undefined') return false
-          return (
-            'ontouchstart' in window ||
-            navigator.maxTouchPoints > 0 ||
-            // @ts-expect-error: msMaxTouchPoints is IE-specific
-            navigator.msMaxTouchPoints > 0
-          )
-        }
-        if (!isTouchDevice()) {
-          textareaRef.current.focus()
-        }
+    }
+
+    if (textareaRef.current) {
+      textareaRef.current.value = ''
+      const isTouchDevice = () => {
+        if (typeof window === 'undefined') return false
+        return (
+          'ontouchstart' in window ||
+          navigator.maxTouchPoints > 0 ||
+          // @ts-expect-error: msMaxTouchPoints is IE-specific
+          navigator.msMaxTouchPoints > 0
+        )
+      }
+      const isInitialMount = previousChatProcessing === null
+      const hasCompletedProcessing = previousChatProcessing === true
+
+      if (
+        !isTouchDevice() &&
+        ((isInitialMount && focusOnMount) || hasCompletedProcessing)
+      ) {
+        textareaRef.current.focus({ preventScroll: true })
       }
     }
-  }, [chatProcessing])
+  }, [chatProcessing, focusOnMount])
 
   // テキスト内容に基づいて適切な行数を計算
   const calculateRows = useCallback((text: string): number => {

--- a/src/components/messageInputContainer.tsx
+++ b/src/components/messageInputContainer.tsx
@@ -6,10 +6,14 @@ import { useVoiceRecognition } from '@/hooks/useVoiceRecognition'
 
 // 無音検出用の状態と変数を追加
 type Props = {
+  focusOnMount?: boolean
   onChatProcessStart: (text: string) => void
 }
 
-export const MessageInputContainer = ({ onChatProcessStart }: Props) => {
+export const MessageInputContainer = ({
+  focusOnMount = true,
+  onChatProcessStart,
+}: Props) => {
   const isSpeaking = homeStore((s) => s.isSpeaking)
   const continuousMicListeningMode = settingsStore(
     (s) => s.continuousMicListeningMode
@@ -42,6 +46,7 @@ export const MessageInputContainer = ({ onChatProcessStart }: Props) => {
 
   return (
     <MessageInput
+      focusOnMount={focusOnMount}
       userMessage={userMessage}
       isMicRecording={isListening}
       onChangeUserMessage={handleInputChange}

--- a/src/components/settings/shell/Footer.tsx
+++ b/src/components/settings/shell/Footer.tsx
@@ -1,7 +1,7 @@
 export const Footer = () => {
   return (
     <footer className="theme-surface-contrast shrink-0 border-t border-primary/20 py-1 text-center font-Montserrat text-xs">
-      powered by ChatVRM from Pixiv / ver. 2.61.0
+      powered by ChatVRM from Pixiv / ver. 2.62.0
     </footer>
   )
 }


### PR DESCRIPTION
## 改善

- 設定画面のフッター表記を`ver. 2.62.0`へ更新しました。

## バグ修正

- 埋め込みウィジェットの初回表示時に入力欄へ自動フォーカスし、親ページがiframe位置までスクロールする問題を修正しました。
- 通常画面の初回フォーカスを維持しつつ、会話処理完了時だけ非タッチ端末で入力欄へフォーカスを戻すようにしました。
- フォーカス時に`preventScroll`を使用し、タッチ端末判定を`maxTouchPoints`ベースへ改善しました。

## テスト

- 埋め込み初回の非フォーカス、通常画面の初回フォーカス、会話処理完了時のフォーカス復帰、ドラフト保持、デスクトップのタッチAPI誤検出をカバーする契約テストを追加しました。
- 関連テスト23件と`npm run build`の成功を確認しました。
- 修正PRでsecret検査、lint/format、unit test、E2E、production E2E、Cloudflare deployがすべて成功しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - チャット入力欄の初回フォーカスを制御できるようになりました。
  - 埋め込みフォームでは、表示時に入力欄へ自動フォーカスしないよう改善しました。
  - チャット処理完了後のフォーカス復元や、下書き内容の保持を改善しました。
  - タッチ環境でも適切に入力欄を扱えるようになりました。

- **その他**
  - フッターに表示されるバージョンを2.62.0へ更新しました。
  - フォーカス動作に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->