### PR TITLE
汎用Receiver Registry APIを追加

### DIFF
--- a/docs/receiver-registry-api-spec.md
+++ b/docs/receiver-registry-api-spec.md
@@ -1,0 +1,184 @@
+# Receiver Registry API 仕様書
+
+## 1. 文書情報
+
+| 項目           | 内容                                    |
+| -------------- | --------------------------------------- |
+| 文書名         | AITuberKit Receiver Registry API 仕様書 |
+| ステータス     | Implemented                             |
+| 対象           | AITuberKit外部制御APIの実装者・利用者   |
+| 作成日         | 2026-08-04                              |
+| 対象バージョン | v2.69.0以降を想定                       |
+
+## 2. 目的
+
+AITuberKitを通常ブラウザ、OBS Browser Source、埋め込み画面などで複数起動した場合に、外部制御アプリケーションが次を実行できるようにする。
+
+1. 現在接続中の受信インスタンスを列挙する。
+2. 表示名、種別、対応機能、発話状態を確認する。
+3. 発話、チャット、停止、プレゼンテーション操作を特定インスタンスへ配送する。
+4. 既存の論理`clientId`を使う外部連携との後方互換性を維持する。
+
+本APIは特定Producerに依存しない。番組、ゲーム、展示、講義などの業務ロジックや選択ポリシーはAITuberKitへ持ち込まない。
+
+## 3. 非目標
+
+- 外部制御アプリケーションの受信先選択UI
+- 受信先の自動フェイルオーバーポリシー
+- Producer固有の表示名、番組名、キャラクター名の生成
+- Receiver情報のプロセス再起動をまたぐ永続化
+- サーバーレス・複数Nodeプロセス間でのReceiver Registry共有
+- ブラウザタブを閉じた後も同じ`receiverId`を再利用する保証
+
+## 4. 用語
+
+| 用語                 | 定義                                                                       |
+| -------------------- | -------------------------------------------------------------------------- |
+| Receiver             | 発話・チャット・プレゼンテーション命令を受信するAITuberKit画面インスタンス |
+| `receiverId`         | Receiverの一時的なルーティングID。ブラウザタブまたはOBSインスタンス単位    |
+| `configuredClientId` | AITuberKit設定に保存された論理クライアントID。複数Receiverで共有されうる   |
+| Legacy receiver      | `receiverId`導入前の`clientId`だけで動作する互換経路                       |
+| Producer             | AITuberKitを外部APIから制御するアプリケーション                            |
+
+## 5. 責務分離
+
+### 5.1 AITuberKit
+
+- Receiverごとの一時IDを生成する。
+- Receiverの接続状態を定期報告する。
+- 接続中Receiverを認証付きAPIで列挙する。
+- 指定されたReceiverのキューから命令を取得する。
+- 既存`clientId`経路を互換目的で維持する。
+
+### 5.2 Producer
+
+- どのReceiverを使用するか決定する。
+- 選択UI、選択履歴、フェイルオーバーを必要に応じて実装する。
+- 切断済みReceiverを選択し続けず、一覧を再取得する。
+- `capabilities`を確認してから機能を呼び出す。
+
+## 6. Receiver IDライフサイクル
+
+1. AITuberKit画面は初回起動時にランダムなセッションIDを生成する。
+2. セッションIDを`sessionStorage`へ保存し、同じタブの再読込では再利用する。
+3. `receiverId`は`aituber-receiver-<sessionId>`形式とする。
+4. タブを閉じて新規作成した場合、通常は新しい`receiverId`になる。
+5. Receiverは2秒間隔で状態を報告する。
+6. 最終報告から10秒を超えたReceiverは一覧から除外する。
+
+`receiverId`は永続的な端末IDではない。Producerは保存済みIDが一覧に存在しない場合、利用者へ再選択を促すか、自身のポリシーで別Receiverを選ぶ。
+
+## 7. Receiver能力
+
+| capability     | 意味                                                              |
+| -------------- | ----------------------------------------------------------------- |
+| `presentation` | 外部プレゼンテーションの登録済み資料を読込・制御できる            |
+| `speech`       | `/api/v1/speak`または`/api/v1/messages`による直接発話を受信できる |
+| `chat`         | `/api/v1/chat`または`ai_generate`メッセージを処理できる           |
+
+`speech`と`chat`はMessage Receiver設定が有効な場合だけ公開する。`presentation`は外部制御APIへ接続しているReceiverで公開する。
+
+## 8. Receiver一覧API
+
+### 8.1 リクエスト
+
+```http
+GET /api/v1/receivers/
+Authorization: Bearer <AITUBERKIT_API_KEY>
+```
+
+APIキー認証を必須とする。クエリ文字列のAPIキーは受け付けない。
+
+### 8.2 レスポンス
+
+```json
+{
+  "ok": true,
+  "receivers": [
+    {
+      "receiverId": "aituber-receiver-7be9e2c4-57de-4ddb-a808-e85da6fb2387",
+      "configuredClientId": "main-stage",
+      "displayName": "Chrome a6fb2387",
+      "kind": "browser",
+      "capabilities": ["presentation", "chat", "speech"],
+      "connected": true,
+      "isSpeaking": false,
+      "lastSeenAt": "2026-08-04T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+### 8.3 フィールド
+
+| フィールド           | 型                             | 説明                                           |
+| -------------------- | ------------------------------ | ---------------------------------------------- |
+| `receiverId`         | string                         | 外部APIの配送先に使用する一時ID                |
+| `configuredClientId` | string                         | AITuberKit設定由来の論理ID                     |
+| `displayName`        | string                         | 選択UI向けの補助表示名。永続識別には使用しない |
+| `kind`               | `browser` \| `obs` \| `legacy` | Receiver種別                                   |
+| `capabilities`       | string[]                       | 対応機能                                       |
+| `connected`          | true                           | 一覧掲載時点で接続中であることを示す           |
+| `isSpeaking`         | boolean                        | 現在発話中か                                   |
+| `lastSeenAt`         | ISO 8601 string                | 最終状態報告時刻                               |
+
+一覧順は`lastSeenAt`の降順とする。
+
+## 9. Receiverへの配送
+
+配送先を指定する既存v1 APIは`receiverId`を優先ルーティングパラメータとして受け付ける。イベントAPIの絞り込みにも`receiverId`を使用できる。
+
+```http
+POST /api/v1/speak/?receiverId=aituber-receiver-...
+GET /api/v1/presentation/status/?receiverId=aituber-receiver-...
+```
+
+JSON bodyを持つAPIでは次の形式も使用できる。
+
+```json
+{
+  "receiverId": "aituber-receiver-...",
+  "text": "このReceiverだけが発話します"
+}
+```
+
+互換性のため`clientId`も継続して受け付ける。両方が指定された場合は`receiverId`を優先する。
+
+優先順位は次のとおり。
+
+1. JSON bodyの`receiverId`
+2. JSON bodyの`clientId`
+3. queryの`receiverId`
+4. queryの`clientId`
+
+## 10. Legacy互換
+
+- 新しいAITuberKit画面はReceiver固有IDと従来の`configuredClientId`の両方をポーリングする。
+- Receiver固有のAssignmentが存在する場合、そのReceiverはLegacy Assignmentを処理しない。
+- 同一`configuredClientId`を共有するタブのうち、Legacy経路は既存のタブリーダーだけが処理する。
+- Receiver一覧に新形式Receiverが1件以上存在する場合、Legacy重複は一覧へ返さない。
+- 新形式Receiverが存在しない場合、旧クライアントの状態報告を`kind: legacy`として返してよい。
+- Producerは同一操作でReceiver経路とLegacy経路を混在させない。
+
+## 11. セキュリティ
+
+- Receiver一覧とv1制御APIは`AITUBERKIT_API_KEY`を必須とする。
+- `displayName`は信頼済みHTMLとして扱わない。
+- 状態報告から受け取る文字列は最大200文字へ制限する。
+- 公開レスポンスにはAIモデル名、音声エンジン、システムプロンプト、APIキーを含めない。
+- `receiverId`は認証情報ではない。IDを知っていてもAPIキーなしでは操作できない。
+
+## 12. 実装制約
+
+Receiver Registryは現在の`messageGateway`と同じNode.jsプロセス内メモリを使用する。複数プロセス構成やサーバーレス構成では共有されない。将来その構成をサポートする場合は、TTL付き共有ストアへ置き換える。
+
+## 13. Producer非依存要件
+
+AITuberKit本体へ次を追加してはならない。
+
+- Morning Show、番組、ニュース、ゲームなど特定Producerの名称
+- Producer固有の自動選択規則
+- Producer固有のReceiver表示順
+- 特定Producerだけに必要な永続化形式
+
+AITuberKitはReceiverの事実を公開し、選択判断はProducerへ委ねる。

--- a/docs/receiver-registry-api-spec.md
+++ b/docs/receiver-registry-api-spec.md
@@ -154,6 +154,8 @@ JSON bodyを持つAPIでは次の形式も使用できる。
 ## 10. Legacy互換
 
 - 新しいAITuberKit画面はReceiver固有IDと従来の`configuredClientId`の両方をポーリングする。
+- Receiver固有メッセージはAPIキー必須の`GET /api/v1/client/messages/?receiverId=...`から取得する。
+- Legacy経路だけは後方互換のため既存の`GET /api/messages/?clientId=...`を使用する。
 - Receiver固有のAssignmentが存在する場合、そのReceiverはLegacy Assignmentを処理しない。
 - 同一`configuredClientId`を共有するタブのうち、Legacy経路は既存のタブリーダーだけが処理する。
 - Receiver一覧に新形式Receiverが1件以上存在する場合、Legacy重複は一覧へ返さない。

--- a/src/__tests__/features/api/receiverRegistry.test.ts
+++ b/src/__tests__/features/api/receiverRegistry.test.ts
@@ -1,0 +1,50 @@
+import {
+  createReceiverDescriptor,
+  createReceiverId,
+  getReceiverCapabilities,
+  getReceiverDisplayName,
+  getReceiverKind,
+} from '@/features/api/receiverRegistry'
+
+describe('receiverRegistry', () => {
+  it('一時セッションIDからReceiver IDを生成する', () => {
+    expect(createReceiverId('session-1')).toBe('aituber-receiver-session-1')
+  })
+
+  it('ブラウザとOBSを汎用Receiver種別として識別する', () => {
+    expect(getReceiverKind('Mozilla/5.0 Chrome/140.0')).toBe('browser')
+    expect(getReceiverKind('Mozilla/5.0 OBS/31.0')).toBe('obs')
+    expect(
+      getReceiverDisplayName(
+        'Mozilla/5.0 Chrome/140.0',
+        'aituber-receiver-12345678'
+      )
+    ).toBe('Chrome 12345678')
+  })
+
+  it('Message Receiver設定に応じて能力を公開する', () => {
+    expect(getReceiverCapabilities(false)).toEqual(['presentation'])
+    expect(getReceiverCapabilities(true)).toEqual([
+      'presentation',
+      'chat',
+      'speech',
+    ])
+  })
+
+  it('Producer非依存のReceiver記述を生成する', () => {
+    expect(
+      createReceiverDescriptor(
+        'configured-stage',
+        'session-12345678',
+        'Mozilla/5.0 OBS/31.0',
+        true
+      )
+    ).toEqual({
+      receiverId: 'aituber-receiver-session-12345678',
+      configuredClientId: 'configured-stage',
+      displayName: 'OBS 12345678',
+      kind: 'obs',
+      capabilities: ['presentation', 'chat', 'speech'],
+    })
+  })
+})

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -150,7 +150,7 @@ describe('/api/v1 external API', () => {
 
   it('accepts receiverId as the preferred routing parameter', () => {
     const speak = require('@/pages/api/v1/speak').default
-    const messages = require('@/pages/api/messages').default
+    const messages = require('@/pages/api/v1/client/messages').default
     const speakRes = createMockRes()
 
     speak(
@@ -163,11 +163,22 @@ describe('/api/v1 external API', () => {
       speakRes
     )
 
+    const unauthenticatedRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { receiverId: 'aituber-receiver-tab-1' },
+      }),
+      unauthenticatedRes
+    )
+    expect(unauthenticatedRes._status).toBe(401)
+
     const messagesRes = createMockRes()
     messages(
       createMockReq({
         method: 'GET',
-        query: { clientId: 'aituber-receiver-tab-1' },
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { receiverId: 'aituber-receiver-tab-1' },
       }),
       messagesRes
     )
@@ -884,7 +895,7 @@ describe('/api/v1 external API', () => {
     ).toEqual(expect.arrayContaining(['presentation_loaded', 'slide_changed']))
   })
 
-  it('returns recent events as a JSON snapshot', () => {
+  it('falls back from an empty receiverId when filtering event snapshots', () => {
     const speak = require('@/pages/api/v1/speak').default
     const events = require('@/pages/api/v1/events').default
 
@@ -904,7 +915,8 @@ describe('/api/v1 external API', () => {
         method: 'GET',
         headers: { authorization: 'Bearer test-api-key' },
         query: {
-          receiverId: 'aituber-receiver-client1',
+          receiverId: '   ',
+          clientId: '  aituber-receiver-client1  ',
           snapshot: 'true',
         },
       }),

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -97,6 +97,87 @@ describe('/api/v1 external API', () => {
     })
   })
 
+  it('lists active receiver instances without exposing legacy duplicates', () => {
+    const { updateClientStatus } = require('@/features/api/messageGateway')
+    const receivers = require('@/pages/api/v1/receivers').default
+    const commonStatus = {
+      connected: true,
+      isSpeaking: false,
+      chatProcessing: false,
+      messageReceiverEnabled: true,
+    }
+
+    updateClientStatus('aituber-receiver-tab-1', {
+      ...commonStatus,
+      configuredClientId: 'stage',
+      receiverDisplayName: 'Chrome tab-1',
+      receiverKind: 'browser',
+      receiverCapabilities: ['presentation', 'chat', 'speech'],
+    })
+    updateClientStatus('stage', {
+      ...commonStatus,
+      configuredClientId: 'stage',
+      receiverDisplayName: 'AITuberKit legacy receiver',
+      receiverKind: 'legacy',
+    })
+
+    const res = createMockRes()
+    receivers(
+      createMockReq({
+        method: 'GET',
+        headers: { authorization: 'Bearer test-api-key' },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(200)
+    expect(res._json).toEqual({
+      ok: true,
+      receivers: [
+        expect.objectContaining({
+          receiverId: 'aituber-receiver-tab-1',
+          configuredClientId: 'stage',
+          displayName: 'Chrome tab-1',
+          kind: 'browser',
+          capabilities: ['presentation', 'chat', 'speech'],
+          connected: true,
+          isSpeaking: false,
+          lastSeenAt: expect.any(String),
+        }),
+      ],
+    })
+  })
+
+  it('accepts receiverId as the preferred routing parameter', () => {
+    const speak = require('@/pages/api/v1/speak').default
+    const messages = require('@/pages/api/messages').default
+    const speakRes = createMockRes()
+
+    speak(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { receiverId: 'aituber-receiver-tab-1' },
+        body: { text: 'receiver routed message' },
+      }),
+      speakRes
+    )
+
+    const messagesRes = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        query: { clientId: 'aituber-receiver-tab-1' },
+      }),
+      messagesRes
+    )
+
+    expect(speakRes._status).toBe(202)
+    expect((messagesRes._json as { messages: unknown[] }).messages).toEqual([
+      expect.objectContaining({ message: 'receiver routed message' }),
+    ])
+  })
+
   it('does not accept public env keys or query string API keys for v1 authentication', () => {
     delete process.env.AITUBERKIT_API_KEY
     process.env.NEXT_PUBLIC_AITUBERKIT_API_KEY = 'public-key'
@@ -811,7 +892,7 @@ describe('/api/v1 external API', () => {
       createMockReq({
         method: 'POST',
         headers: { authorization: 'Bearer test-api-key' },
-        query: { clientId: 'client1' },
+        query: { receiverId: 'aituber-receiver-client1' },
         body: { text: 'event source' },
       }),
       createMockRes()
@@ -822,7 +903,10 @@ describe('/api/v1 external API', () => {
       createMockReq({
         method: 'GET',
         headers: { authorization: 'Bearer test-api-key' },
-        query: { clientId: 'client1', snapshot: 'true' },
+        query: {
+          receiverId: 'aituber-receiver-client1',
+          snapshot: 'true',
+        },
       }),
       eventsRes
     )

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -596,9 +596,16 @@ const MessageReceiver = () => {
       }
       if (!settingsStore.getState().messageReceiverEnabled) return
       const lastTimestamp = lastTimestampsRef.current[targetId] ?? 0
+      const authHeaders = mode === 'receiver' ? getClientApiHeaders() : null
+      if (mode === 'receiver' && !authHeaders) return
       try {
+        const endpoint =
+          mode === 'receiver'
+            ? `/api/v1/client/messages/?lastTimestamp=${lastTimestamp}&receiverId=${encodeURIComponent(targetId)}`
+            : `/api/messages/?lastTimestamp=${lastTimestamp}&clientId=${encodeURIComponent(targetId)}`
         const response = await fetch(
-          `/api/messages/?lastTimestamp=${lastTimestamp}&clientId=${encodeURIComponent(targetId)}`
+          endpoint,
+          authHeaders ? { headers: authHeaders } : undefined
         )
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`)

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -32,6 +32,10 @@ import {
   createClientTabId,
   parseClientTabLease,
 } from '@/features/api/clientTabLeadership'
+import {
+  createReceiverDescriptor,
+  getReceiverCapabilities,
+} from '@/features/api/receiverRegistry'
 
 const CLIENT_TAB_LEASE_DURATION = 5000
 const CLIENT_TAB_LEASE_REFRESH_INTERVAL = 2000
@@ -94,7 +98,7 @@ const getClientApiHeaders = () => {
 }
 
 const MessageReceiver = () => {
-  const lastTimestampRef = useRef(0)
+  const lastTimestampsRef = useRef<Record<string, number>>({})
   const clientId = settingsStore((state) => state.clientId)
   const { isRestrictedMode } = useRestrictedMode()
   const handleSendChat = handleSendChatFn()
@@ -283,9 +287,32 @@ const MessageReceiver = () => {
     let failedPresentationKey: string | null = null
     let presentationRetryAttempt = 0
     let presentationRetryAfter = 0
-    const tabId = createClientTabId()
+    const receiverStorageKey = `aituber-kit-receiver:${clientId}`
+    let tabId = createClientTabId()
+    try {
+      const storedTabId = window.sessionStorage.getItem(receiverStorageKey)
+      if (storedTabId) {
+        tabId = storedTabId
+      } else {
+        window.sessionStorage.setItem(receiverStorageKey, tabId)
+      }
+    } catch {
+      // OBSなどsessionStorageが制限される環境では一時IDを使用する。
+    }
+    const receiver = createReceiverDescriptor(
+      clientId,
+      tabId,
+      navigator.userAgent,
+      settingsStore.getState().messageReceiverEnabled
+    )
+    const {
+      receiverId,
+      displayName: receiverDisplayName,
+      kind: receiverKind,
+    } = receiver
     const leaseKey = `aituber-kit-client-tab-leader:${clientId}`
     let isClientTabLeader = false
+    let receiverHasAssignment = false
 
     const readClientTabLease = () => {
       try {
@@ -422,8 +449,11 @@ const MessageReceiver = () => {
       }
     }
 
-    const reportStatus = async () => {
-      if (!isClientTabLeader) return
+    const reportStatus = async (
+      targetId: string,
+      mode: 'receiver' | 'legacy'
+    ) => {
+      if (mode === 'legacy' && !isClientTabLeader) return
       const authHeaders = getClientApiHeaders()
       if (!authHeaders) return
 
@@ -432,7 +462,7 @@ const MessageReceiver = () => {
 
       try {
         const response = await fetch(
-          `/api/v1/client/status/?clientId=${encodeURIComponent(clientId)}`,
+          `/api/v1/client/status/?receiverId=${encodeURIComponent(targetId)}`,
           {
             method: 'POST',
             headers: {
@@ -440,6 +470,23 @@ const MessageReceiver = () => {
               ...authHeaders,
             },
             body: JSON.stringify({
+              ...(mode === 'receiver'
+                ? {
+                    configuredClientId: clientId,
+                    receiverDisplayName,
+                    receiverKind,
+                    receiverCapabilities: getReceiverCapabilities(
+                      ss.messageReceiverEnabled
+                    ),
+                  }
+                : {
+                    configuredClientId: clientId,
+                    receiverDisplayName: 'AITuberKit legacy receiver',
+                    receiverKind: 'legacy',
+                    receiverCapabilities: getReceiverCapabilities(
+                      ss.messageReceiverEnabled
+                    ),
+                  }),
               connected: true,
               isSpeaking: hs.isSpeaking,
               activeSpeech: hs.activeSpeech,
@@ -457,7 +504,7 @@ const MessageReceiver = () => {
           throw new Error(`HTTP error! status: ${response.status}`)
         }
         const data = await response.json()
-        if (!isClientTabLeader) return
+        if (mode === 'legacy' && !isClientTabLeader) return
         if (data.assignmentError) {
           logger.error(
             'Error reading presentation assignment:',
@@ -465,27 +512,41 @@ const MessageReceiver = () => {
           )
           return
         }
-        await reconcileAssignment(data.assignment ?? null)
+        const assignment = data.assignment ?? null
+        if (mode === 'receiver') {
+          const previouslyAssigned = receiverHasAssignment
+          receiverHasAssignment = Boolean(assignment)
+          if (assignment || previouslyAssigned) {
+            await reconcileAssignment(assignment)
+          }
+        } else if (!receiverHasAssignment) {
+          await reconcileAssignment(assignment)
+        }
       } catch (error) {
         logger.error('Error reporting client status:', error)
       }
     }
 
-    const fetchCommands = async () => {
-      if (!isClientTabLeader) return
+    const fetchCommands = async (
+      targetId: string,
+      mode: 'receiver' | 'legacy'
+    ) => {
+      if (mode === 'legacy' && (!isClientTabLeader || receiverHasAssignment)) {
+        return
+      }
       const authHeaders = getClientApiHeaders()
       if (!authHeaders) return
 
       try {
         const response = await fetch(
-          `/api/v1/client/commands/?clientId=${encodeURIComponent(clientId)}`,
+          `/api/v1/client/commands/?receiverId=${encodeURIComponent(targetId)}`,
           { headers: authHeaders }
         )
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`)
         }
         const data = await response.json()
-        if (!isClientTabLeader) return
+        if (mode === 'legacy' && !isClientTabLeader) return
         const commands = (data.commands || []) as ReceivedCommand[]
         for (const command of commands) {
           if (command.command === 'stop') {
@@ -505,7 +566,7 @@ const MessageReceiver = () => {
             )
           } else if (command.command === 'presentation.control') {
             if (!presentationStore.getState().document) {
-              await reportStatus()
+              await reportStatus(targetId, mode)
             }
             const applied = applyPresentationControl(
               command.action,
@@ -519,29 +580,35 @@ const MessageReceiver = () => {
         }
 
         if (commands.length > 0) {
-          await reportStatus()
+          await reportStatus(targetId, mode)
         }
       } catch (error) {
         logger.error('Error fetching commands:', error)
       }
     }
 
-    const fetchMessages = async () => {
-      if (!isClientTabLeader) return
+    const fetchMessages = async (
+      targetId: string,
+      mode: 'receiver' | 'legacy'
+    ) => {
+      if (mode === 'legacy' && (!isClientTabLeader || receiverHasAssignment)) {
+        return
+      }
       if (!settingsStore.getState().messageReceiverEnabled) return
+      const lastTimestamp = lastTimestampsRef.current[targetId] ?? 0
       try {
         const response = await fetch(
-          `/api/messages/?lastTimestamp=${lastTimestampRef.current}&clientId=${encodeURIComponent(clientId)}`
+          `/api/messages/?lastTimestamp=${lastTimestamp}&clientId=${encodeURIComponent(targetId)}`
         )
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`)
         }
         const data = await response.json()
-        if (!isClientTabLeader) return
+        if (mode === 'legacy' && !isClientTabLeader) return
         if (data.messages && data.messages.length > 0) {
           const newLastTimestamp =
             data.messages[data.messages.length - 1].timestamp
-          lastTimestampRef.current = newLastTimestamp
+          lastTimestampsRef.current[targetId] = newLastTimestamp
           await speakMessage(data.messages)
         }
       } catch (error) {
@@ -558,7 +625,8 @@ const MessageReceiver = () => {
       if (isFetchingMessages) return
       isFetchingMessages = true
       try {
-        await fetchMessages()
+        await fetchMessages(receiverId, 'receiver')
+        await fetchMessages(clientId, 'legacy')
       } finally {
         isFetchingMessages = false
       }
@@ -568,21 +636,22 @@ const MessageReceiver = () => {
       if (isFetchingCommands) return
       isFetchingCommands = true
       try {
-        await fetchCommands()
+        await fetchCommands(receiverId, 'receiver')
+        await fetchCommands(clientId, 'legacy')
       } finally {
         isFetchingCommands = false
       }
     }
 
     const safeReportStatus = async () => {
-      if (!isClientTabLeader) return
       isStatusReportQueued = true
       if (isReportingStatus) return
       isReportingStatus = true
       try {
         while (isStatusReportQueued) {
           isStatusReportQueued = false
-          await reportStatus()
+          await reportStatus(receiverId, 'receiver')
+          await reportStatus(clientId, 'legacy')
         }
       } finally {
         isReportingStatus = false
@@ -591,7 +660,7 @@ const MessageReceiver = () => {
 
     const unsubscribePresentationStatus = presentationStore.subscribe(
       (state, previousState) => {
-        if (isClientTabLeader && state.updatedAt !== previousState.updatedAt) {
+        if (state.updatedAt !== previousState.updatedAt) {
           void safeReportStatus()
         }
       }
@@ -600,9 +669,8 @@ const MessageReceiver = () => {
     const unsubscribeSpeechStatus = homeStore.subscribe(
       (state, previousState) => {
         if (
-          isClientTabLeader &&
-          (state.isSpeaking !== previousState.isSpeaking ||
-            state.activeSpeech?.id !== previousState.activeSpeech?.id)
+          state.isSpeaking !== previousState.isSpeaking ||
+          state.activeSpeech?.id !== previousState.activeSpeech?.id
         ) {
           void safeReportStatus()
         }
@@ -645,6 +713,10 @@ const MessageReceiver = () => {
     window.addEventListener('storage', handleStorage)
     window.addEventListener('beforeunload', releaseClientTabLease)
     document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    void safeFetchCommands()
+    void safeFetchMessages()
+    void safeReportStatus()
 
     if (document.visibilityState === 'visible' && document.hasFocus()) {
       claimClientTabLeadership()

--- a/src/features/api/http.ts
+++ b/src/features/api/http.ts
@@ -47,10 +47,20 @@ export const getClientIdFromRequest = (
   req: NextApiRequest,
   bodyClientId?: unknown
 ): string => {
+  const bodyReceiverId = req.body?.receiverId
+  const queryReceiverId = req.query.receiverId
   const queryClientId = req.query.clientId
+  if (typeof bodyReceiverId === 'string') {
+    const trimmedBodyReceiverId = bodyReceiverId.trim()
+    if (trimmedBodyReceiverId) return trimmedBodyReceiverId
+  }
   if (typeof bodyClientId === 'string') {
     const trimmedBodyClientId = bodyClientId.trim()
     if (trimmedBodyClientId) return trimmedBodyClientId
+  }
+  if (typeof queryReceiverId === 'string') {
+    const trimmedQueryReceiverId = queryReceiverId.trim()
+    if (trimmedQueryReceiverId) return trimmedQueryReceiverId
   }
   if (typeof queryClientId === 'string') {
     const trimmedQueryClientId = queryClientId.trim()

--- a/src/features/api/messageGateway.ts
+++ b/src/features/api/messageGateway.ts
@@ -5,6 +5,10 @@ import type {
   PresentationControlAction,
   PresentationControlTarget,
 } from '@/features/presentation/presentationTypes'
+import type {
+  ReceiverCapability,
+  ReceiverKind,
+} from '@/features/api/receiverRegistry'
 
 export type MessageType = 'direct_send' | 'ai_generate' | 'user_input'
 
@@ -72,6 +76,10 @@ export type QueuedCommand =
 
 export interface ClientStatus {
   clientId: string
+  configuredClientId?: string
+  receiverDisplayName?: string
+  receiverKind?: ReceiverKind
+  receiverCapabilities?: ReceiverCapability[]
   connected: boolean
   isSpeaking: boolean
   activeSpeech?: { id: string; text: string } | null
@@ -83,6 +91,17 @@ export interface ClientStatus {
   externalLinkageMode?: boolean
   presentation?: PresentationActualState
   lastSeenAt: number
+}
+
+export interface ActiveReceiver {
+  receiverId: string
+  configuredClientId: string
+  displayName: string
+  kind: ReceiverKind
+  capabilities: ReceiverCapability[]
+  connected: true
+  isSpeaking: boolean
+  lastSeenAt: string
 }
 
 export interface ApiEvent {
@@ -144,6 +163,7 @@ export interface EnqueueMessagesParams {
 }
 
 const CLIENT_TIMEOUT = 1000 * 60 * 5
+const ACTIVE_RECEIVER_WINDOW = 1000 * 10
 const RESPONSE_CALLBACK_TIMEOUT = 1000 * 60 * 30
 const RECENT_EVENT_LIMIT = 100
 
@@ -531,6 +551,45 @@ export const updateClientStatus = (
 
 export const getClientStatus = (clientId: string): ClientStatus | null =>
   getGatewayState().statusesPerClient[clientId] ?? null
+
+const defaultReceiverCapabilities = (
+  status: ClientStatus
+): ReceiverCapability[] => [
+  'presentation',
+  ...(status.messageReceiverEnabled ? (['chat', 'speech'] as const) : []),
+]
+
+const toActiveReceiver = (status: ClientStatus): ActiveReceiver => ({
+  receiverId: status.clientId,
+  configuredClientId: status.configuredClientId ?? status.clientId,
+  displayName:
+    status.receiverDisplayName ??
+    `AITuberKit ${status.clientId.slice(-8) || status.clientId}`,
+  kind: status.receiverKind ?? 'legacy',
+  capabilities:
+    status.receiverCapabilities ?? defaultReceiverCapabilities(status),
+  connected: true,
+  isSpeaking: status.isSpeaking,
+  lastSeenAt: new Date(status.lastSeenAt).toISOString(),
+})
+
+export const listActiveReceivers = (now = Date.now()): ActiveReceiver[] => {
+  cleanupClientQueues()
+  const activeStatuses = Object.values(getGatewayState().statusesPerClient)
+    .filter(
+      (status) =>
+        status.connected && now - status.lastSeenAt <= ACTIVE_RECEIVER_WINDOW
+    )
+    .sort((left, right) => right.lastSeenAt - left.lastSeenAt)
+  const registeredReceivers = activeStatuses.filter(
+    (status) => status.receiverKind && status.receiverKind !== 'legacy'
+  )
+  return (
+    registeredReceivers.length > 0
+      ? registeredReceivers
+      : activeStatuses.filter((status) => status.receiverKind !== 'legacy')
+  ).map(toActiveReceiver)
+}
 
 export const getClientQueueSummary = (clientId: string) => {
   const queue = getQueueIfExists(clientId)

--- a/src/features/api/receiverRegistry.ts
+++ b/src/features/api/receiverRegistry.ts
@@ -1,0 +1,57 @@
+export const RECEIVER_ID_PREFIX = 'aituber-receiver-'
+
+export type ReceiverKind = 'browser' | 'obs' | 'legacy'
+
+export type ReceiverCapability = 'chat' | 'presentation' | 'speech'
+
+export interface ReceiverDescriptor {
+  receiverId: string
+  configuredClientId: string
+  displayName: string
+  kind: Exclude<ReceiverKind, 'legacy'>
+  capabilities: ReceiverCapability[]
+}
+
+export const createReceiverId = (sessionId: string) =>
+  `${RECEIVER_ID_PREFIX}${sessionId}`
+
+export const getReceiverKind = (
+  userAgent: string
+): Exclude<ReceiverKind, 'legacy'> =>
+  /OBS\//i.test(userAgent) ? 'obs' : 'browser'
+
+export const getReceiverDisplayName = (
+  userAgent: string,
+  receiverId: string
+) => {
+  const suffix = receiverId.slice(-8)
+  if (/OBS\//i.test(userAgent)) return `OBS ${suffix}`
+  if (/Edg\//.test(userAgent)) return `Edge ${suffix}`
+  if (/Chrome\//.test(userAgent)) return `Chrome ${suffix}`
+  if (/Firefox\//.test(userAgent)) return `Firefox ${suffix}`
+  if (/Safari\//.test(userAgent)) return `Safari ${suffix}`
+  return `Browser ${suffix}`
+}
+
+export const getReceiverCapabilities = (
+  messageReceiverEnabled: boolean
+): ReceiverCapability[] => [
+  'presentation',
+  ...(messageReceiverEnabled ? (['chat', 'speech'] as const) : []),
+]
+
+export const createReceiverDescriptor = (
+  configuredClientId: string,
+  sessionId: string,
+  userAgent: string,
+  messageReceiverEnabled: boolean
+): ReceiverDescriptor => {
+  const receiverId = createReceiverId(sessionId)
+  return {
+    receiverId,
+    configuredClientId,
+    displayName: getReceiverDisplayName(userAgent, receiverId),
+    kind: getReceiverKind(userAgent),
+    capabilities: getReceiverCapabilities(messageReceiverEnabled),
+  }
+}

--- a/src/lib/accessPolicy/routePolicies.ts
+++ b/src/lib/accessPolicy/routePolicies.ts
@@ -565,6 +565,15 @@ export const routePolicies = {
     restrictedBehavior: 'deny',
     requiresApiKey: true,
   },
+  '/api/v1/client/messages': {
+    path: '/api/v1/client/messages',
+    featureName: 'v1/client/messages',
+    methods: ['GET'],
+    resources: ['external-control'],
+    secret: { kind: 'none' },
+    restrictedBehavior: 'deny',
+    requiresApiKey: true,
+  },
   '/api/v1/client/status': {
     path: '/api/v1/client/status',
     featureName: 'v1/client/status',

--- a/src/lib/accessPolicy/routePolicies.ts
+++ b/src/lib/accessPolicy/routePolicies.ts
@@ -574,6 +574,15 @@ export const routePolicies = {
     restrictedBehavior: 'deny',
     requiresApiKey: true,
   },
+  '/api/v1/receivers': {
+    path: '/api/v1/receivers',
+    featureName: 'v1/receivers',
+    methods: ['GET'],
+    resources: ['external-control'],
+    secret: { kind: 'none' },
+    restrictedBehavior: 'deny',
+    requiresApiKey: true,
+  },
   '/api/v1/presentations/[presentationId]': {
     path: '/api/v1/presentations/[presentationId]',
     featureName: 'v1/presentations',

--- a/src/pages/api/v1/client/messages.ts
+++ b/src/pages/api/v1/client/messages.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { dequeueMessages } from '@/features/api/messageGateway'
+import { getClientIdFromRequest } from '@/features/api/http'
+import { withAccessPolicy } from '@/lib/accessPolicy/withAccessPolicy'
+import { routePolicies } from '@/lib/accessPolicy/routePolicies'
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  const clientId = getClientIdFromRequest(req)
+  if (!clientId) {
+    return res.status(400).json({ error: 'Client ID is required' })
+  }
+
+  return res.status(200).json({ messages: dequeueMessages(clientId) })
+}
+
+export default withAccessPolicy(
+  routePolicies['/api/v1/client/messages'],
+  handler
+)

--- a/src/pages/api/v1/client/status.ts
+++ b/src/pages/api/v1/client/status.ts
@@ -11,6 +11,10 @@ import type {
   PresentationActualState,
   PresentationPlaybackState,
 } from '@/features/presentation/presentationTypes'
+import type {
+  ReceiverCapability,
+  ReceiverKind,
+} from '@/features/api/receiverRegistry'
 
 const playbackStates: PresentationPlaybackState[] = [
   'unassigned',
@@ -21,6 +25,13 @@ const playbackStates: PresentationPlaybackState[] = [
   'section_paused',
   'completed',
   'error',
+]
+
+const receiverKinds: ReceiverKind[] = ['browser', 'obs', 'legacy']
+const receiverCapabilities: ReceiverCapability[] = [
+  'chat',
+  'presentation',
+  'speech',
 ]
 
 const normalizePresentationStatus = (
@@ -59,6 +70,23 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const status = updateClientStatus(clientId, {
+    configuredClientId:
+      typeof req.body?.configuredClientId === 'string'
+        ? req.body.configuredClientId.slice(0, 200)
+        : undefined,
+    receiverDisplayName:
+      typeof req.body?.receiverDisplayName === 'string'
+        ? req.body.receiverDisplayName.slice(0, 200)
+        : undefined,
+    receiverKind: receiverKinds.includes(req.body?.receiverKind)
+      ? req.body.receiverKind
+      : undefined,
+    receiverCapabilities: Array.isArray(req.body?.receiverCapabilities)
+      ? req.body.receiverCapabilities.filter(
+          (value: unknown): value is ReceiverCapability =>
+            receiverCapabilities.includes(value as ReceiverCapability)
+        )
+      : undefined,
     connected: req.body?.connected === true,
     isSpeaking: req.body?.isSpeaking === true,
     activeSpeech:

--- a/src/pages/api/v1/events.ts
+++ b/src/pages/api/v1/events.ts
@@ -15,7 +15,11 @@ const writeSseEvent = (res: NextApiResponse, event: ApiEvent) => {
 
 const handler = (req: NextApiRequest, res: NextApiResponse) => {
   const clientId =
-    typeof req.query.clientId === 'string' ? req.query.clientId : undefined
+    typeof req.query.receiverId === 'string'
+      ? req.query.receiverId
+      : typeof req.query.clientId === 'string'
+        ? req.query.clientId
+        : undefined
   const snapshot = req.query.snapshot === 'true'
 
   if (snapshot) {

--- a/src/pages/api/v1/events.ts
+++ b/src/pages/api/v1/events.ts
@@ -14,12 +14,11 @@ const writeSseEvent = (res: NextApiResponse, event: ApiEvent) => {
 }
 
 const handler = (req: NextApiRequest, res: NextApiResponse) => {
-  const clientId =
-    typeof req.query.receiverId === 'string'
-      ? req.query.receiverId
-      : typeof req.query.clientId === 'string'
-        ? req.query.clientId
-        : undefined
+  const receiverId =
+    typeof req.query.receiverId === 'string' ? req.query.receiverId.trim() : ''
+  const legacyClientId =
+    typeof req.query.clientId === 'string' ? req.query.clientId.trim() : ''
+  const clientId = receiverId || legacyClientId || undefined
   const snapshot = req.query.snapshot === 'true'
 
   if (snapshot) {

--- a/src/pages/api/v1/receivers.ts
+++ b/src/pages/api/v1/receivers.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { listActiveReceivers } from '@/features/api/messageGateway'
+import { withAccessPolicy } from '@/lib/accessPolicy/withAccessPolicy'
+import { routePolicies } from '@/lib/accessPolicy/routePolicies'
+
+const handler = (_req: NextApiRequest, res: NextApiResponse) =>
+  res.status(200).json({ ok: true, receivers: listActiveReceivers() })
+
+export default withAccessPolicy(routePolicies['/api/v1/receivers'], handler)


### PR DESCRIPTION
## Summary

- AITuberKitを開いているブラウザタブ・OBS Browser Sourceごとに一時的な`receiverId`を登録し、接続中Receiverを列挙する認証付き`GET /api/v1/receivers`を追加しました。
- 発話・チャット・停止・Presentation操作の既存APIで`receiverId`を優先配送先として受け付け、従来の`clientId`経路も後方互換として維持しました。
- Receiver固有経路と従来経路の二重処理を避けるタブリーダー互換処理、10秒TTL、capabilities、Producer非依存の責務境界を仕様書として追加しました。

## Verification

- `npm exec -- eslint`（変更したTypeScript/TSXファイル）
- `npm exec -- prettier --check`（変更ファイルと仕様書）
- `npm test -- --runInBand src/__tests__/features/api/clientTabLeadership.test.ts src/__tests__/features/api/receiverRegistry.test.ts src/__tests__/pages/api/v1/externalApi.test.ts`（3 suites / 30 tests passed）
- `npm run build`（成功、`/api/v1/receivers`の生成を確認）
- 全体テストは200 suites / 2205 testsが成功。既存の`src/__tests__/features/stores/images.test.ts`のみ、Nodeの`localStorage`未設定による14件の失敗があり、未変更の`develop`系worktreeでも単独再現することを確認済みです。

## Notes

- Registryは既存のmessage gatewayと同じNode.jsプロセス内メモリを使用します。複数プロセス・サーバーレス間の共有は本PRの対象外です。
- Receiver選択UIや自動フェイルオーバーなど、Producer固有の判断はAITuberKit側へ持ち込まず、外部アプリケーション側の責務としています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 接続中のReceiver一覧を取得するAPIを追加しました。
  * Receiverごとの種別、表示名、対応機能、発話状態、最終更新時刻を確認できます。
  * `receiverId`を優先したメッセージ配送に対応し、従来の`clientId`も引き続き利用できます。
  * Receiverの状態・能力情報を自動報告できるようになりました。
  * Receiver単位でメッセージを取得できるAPIを追加しました。

* **ドキュメント**
  * Receiver Registry APIの仕様書を追加しました。

* **セキュリティ**
  * Receiver関連APIにAPIキー認証とアクセス制御を適用しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->