### PR TITLE
Receiver通知をSSE化してストリーミング発話を高速化

### DIFF
--- a/docs/external-presentation-api-spec.md
+++ b/docs/external-presentation-api-spec.md
@@ -87,7 +87,7 @@ flowchart LR
   API["AITuberKit v1 API"]
   Storage["Presentation永続ストレージ"]
   Assignment["Client Assignment"]
-  Poller["messageReceiver / status poller"]
+  Receiver["messageReceiver / SSE subscriber"]
   Store["presentationStore"]
   Viewer["スライド表示・発話"]
   Chat["マイク入力・チャット"]
@@ -97,9 +97,9 @@ flowchart LR
   API --> Storage
   Producer -->|activate / control| API
   API --> Assignment
-  Poller -->|desired state取得| API
-  API -->|manifest| Poller
-  Poller --> Store
+  Receiver -->|desired state取得| API
+  API -->|event / manifest| Receiver
+  Receiver --> Store
   Store --> Viewer
   Chat --> LLM
   Store -->|active section brief| LLM
@@ -125,7 +125,7 @@ flowchart LR
 新しいWebSocketは追加しない。次の既存機構を拡張する。
 
 - `messageGateway.ts`のクライアント別コマンドキュー
-- `messageReceiver.tsx`のコマンドポーリング
+- `messageReceiver.tsx`のSSE通知と切断中のコマンドポーリング
 - `/api/v1/client/status`の状態報告
 - `/api/v1/events`のSSEイベント
 - 既存Access PolicyとAPIキー認証

--- a/docs/receiver-registry-api-spec.md
+++ b/docs/receiver-registry-api-spec.md
@@ -138,9 +138,15 @@ JSON bodyを持つAPIでは次の形式も使用できる。
 ```json
 {
   "receiverId": "aituber-receiver-...",
-  "text": "このReceiverだけが発話します"
+  "text": "このReceiverだけが発話します",
+  "speechSessionId": "answer-stream-1"
 }
 ```
+
+ストリーミング生成した回答を複数回の`/api/v1/speak`へ分ける場合は、
+同じ回答の全リクエストに共通の`speechSessionId`を指定する。Receiverは同じIDの
+発話を同一のSpeakQueueセッションへFIFOで追加し、後続文による先行キューの破棄を防ぐ。
+IDは1〜200文字とする。省略時は従来どおり、リクエストごとに独立した発話として扱う。
 
 互換性のため`clientId`も継続して受け付ける。両方が指定された場合は`receiverId`を優先する。
 
@@ -153,7 +159,12 @@ JSON bodyを持つAPIでは次の形式も使用できる。
 
 ## 10. Legacy互換
 
-- 新しいAITuberKit画面はReceiver固有IDと従来の`configuredClientId`の両方をポーリングする。
+- 新しいAITuberKit画面はReceiver固有IDと従来の`configuredClientId`の両方について、
+  認証付き`GET /api/v1/events/`を購読する。
+- `message_queued`を受信したらメッセージを、`command_queued`または`stop_requested`を
+  受信したらコマンドを即時取得する。SSE接続中は15秒ごとに取りこぼしを確認する。
+- SSEが切断している間だけ、メッセージとコマンドを1秒ごとにポーリングし、
+  250ミリ秒から最大5秒の指数バックオフでSSEへ再接続する。
 - Receiver固有メッセージはAPIキー必須の`GET /api/v1/client/messages/?receiverId=...`から取得する。
 - Legacy経路だけは後方互換のため既存の`GET /api/messages/?clientId=...`を使用する。
 - Receiver固有のAssignmentが存在する場合、そのReceiverはLegacy Assignmentを処理しない。

--- a/src/__tests__/features/api/receiverEventStream.test.ts
+++ b/src/__tests__/features/api/receiverEventStream.test.ts
@@ -31,6 +31,7 @@ describe('receiverEventStream', () => {
   }
 
   afterEach(() => {
+    jest.useRealTimers()
     jest.restoreAllMocks()
     if (originalFetch) {
       global.fetch = originalFetch
@@ -136,5 +137,33 @@ describe('receiverEventStream', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(errors).toHaveLength(1)
     expect(connectionChanges).toEqual([true, false])
+  })
+
+  it('直後に閉じる200応答で再接続待機を250ms、500ms、1秒へ増やす', async () => {
+    jest.useFakeTimers()
+    const controller = new AbortController()
+    const timeoutSpy = jest.spyOn(global, 'setTimeout')
+    const fetchMock = jest.fn().mockImplementation(async () => {
+      if (fetchMock.mock.calls.length === 4) controller.abort()
+      return createSseResponse([])
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const subscription = subscribeReceiverEventStream({
+      targetId: 'receiver-immediate-close',
+      headers: { Authorization: 'Bearer test-key' },
+      signal: controller.signal,
+      onWakeup: jest.fn(),
+    })
+
+    await jest.advanceTimersByTimeAsync(250)
+    await jest.advanceTimersByTimeAsync(500)
+    await jest.advanceTimersByTimeAsync(1_000)
+    await subscription
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(timeoutSpy.mock.calls.map((call) => call[1])).toEqual([
+      250, 500, 1_000,
+    ])
   })
 })

--- a/src/__tests__/features/api/receiverEventStream.test.ts
+++ b/src/__tests__/features/api/receiverEventStream.test.ts
@@ -1,0 +1,140 @@
+import {
+  createCoalescedRunner,
+  receiverWakeupForEvent,
+  subscribeReceiverEventStream,
+  type ReceiverWakeup,
+} from '@/features/api/receiverEventStream'
+
+describe('receiverEventStream', () => {
+  const originalFetch = global.fetch
+
+  const createSseResponse = (chunks: string[]) => {
+    let index = 0
+
+    return {
+      ok: true,
+      status: 200,
+      body: {
+        getReader: () => ({
+          read: jest.fn(async () => {
+            if (index >= chunks.length) {
+              return { done: true, value: undefined }
+            }
+
+            const value = new Uint8Array(Buffer.from(chunks[index]))
+            index += 1
+            return { done: false, value }
+          }),
+        }),
+      },
+    } as unknown as Response
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    if (originalFetch) {
+      global.fetch = originalFetch
+    } else {
+      delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch
+    }
+  })
+
+  it('発話とコマンドのキューイベントだけを即時取得トリガーへ変換する', () => {
+    expect(receiverWakeupForEvent('message_queued')).toBe('messages')
+    expect(receiverWakeupForEvent('command_queued')).toBe('commands')
+    expect(receiverWakeupForEvent('stop_requested')).toBe('commands')
+    expect(receiverWakeupForEvent('status_updated')).toBeNull()
+  })
+
+  it('処理中に重なった通知を捨てず、1回の再実行へまとめる', async () => {
+    let releaseFirstRun: (() => void) | undefined
+    const firstRunGate = new Promise<void>((resolve) => {
+      releaseFirstRun = resolve
+    })
+    const task = jest
+      .fn<Promise<void>, []>()
+      .mockImplementationOnce(() => firstRunGate)
+      .mockResolvedValue(undefined)
+    const run = createCoalescedRunner(task)
+
+    const first = run()
+    const second = run()
+    const third = run()
+
+    expect(second).toBe(first)
+    expect(third).toBe(first)
+    expect(task).toHaveBeenCalledTimes(1)
+
+    releaseFirstRun?.()
+    await first
+
+    expect(task).toHaveBeenCalledTimes(2)
+  })
+
+  it('認証付きSSEの分割chunkを読み、Receiverの取得処理を起こす', async () => {
+    const controller = new AbortController()
+    const wakeups: ReceiverWakeup[] = []
+    const connectionChanges: boolean[] = []
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(
+        createSseResponse([
+          ': connected\n\nevent: message_',
+          'queued\ndata: {"type":"message_queued"}\n\n' +
+            'event: status_updated\ndata: {}\n\n' +
+            'event: command_queued\ndata: {"type":"command_queued"}\n\n',
+        ])
+      )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await subscribeReceiverEventStream({
+      targetId: 'receiver-1',
+      headers: { Authorization: 'Bearer test-key' },
+      signal: controller.signal,
+      onWakeup: (wakeup) => {
+        wakeups.push(wakeup)
+        if (wakeups.length === 2) controller.abort()
+      },
+      onConnectionChange: (connected) => connectionChanges.push(connected),
+    })
+
+    expect(wakeups).toEqual(['messages', 'commands'])
+    expect(connectionChanges).toEqual([true, false])
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/events/?receiverId=receiver-1',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer test-key',
+          Accept: 'text/event-stream',
+        },
+        signal: controller.signal,
+      })
+    )
+  })
+
+  it('切断後に再接続し、フォールバック可能な接続状態を通知する', async () => {
+    const controller = new AbortController()
+    const errors: unknown[] = []
+    const connectionChanges: boolean[] = []
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary disconnect'))
+      .mockResolvedValueOnce(
+        createSseResponse(['event: message_queued\ndata: {}\n\n'])
+      )
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await subscribeReceiverEventStream({
+      targetId: 'receiver-2',
+      headers: { Authorization: 'Bearer test-key' },
+      signal: controller.signal,
+      onWakeup: () => controller.abort(),
+      onConnectionChange: (connected) => connectionChanges.push(connected),
+      onError: (error) => errors.push(error),
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(errors).toHaveLength(1)
+    expect(connectionChanges).toEqual([true, false])
+  })
+})

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -242,6 +242,7 @@ describe('/api/v1 external API', () => {
           text: 'hello from v1',
           emotion: 'happy',
           priority: 'high',
+          speechSessionId: 'answer-stream-1',
         },
       }),
       speakRes
@@ -271,6 +272,7 @@ describe('/api/v1 external API', () => {
         message: 'hello from v1',
         type: 'direct_send',
         emotion: 'happy',
+        speechSessionId: 'answer-stream-1',
         priority: 'high',
         source: 'v1',
       })

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -279,6 +279,45 @@ describe('/api/v1 external API', () => {
     )
   })
 
+  it('同一発話セッションの高優先度チャンクをFIFOで取得する', () => {
+    const speak = require('@/pages/api/v1/speak').default
+    const messages = require('@/pages/api/v1/client/messages').default
+    const enqueue = (text: string, speechSessionId: string) =>
+      speak(
+        createMockReq({
+          method: 'POST',
+          headers: { authorization: 'Bearer test-api-key' },
+          query: { clientId: 'client1' },
+          body: { text, priority: 'high', speechSessionId },
+        }),
+        createMockRes()
+      )
+
+    enqueue('先に送ったチャンク', 'answer-stream-1')
+    enqueue('別セッションの高優先度発話', 'answer-stream-2')
+    enqueue('後に送ったチャンク', 'answer-stream-1')
+
+    const res = createMockRes()
+    messages(
+      createMockReq({
+        method: 'GET',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { clientId: 'client1' },
+      }),
+      res
+    )
+
+    expect(
+      (res._json as { messages: Array<{ message: string }> }).messages.map(
+        (message) => message.message
+      )
+    ).toEqual([
+      '別セッションの高優先度発話',
+      '先に送ったチャンク',
+      '後に送ったチャンク',
+    ])
+  })
+
   it('queues v1 messages requests with the legacy messages payload shape', () => {
     const v1Messages = require('@/pages/api/v1/messages').default
     const messages = require('@/pages/api/messages').default

--- a/src/__tests__/pages/api/v1/externalApiValidation.test.ts
+++ b/src/__tests__/pages/api/v1/externalApiValidation.test.ts
@@ -178,6 +178,27 @@ describe('/api/v1 validation and mode branches', () => {
       expect(res._json).toEqual({ error: 'System prompt is not a string' })
     })
 
+    it.each([123, '', 'x'.repeat(201)])(
+      'rejects invalid speechSessionId on v1/speak: %p',
+      (speechSessionId) => {
+        const handler = require('@/pages/api/v1/speak').default
+        const res = createMockRes()
+
+        handler(
+          createMockReq({
+            method: 'POST',
+            headers: AUTH_HEADERS,
+            query: { clientId: 'client1' },
+            body: { text: 'hello', speechSessionId },
+          }),
+          res
+        )
+
+        expect(res._status).toBe(400)
+        expect(res._json).toEqual({ error: 'Invalid speech session ID' })
+      }
+    )
+
     it('rejects a non-loopback response callback on v1/chat with 400', () => {
       const handler = require('@/pages/api/v1/chat').default
       const res = createMockRes()
@@ -262,7 +283,11 @@ describe('/api/v1 validation and mode branches', () => {
   describe('events SSE stream', () => {
     it('streams recent events with SSE headers when snapshot is not requested', () => {
       const speak = require('@/pages/api/v1/speak').default
+      const stop = require('@/pages/api/v1/stop').default
       const events = require('@/pages/api/v1/events').default
+      const {
+        enqueuePresentationControlCommand,
+      } = require('@/features/api/messageGateway')
 
       speak(
         createMockReq({
@@ -273,6 +298,16 @@ describe('/api/v1 validation and mode branches', () => {
         }),
         createMockRes()
       )
+      stop(
+        createMockReq({
+          method: 'POST',
+          headers: AUTH_HEADERS,
+          query: { clientId: 'client1' },
+          body: { mode: 'queue' },
+        }),
+        createMockRes()
+      )
+      enqueuePresentationControlCommand('client1', 'next_slide')
 
       const res = createMockRes()
       events(
@@ -288,6 +323,9 @@ describe('/api/v1 validation and mode branches', () => {
       expect(res._headers['Content-Type']).toBe('text/event-stream')
       expect(res._writes[0]).toBe(': connected\n\n')
       expect(res._writes.join('')).toContain('event: message_queued')
+      expect(res._writes.join('')).toContain('event: stop_requested')
+      expect(res._writes.join('')).toContain('event: command_queued')
+      res._emit('close')
     })
   })
 })

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -36,9 +36,15 @@ import {
   createReceiverDescriptor,
   getReceiverCapabilities,
 } from '@/features/api/receiverRegistry'
+import {
+  createCoalescedRunner,
+  subscribeReceiverEventStream,
+} from '@/features/api/receiverEventStream'
 
 const CLIENT_TAB_LEASE_DURATION = 5000
 const CLIENT_TAB_LEASE_REFRESH_INTERVAL = 2000
+const DISCONNECTED_FALLBACK_POLL_INTERVAL = 1000
+const CONNECTED_SAFETY_POLL_INTERVAL = 15000
 
 class ReceivedMessage {
   timestamp: number
@@ -47,6 +53,7 @@ class ReceivedMessage {
   systemPrompt?: string
   useCurrentSystemPrompt?: boolean
   image?: string
+  speechSessionId?: string
   responseCallback?: QueuedResponseCallback
 
   constructor(
@@ -56,6 +63,7 @@ class ReceivedMessage {
     systemPrompt?: string,
     useCurrentSystemPrompt?: boolean,
     image?: string,
+    speechSessionId?: string,
     responseCallback?: QueuedResponseCallback
   ) {
     this.timestamp = timestamp
@@ -64,6 +72,7 @@ class ReceivedMessage {
     this.systemPrompt = systemPrompt
     this.useCurrentSystemPrompt = useCurrentSystemPrompt
     this.image = image
+    this.speechSessionId = speechSessionId
     this.responseCallback = responseCallback
   }
 }
@@ -111,7 +120,7 @@ const MessageReceiver = () => {
       for (const message of messages) {
         switch (message.type) {
           case 'direct_send':
-            await speakMessageHandler(message.message)
+            await speakMessageHandler(message.message, message.speechSessionId)
             break
           case 'ai_generate': {
             // 外部画像が提供された場合はそれを使用、なければカメラキャプチャ
@@ -623,32 +632,18 @@ const MessageReceiver = () => {
       }
     }
 
-    let isFetchingMessages = false
-    let isFetchingCommands = false
     let isReportingStatus = false
     let isStatusReportQueued = false
 
-    const safeFetchMessages = async () => {
-      if (isFetchingMessages) return
-      isFetchingMessages = true
-      try {
-        await fetchMessages(receiverId, 'receiver')
-        await fetchMessages(clientId, 'legacy')
-      } finally {
-        isFetchingMessages = false
-      }
-    }
+    const safeFetchMessages = createCoalescedRunner(async () => {
+      await fetchMessages(receiverId, 'receiver')
+      await fetchMessages(clientId, 'legacy')
+    })
 
-    const safeFetchCommands = async () => {
-      if (isFetchingCommands) return
-      isFetchingCommands = true
-      try {
-        await fetchCommands(receiverId, 'receiver')
-        await fetchCommands(clientId, 'legacy')
-      } finally {
-        isFetchingCommands = false
-      }
-    }
+    const safeFetchCommands = createCoalescedRunner(async () => {
+      await fetchCommands(receiverId, 'receiver')
+      await fetchCommands(clientId, 'legacy')
+    })
 
     const safeReportStatus = async () => {
       isStatusReportQueued = true
@@ -731,8 +726,50 @@ const MessageReceiver = () => {
       refreshClientTabLeadership()
     }
 
-    const commandIntervalId = setInterval(() => void safeFetchCommands(), 1000)
-    const intervalId = setInterval(() => void safeFetchMessages(), 1000)
+    const eventStreamAbortController = new AbortController()
+    const eventStreamTargets = [...new Set([receiverId, clientId])]
+    const connectedEventStreamTargets = new Set<string>()
+    const eventStreamHeaders = getClientApiHeaders()
+
+    if (eventStreamHeaders) {
+      eventStreamTargets.forEach((targetId) => {
+        void subscribeReceiverEventStream({
+          targetId,
+          headers: eventStreamHeaders,
+          signal: eventStreamAbortController.signal,
+          onWakeup: (wakeup) => {
+            if (wakeup === 'messages') void safeFetchMessages()
+            if (wakeup === 'commands') void safeFetchCommands()
+          },
+          onConnectionChange: (connected) => {
+            if (connected) {
+              connectedEventStreamTargets.add(targetId)
+              // 接続確立直前に追加されたキューとの競合を閉じる。
+              void safeFetchCommands()
+              void safeFetchMessages()
+            } else {
+              connectedEventStreamTargets.delete(targetId)
+            }
+          },
+          onError: (error) =>
+            logger.error('Receiver event stream disconnected:', error),
+        })
+      })
+    }
+
+    const fallbackIntervalId = setInterval(() => {
+      if (
+        !eventStreamHeaders ||
+        connectedEventStreamTargets.size < eventStreamTargets.length
+      ) {
+        void safeFetchCommands()
+        void safeFetchMessages()
+      }
+    }, DISCONNECTED_FALLBACK_POLL_INTERVAL)
+    const safetyIntervalId = setInterval(() => {
+      void safeFetchCommands()
+      void safeFetchMessages()
+    }, CONNECTED_SAFETY_POLL_INTERVAL)
     const statusIntervalId = setInterval(() => void safeReportStatus(), 2000)
     const leaseIntervalId = setInterval(
       refreshClientTabLeadership,
@@ -740,8 +777,9 @@ const MessageReceiver = () => {
     )
 
     return () => {
-      clearInterval(intervalId)
-      clearInterval(commandIntervalId)
+      eventStreamAbortController.abort()
+      clearInterval(fallbackIntervalId)
+      clearInterval(safetyIntervalId)
       clearInterval(statusIntervalId)
       clearInterval(leaseIntervalId)
       unsubscribePresentationStatus()

--- a/src/features/api/messageGateway.ts
+++ b/src/features/api/messageGateway.ts
@@ -38,6 +38,8 @@ export interface QueuedMessage {
   useCurrentSystemPrompt?: boolean
   image?: string
   emotion?: string
+  /** 分割された同一回答を同じSpeakQueueセッションへ積むためのID。 */
+  speechSessionId?: string
   priority?: 'normal' | 'high'
   interrupt?: boolean
   source?: 'legacy' | 'v1'
@@ -110,6 +112,7 @@ export interface ApiEvent {
   clientId: string
   type:
     | 'message_queued'
+    | 'command_queued'
     | 'messages_fetched'
     | 'stop_requested'
     | 'commands_fetched'
@@ -156,6 +159,7 @@ export interface EnqueueMessagesParams {
   useCurrentSystemPrompt?: boolean
   image?: string
   emotion?: string
+  speechSessionId?: string
   priority?: 'normal' | 'high'
   interrupt?: boolean
   source?: 'legacy' | 'v1'
@@ -307,6 +311,7 @@ export const enqueueMessages = ({
   useCurrentSystemPrompt,
   image,
   emotion,
+  speechSessionId,
   priority = 'normal',
   interrupt = false,
   source = 'v1',
@@ -329,6 +334,7 @@ export const enqueueMessages = ({
       useCurrentSystemPrompt,
       image,
       emotion,
+      speechSessionId,
       priority,
       interrupt,
       source,
@@ -408,6 +414,10 @@ export const enqueuePresentationLoadCommand = (
   }
   queue.commands.push(command)
   queue.lastAccessed = command.timestamp
+  emitApiEvent(clientId, 'command_queued', {
+    commandId: command.id,
+    commandType: command.command,
+  })
   return command
 }
 
@@ -429,6 +439,10 @@ export const enqueuePresentationControlCommand = (
   }
   queue.commands.push(command)
   queue.lastAccessed = command.timestamp
+  emitApiEvent(clientId, 'command_queued', {
+    commandId: command.id,
+    commandType: command.command,
+  })
   return command
 }
 

--- a/src/features/api/messageGateway.ts
+++ b/src/features/api/messageGateway.ts
@@ -343,7 +343,16 @@ export const enqueueMessages = ({
   })
 
   if (priority === 'high') {
-    queue.messages.unshift(...queuedMessages)
+    const lastSessionMessageIndex = speechSessionId
+      ? queue.messages.findLastIndex(
+          (message) => message.speechSessionId === speechSessionId
+        )
+      : -1
+    if (lastSessionMessageIndex >= 0) {
+      queue.messages.splice(lastSessionMessageIndex + 1, 0, ...queuedMessages)
+    } else {
+      queue.messages.unshift(...queuedMessages)
+    }
   } else {
     queue.messages.push(...queuedMessages)
   }

--- a/src/features/api/receiverEventStream.ts
+++ b/src/features/api/receiverEventStream.ts
@@ -1,0 +1,139 @@
+export type ReceiverWakeup = 'messages' | 'commands'
+
+type ReceiverEventStreamOptions = {
+  targetId: string
+  headers: Record<string, string>
+  signal: AbortSignal
+  onWakeup: (wakeup: ReceiverWakeup) => void
+  onConnectionChange?: (connected: boolean) => void
+  onError?: (error: unknown) => void
+}
+
+/**
+ * 実行中に重なった通知を捨てず、完了直後の1回へまとめる。
+ */
+export const createCoalescedRunner = (task: () => Promise<void>) => {
+  let running: Promise<void> | null = null
+  let queued = false
+
+  return (): Promise<void> => {
+    queued = true
+    if (running) return running
+
+    running = (async () => {
+      try {
+        while (queued) {
+          queued = false
+          await task()
+        }
+      } finally {
+        running = null
+      }
+    })()
+    return running
+  }
+}
+
+const INITIAL_RECONNECT_DELAY_MS = 250
+const MAX_RECONNECT_DELAY_MS = 5_000
+
+export const receiverWakeupForEvent = (
+  eventType: string
+): ReceiverWakeup | null => {
+  if (eventType === 'message_queued') return 'messages'
+  if (eventType === 'command_queued' || eventType === 'stop_requested') {
+    return 'commands'
+  }
+  return null
+}
+
+const consumeSseBlock = (
+  block: string,
+  onWakeup: (wakeup: ReceiverWakeup) => void
+) => {
+  const eventLine = block
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('event:'))
+  if (!eventLine) return
+  const wakeup = receiverWakeupForEvent(eventLine.slice('event:'.length).trim())
+  if (wakeup) onWakeup(wakeup)
+}
+
+const waitForReconnect = (signal: AbortSignal, delayMs: number) =>
+  new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    const handleAbort = () => {
+      clearTimeout(timeoutId)
+      resolve()
+    }
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener('abort', handleAbort)
+      resolve()
+    }, delayMs)
+    signal.addEventListener('abort', handleAbort, { once: true })
+  })
+
+/**
+ * Receiver向けの認証付きSSE購読。
+ * EventSourceはAuthorization headerを付けられないためfetch streamを使う。
+ */
+export const subscribeReceiverEventStream = async ({
+  targetId,
+  headers,
+  signal,
+  onWakeup,
+  onConnectionChange,
+  onError,
+}: ReceiverEventStreamOptions): Promise<void> => {
+  let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
+
+  while (!signal.aborted) {
+    let connected = false
+    try {
+      const response = await fetch(
+        `/api/v1/events/?receiverId=${encodeURIComponent(targetId)}`,
+        {
+          headers: { ...headers, Accept: 'text/event-stream' },
+          signal,
+        }
+      )
+      if (!response.ok)
+        throw new Error(`HTTP error! status: ${response.status}`)
+      if (!response.body) throw new Error('Event stream body is missing')
+
+      connected = true
+      reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
+      onConnectionChange?.(true)
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      while (!signal.aborted) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+
+        let boundary = buffer.search(/\r?\n\r?\n/)
+        while (boundary >= 0) {
+          const block = buffer.slice(0, boundary)
+          const delimiter = buffer.slice(boundary).match(/^\r?\n\r?\n/)?.[0]
+          buffer = buffer.slice(boundary + (delimiter?.length ?? 2))
+          consumeSseBlock(block, onWakeup)
+          boundary = buffer.search(/\r?\n\r?\n/)
+        }
+      }
+      if (!signal.aborted) throw new Error('Event stream disconnected')
+    } catch (error) {
+      if (!signal.aborted) onError?.(error)
+    } finally {
+      if (connected) onConnectionChange?.(false)
+    }
+
+    if (signal.aborted) break
+    await waitForReconnect(signal, reconnectDelayMs)
+    reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS)
+  }
+}

--- a/src/features/api/receiverEventStream.ts
+++ b/src/features/api/receiverEventStream.ts
@@ -36,6 +36,7 @@ export const createCoalescedRunner = (task: () => Promise<void>) => {
 
 const INITIAL_RECONNECT_DELAY_MS = 250
 const MAX_RECONNECT_DELAY_MS = 5_000
+const RECONNECT_BACKOFF_RESET_AFTER_MS = 15_000
 
 export const receiverWakeupForEvent = (
   eventType: string
@@ -92,6 +93,7 @@ export const subscribeReceiverEventStream = async ({
 
   while (!signal.aborted) {
     let connected = false
+    let connectedAt = 0
     try {
       const response = await fetch(
         `/api/v1/events/?receiverId=${encodeURIComponent(targetId)}`,
@@ -105,7 +107,7 @@ export const subscribeReceiverEventStream = async ({
       if (!response.body) throw new Error('Event stream body is missing')
 
       connected = true
-      reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
+      connectedAt = Date.now()
       onConnectionChange?.(true)
 
       const reader = response.body.getReader()
@@ -129,6 +131,12 @@ export const subscribeReceiverEventStream = async ({
     } catch (error) {
       if (!signal.aborted) onError?.(error)
     } finally {
+      if (
+        connected &&
+        Date.now() - connectedAt >= RECONNECT_BACKOFF_RESET_AFTER_MS
+      ) {
+        reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS
+      }
       if (connected) onConnectionChange?.(false)
     }
 

--- a/src/features/chat/speechPipeline/speakMessageHandler.ts
+++ b/src/features/chat/speechPipeline/speakMessageHandler.ts
@@ -14,8 +14,11 @@ import settingsStore from '@/features/stores/settings'
  * （表示形式のみ現行の正規化フォーマットを踏襲。設計§5.1）。
  * chatProcessing管理・記憶保存・思考ポーズは行わない（現行踏襲）。
  */
-export const speakMessageHandler = async (receivedMessage: string) => {
-  const sessionId = generateMessageId()
+export const speakMessageHandler = async (
+  receivedMessage: string,
+  speechSessionId?: string
+) => {
+  const sessionId = speechSessionId || generateMessageId()
   const writer = new NormalizedMessageLogWriter()
   const dispatcher = createSpeechDispatcher(sessionId)
   const segmenter = new SpeechSegmenter({

--- a/src/pages/api/v1/events.ts
+++ b/src/pages/api/v1/events.ts
@@ -32,6 +32,7 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache, no-transform',
     Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
   })
 
   res.write(': connected\n\n')
@@ -44,7 +45,16 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     }
   })
 
-  req.socket.on('close', unsubscribe)
+  const heartbeat = setInterval(() => res.write(': heartbeat\n\n'), 15_000)
+  let closed = false
+  const cleanup = () => {
+    if (closed) return
+    closed = true
+    clearInterval(heartbeat)
+    unsubscribe()
+  }
+  req.socket.on('close', cleanup)
+  res.once('close', cleanup)
 }
 
 export default withAccessPolicy(routePolicies['/api/v1/events'], handler)

--- a/src/pages/api/v1/speak.ts
+++ b/src/pages/api/v1/speak.ts
@@ -34,6 +34,20 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(400).json({ error: 'Text or messages are required' })
   }
 
+  const speechSessionIdInput = req.body?.speechSessionId
+  if (
+    speechSessionIdInput !== undefined &&
+    (typeof speechSessionIdInput !== 'string' ||
+      speechSessionIdInput.trim().length === 0 ||
+      speechSessionIdInput.trim().length > 200)
+  ) {
+    return res.status(400).json({ error: 'Invalid speech session ID' })
+  }
+  const speechSessionId =
+    typeof speechSessionIdInput === 'string'
+      ? speechSessionIdInput.trim()
+      : undefined
+
   const imageResult = normalizeImage(req.body?.image)
   if (!imageResult.ok) {
     return res.status(imageResult.status).json({ error: imageResult.error })
@@ -51,6 +65,7 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     image: imageResult.image,
     emotion:
       typeof req.body?.emotion === 'string' ? req.body.emotion : undefined,
+    speechSessionId,
     priority: req.body?.priority === 'high' ? 'high' : 'normal',
     interrupt,
     source: 'v1',

--- a/src/pages/send-message.tsx
+++ b/src/pages/send-message.tsx
@@ -140,6 +140,12 @@ const endpoints: EndpointDefinition[] = [
         description: '発話時の表情・感情指定です。未指定なら通常状態です。',
       },
       {
+        name: 'speechSessionId',
+        type: 'string',
+        description:
+          'ストリーミング回答を分割送信するとき、同じ回答の全リクエストに共通で指定します。発話順を維持したまま同一キューへ追加されます。',
+      },
+      {
         name: 'priority',
         type: '"normal" | "high"',
         description: 'high の場合は通常より前にキューへ入れます。',

--- a/src/pages/send-message.tsx
+++ b/src/pages/send-message.tsx
@@ -143,7 +143,7 @@ const endpoints: EndpointDefinition[] = [
         name: 'speechSessionId',
         type: 'string',
         description:
-          'ストリーミング回答を分割送信するとき、同じ回答の全リクエストに共通で指定します。発話順を維持したまま同一キューへ追加されます。',
+          'ストリーミング回答を分割送信するとき、同じ回答の全リクエストに共通で指定します。trim後1〜200文字が必要で、発話順を維持したまま同一キューへ追加されます。',
       },
       {
         name: 'priority',


### PR DESCRIPTION
## Summary

- Message Receiverを認証付きSSE通知へ切り替え、発話・停止・プレゼン操作をキュー投入直後に取得します。
- SSE切断中は1秒ポーリングへフォールバックし、接続中も15秒ごとの安全確認と指数バックオフ再接続を維持します。
- 分割されたストリーミング回答へ共通の`speechSessionId`を渡し、同一SpeakQueueセッションでFIFO処理します。
- TTS処理中に重なった通知をまとめて再実行し、後続チャンクの取りこぼしを防止します。

## Verification

- `npm exec eslint -- <変更対象>`
- `npm test -- --runInBand src/__tests__/features/api/receiverEventStream.test.ts src/__tests__/pages/api/v1/externalApi.test.ts src/__tests__/pages/api/v1/externalApiValidation.test.ts`（54件通過）
- `NODE_OPTIONS="--localstorage-file=<temporary-file>" npm test -- --runInBand`（202 suites、2226件通過、7件skip）
- `npm run build`
- 接続中OBS Receiverで`stop_requested`から`commands_fetched`まで28msであることを実測
- Morning Showからの音声入力で、ストリーミング発話の体感遅延が改善したことを確認

## Notes

- Node 24では`--localstorage-file`未指定時、既存の`images.test.ts`がNode組み込み`localStorage`の保存先不足で14件失敗します。保存先を明示すると全suiteが通過します。
- `EventSource`はAuthorizationヘッダーを指定できないため、Receiver側は`fetch`のReadableStreamでSSEを購読します。
- SSE障害時も既存の1秒ポーリングへ自動的に戻るため、配送経路は維持されます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ReceiverがSSEでイベントを受信し、メッセージやコマンドを即時処理できるようになりました。
  - SSE切断時の自動再接続、接続状態通知、フォールバックポーリングに対応しました。
  - `/api/v1/speak`で発話セッションIDを指定でき、分割された発話の順序を維持できます。
  - プレゼンテーション操作や停止要求のイベント通知に対応しました。

- **改善**
  - SSE接続のハートビートにより、接続状態を安定して維持します。
  - 発話セッションIDの形式・長さを検証し、不正な入力にはエラーを返します。

- **ドキュメント**
  - SSE購読、発話セッション、Receiver通信の仕様を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->