### PR TITLE
背景設定を永続化する

### DIFF
--- a/src/__tests__/components/embedAppFocus.test.tsx
+++ b/src/__tests__/components/embedAppFocus.test.tsx
@@ -40,12 +40,10 @@ jest.mock('@/features/stores/home', () => ({
       selector({
         webcamStatus: false,
         captureStatus: false,
-        backgroundImageUrl: 'green',
         chatLog: [],
       })
     ),
     {
-      getInitialState: jest.fn(() => ({ backgroundImageUrl: 'green' })),
       setState: jest.fn(),
     }
   ),
@@ -75,6 +73,7 @@ jest.mock('@/features/stores/settings', () => ({
         showPresetQuestions: false,
         presetQuestions: [],
         colorTheme: 'default',
+        backgroundImageUrl: 'green',
       })),
       setState: jest.fn(),
     }

--- a/src/__tests__/features/settings/settingsFile.test.ts
+++ b/src/__tests__/features/settings/settingsFile.test.ts
@@ -27,6 +27,7 @@ describe('settings file export and import', () => {
       characterName: 'ニケ',
       dynamicRetrievalThreshold: 0.7,
       showControlPanel: false,
+      backgroundImageUrl: 'green',
     })
   })
 
@@ -51,6 +52,7 @@ describe('settings file export and import', () => {
     expect(data.settings.characterName).toBe('ニケ')
     expect(data.settings.dynamicRetrievalThreshold).toBe(0.7)
     expect(data.settings.showControlPanel).toBe(false)
+    expect(data.settings.backgroundImageUrl).toBe('green')
     expect(data.settings).not.toHaveProperty('openaiKey')
     expect(data.settings).not.toHaveProperty('cartesiaApiKey')
     expect(data.settings).not.toHaveProperty('customApiHeaders')

--- a/src/__tests__/features/stores/settingsPersistence.test.ts
+++ b/src/__tests__/features/stores/settingsPersistence.test.ts
@@ -5,6 +5,8 @@ describe('settingsStore persistence', () => {
     process.env.NEXT_PUBLIC_ALWAYS_OVERRIDE_WITH_ENV_VARIABLES
   const originalShowInputForm = process.env.NEXT_PUBLIC_SHOW_INPUT_FORM
   const originalChatLogMode = process.env.NEXT_PUBLIC_CHAT_LOG_MODE
+  const originalBackgroundImagePath =
+    process.env.NEXT_PUBLIC_BACKGROUND_IMAGE_PATH
 
   const loadStore = () => {
     jest.resetModules()
@@ -25,6 +27,12 @@ describe('settingsStore persistence', () => {
       delete process.env.NEXT_PUBLIC_CHAT_LOG_MODE
     } else {
       process.env.NEXT_PUBLIC_CHAT_LOG_MODE = originalChatLogMode
+    }
+    if (originalBackgroundImagePath === undefined) {
+      delete process.env.NEXT_PUBLIC_BACKGROUND_IMAGE_PATH
+    } else {
+      process.env.NEXT_PUBLIC_BACKGROUND_IMAGE_PATH =
+        originalBackgroundImagePath
     }
   })
 
@@ -111,6 +119,7 @@ describe('settingsStore persistence', () => {
       showControlPanel: false,
       showInputForm: false,
       chatLogMode: 'hidden',
+      backgroundImageUrl: 'green',
     })
 
     const persisted = JSON.parse(localStorage.getItem(storageKey) ?? '{}')
@@ -119,6 +128,7 @@ describe('settingsStore persistence', () => {
     expect(persisted.state.showControlPanel).toBe(false)
     expect(persisted.state.showInputForm).toBe(false)
     expect(persisted.state.chatLogMode).toBe('hidden')
+    expect(persisted.state.backgroundImageUrl).toBe('green')
 
     const reloadedSettingsStore = loadStore()
     expect(reloadedSettingsStore.getState().cartesiaApiKey).toBe(
@@ -130,5 +140,6 @@ describe('settingsStore persistence', () => {
     expect(reloadedSettingsStore.getState().showControlPanel).toBe(false)
     expect(reloadedSettingsStore.getState().showInputForm).toBe(false)
     expect(reloadedSettingsStore.getState().chatLogMode).toBe('hidden')
+    expect(reloadedSettingsStore.getState().backgroundImageUrl).toBe('green')
   })
 })

--- a/src/components/embed/EmbedApp.tsx
+++ b/src/components/embed/EmbedApp.tsx
@@ -36,10 +36,13 @@ const applyEmbedConfig = (embedId?: string) => {
   const queryConfig = getEmbedOverridesFromSearchParams(params)
   const config = mergeEmbedConfig(baseConfig, queryConfig)
   const defaultSettings = settingsStore.getInitialState()
-  const defaultHome = homeStore.getInitialState()
 
   if (!isEmbedOriginAllowed(config, document.referrer)) {
-    return { allowed: false, id: config.id || embedId || '' }
+    return {
+      allowed: false,
+      id: config.id || embedId || '',
+      backgroundImageUrl: defaultSettings.backgroundImageUrl,
+    }
   }
 
   settingsStore.setState({
@@ -73,19 +76,18 @@ const applyEmbedConfig = (embedId?: string) => {
     config.colorTheme ?? defaultSettings.colorTheme
   )
 
-  homeStore.setState({
+  return {
+    allowed: true,
+    id: config.id || embedId || '',
     backgroundImageUrl:
-      config.backgroundImageUrl ?? defaultHome.backgroundImageUrl,
-  })
-
-  return { allowed: true, id: config.id || embedId || '' }
+      config.backgroundImageUrl ?? defaultSettings.backgroundImageUrl,
+  }
 }
 
 export const EmbedApp = ({ embedId }: Props) => {
   const { t } = useTranslation()
   const webcamStatus = homeStore((s) => s.webcamStatus)
   const captureStatus = homeStore((s) => s.captureStatus)
-  const backgroundImageUrl = homeStore((s) => s.backgroundImageUrl)
   const chatLog = homeStore((s) => s.chatLog)
   const useVideoAsBackground = settingsStore((s) => s.useVideoAsBackground)
   const modelType = settingsStore((s) => s.modelType)
@@ -95,6 +97,9 @@ export const EmbedApp = ({ embedId }: Props) => {
   const [isReady, setIsReady] = useState(false)
   const [isAllowed, setIsAllowed] = useState(true)
   const [resolvedEmbedId, setResolvedEmbedId] = useState(embedId || '')
+  const [backgroundImageUrl, setBackgroundImageUrl] = useState(
+    () => settingsStore.getInitialState().backgroundImageUrl
+  )
   const pageTitle = t('EmbedPageTitle')
   usePresetLoader()
 
@@ -104,6 +109,7 @@ export const EmbedApp = ({ embedId }: Props) => {
     const timeoutId = window.setTimeout(() => {
       setResolvedEmbedId(result.id)
       setIsAllowed(result.allowed)
+      setBackgroundImageUrl(result.backgroundImageUrl)
       setIsReady(true)
     }, 0)
 

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -516,26 +516,6 @@ export const Menu = () => {
         }}
         onChange={handleChangeVrmFile}
       />
-      <input
-        type="file"
-        className="hidden"
-        accept="image/*"
-        ref={(bgFileInput) => {
-          if (!bgFileInput) {
-            menuStore.setState({ bgFileInput: null })
-            return
-          }
-
-          menuStore.setState({ bgFileInput })
-        }}
-        onChange={(e) => {
-          const file = e.target.files?.[0]
-          if (file) {
-            const imageUrl = URL.createObjectURL(file)
-            homeStore.setState({ backgroundImageUrl: imageUrl })
-          }
-        }}
-      />
     </>
   )
 }

--- a/src/components/settings/based.tsx
+++ b/src/components/settings/based.tsx
@@ -46,7 +46,7 @@ const Based = () => {
   const [error, setError] = useState<string | null>(null)
   const [isUploading, setIsUploading] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
-  const backgroundImageUrl = homeStore((s) => s.backgroundImageUrl)
+  const backgroundImageUrl = settingsStore((s) => s.backgroundImageUrl)
 
   useEffect(() => {
     setIsLoading(true)
@@ -94,7 +94,7 @@ const Based = () => {
       }
 
       const { path } = await response.json()
-      homeStore.setState({ backgroundImageUrl: path })
+      settingsStore.setState({ backgroundImageUrl: path })
 
       // バックグラウンドリストを更新
       setIsLoading(true)
@@ -189,7 +189,7 @@ const Based = () => {
             value={backgroundImageUrl}
             onChange={(e) => {
               const path = e.target.value
-              homeStore.setState({ backgroundImageUrl: path })
+              settingsStore.setState({ backgroundImageUrl: path })
             }}
             disabled={isLoading || isUploading || isRestrictedMode}
           >

--- a/src/features/stores/home.ts
+++ b/src/features/stores/home.ts
@@ -38,7 +38,6 @@ export interface TransientState {
   incrementChatProcessingCount: () => void
   decrementChatProcessingCount: () => void
   upsertMessage: (message: Partial<Message>) => void
-  backgroundImageUrl: string
   modalImage: string
   triggerShutter: boolean
   webcamStatus: boolean
@@ -257,9 +256,6 @@ const homeStore = create<HomeState>()(
           return { chatLog: updatedChatLog }
         })
       },
-      backgroundImageUrl:
-        process.env.NEXT_PUBLIC_BACKGROUND_IMAGE_PATH ??
-        '/backgrounds/bg-c.png',
       modalImage: '',
       triggerShutter: false,
       webcamStatus: false,

--- a/src/features/stores/menu.ts
+++ b/src/features/stores/menu.ts
@@ -21,7 +21,6 @@ interface MenuState {
   showWebcam: boolean
   showCapture: boolean
   fileInput: HTMLInputElement | null
-  bgFileInput: HTMLInputElement | null
   slideVisible: boolean
   thumbnailVisible: boolean
   activeSettingsTab: SettingsTabKey
@@ -32,7 +31,6 @@ const menuStore = create<MenuState>((set, get) => ({
   showWebcam: false,
   showCapture: false,
   fileInput: null,
-  bgFileInput: null,
   slideVisible: false,
   thumbnailVisible: false,
   activeSettingsTab: 'quickStart',

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -258,6 +258,7 @@ interface General {
   useSearchGrounding: boolean
   dynamicRetrievalThreshold: number
   maxPastMessages: number
+  backgroundImageUrl: string
   useVideoAsBackground: boolean
   hideVideoDisplay: boolean
   temperature: number
@@ -615,6 +616,8 @@ const getInitialValuesFromEnv = (): SettingsState => ({
     0.3,
   maxPastMessages:
     parseInt(process.env.NEXT_PUBLIC_MAX_PAST_MESSAGES || '10') || 10,
+  backgroundImageUrl:
+    process.env.NEXT_PUBLIC_BACKGROUND_IMAGE_PATH || '/backgrounds/bg-c.png',
   useVideoAsBackground:
     process.env.NEXT_PUBLIC_USE_VIDEO_AS_BACKGROUND === 'true',
   hideVideoDisplay: process.env.NEXT_PUBLIC_HIDE_VIDEO_DISPLAY === 'true',
@@ -1241,6 +1244,7 @@ export const selectPersistedSettings = (state: SettingsState) => ({
   relaxedMotionGroup: state.relaxedMotionGroup,
   surprisedMotionGroup: state.surprisedMotionGroup,
   maxPastMessages: state.maxPastMessages,
+  backgroundImageUrl: state.backgroundImageUrl,
   useVideoAsBackground: state.useVideoAsBackground,
   hideVideoDisplay: state.hideVideoDisplay,
   showControlPanel: state.showControlPanel,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,7 @@ import { useLive2DEnabled } from '@/hooks/useLive2DEnabled'
 const Home = () => {
   const webcamStatus = homeStore((s) => s.webcamStatus)
   const captureStatus = homeStore((s) => s.captureStatus)
-  const backgroundImageUrl = homeStore((s) => s.backgroundImageUrl)
+  const backgroundImageUrl = settingsStore((s) => s.backgroundImageUrl)
   const useVideoAsBackground = settingsStore((s) => s.useVideoAsBackground)
   const bgUrl =
     (webcamStatus || captureStatus) && useVideoAsBackground


### PR DESCRIPTION
## Summary

- 背景選択を一時状態の `homeStore` から永続化対象の `settingsStore` へ移設
- グリーンバックやアップロード済み背景の選択をリロード後も復元し、設定バックアップにも含める
- 埋め込みページの背景指定はコンポーネント内の一時上書きとして維持し、通常設定への混入を防止
- 参照されていなかった旧背景ファイル入力と `bgFileInput` 状態を削除

## Verification

- `npm test -- --runInBand src/__tests__/features/stores/settingsPersistence.test.ts src/__tests__/features/settings/settingsFile.test.ts src/__tests__/components/embedAppFocus.test.tsx src/__tests__/features/stores/home.test.ts`（49件成功）
- 変更対象ファイルへの `npx eslint ...`（エラー0件、既存の `menu.tsx:85` 警告1件）
- `npm run build`
- 実ブラウザでグリーンバック選択後にリロードし、localStorageの `backgroundImageUrl` が `green`、描画色が `rgb(0, 255, 0)` のままであることを確認

## Notes

- 設定バックアップに含まれるのは背景の選択値・パスのみで、アップロード画像本体は含まれません。
- 作業ツリーに既存の `public/speakers_aivis.json`、`prtimes/`、`tmp/` がありますが、このPRには含めていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 背景画像の設定を保存できるようになり、次回起動時にも引き継がれます。
  * 埋め込み表示でも、設定した背景画像が適用されます。
  * 背景画像未設定時は、既定の背景画像が表示されます。

* **バグ修正**
  * 背景画像の変更内容が各画面で正しく反映されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->