### PR TITLE
デモサイトのSEOを強化

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,18 @@
+# AITuberKit
+
+AITuberKit is an open-source toolkit for building and experiencing AI character conversations and AITuber (AI VTuber) streaming in a web browser.
+
+## Primary pages
+
+- Demo: https://aituberkit.com/
+- About AITuber and AITuberKit: https://aituberkit.com/aituber/
+- Documentation: https://docs.aituberkit.com/
+- Source code: https://github.com/tegnike/aituber-kit
+
+## Capabilities
+
+- AI character conversations using multiple LLM providers
+- VRM, Live2D, and PNGTuber character models
+- Text-to-speech and speech recognition
+- YouTube comment integration for AITuber streaming
+- Long-term memory, kiosk, idle, slide, and external API modes

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /embed/
+Disallow: /send-message/
+Disallow: /slide-editor/
+
+Sitemap: https://aituberkit.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://aituberkit.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://aituberkit.com/aituber/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>

--- a/scripts/waf/generate-waf-rules.mjs
+++ b/scripts/waf/generate-waf-rules.mjs
@@ -73,6 +73,9 @@ export function generateWafRules(config = loadWafConfig()) {
 
   const browser = config.browserClearance
   const browserClearanceExpression = `(${hostIn} and http.request.method eq "GET" and ${[
+    ...browser.excludedPaths.map(
+      (excludedPath) => `http.request.uri.path ne "${excludedPath}"`
+    ),
     ...browser.excludedPathPrefixes.map(
       (prefix) => `not starts_with(http.request.uri.path, "${prefix}")`
     ),

--- a/scripts/waf/waf.config.json
+++ b/scripts/waf/waf.config.json
@@ -20,6 +20,13 @@
   },
   "browserClearance": {
     "description": "AITuberKit: issue browser clearance before protected API use",
+    "excludedPaths": [
+      "/aituber",
+      "/aituber/",
+      "/robots.txt",
+      "/sitemap.xml",
+      "/llms.txt"
+    ],
     "excludedPathPrefixes": ["/api/", "/_next/", "/assets/"],
     "excludedPathSuffixes": [
       ".js",

--- a/src/__tests__/scripts/generateWafRules.test.ts
+++ b/src/__tests__/scripts/generateWafRules.test.ts
@@ -3,9 +3,9 @@
  *
  * WAF生成スクリプトの検証（docs/access-policy-design.md §6.2）。
  *
- * 1. 移行等価性: 生成ルールが、以前ワークフローYAMLにハードコードされていた
- *    ルールと意味的に等価であること（`in {…}` 集合は順序不問の集合比較、
- *    それ以外は文字列一致）。
+ * 1. 生成ルールが、以前ワークフローYAMLにハードコードされていたルールへ
+ *    明示した公開SEOパスの除外だけを加えた内容であること（`in {…}` 集合は
+ *    順序不問の集合比較、それ以外は文字列一致）。
  * 2. ポリシー整合: 生成される保護対象/embed許可のAPIパス集合が
  *    routePolicies の waf フラグと一致すること。
  * 3. 実行互換性: child_process で実際にスクリプトを実行することで、
@@ -66,7 +66,7 @@ const LEGACY_RULES: WafRule[] = [
     ref: 'aituberkit-browser-clearance',
     description: 'AITuberKit: issue browser clearance before protected API use',
     expression:
-      '(http.host in {"aituberkit.com" "www.aituberkit.com"} and http.request.method eq "GET" and not starts_with(http.request.uri.path, "/api/") and not starts_with(http.request.uri.path, "/_next/") and not starts_with(http.request.uri.path, "/assets/") and not ends_with(http.request.uri.path, ".js") and not ends_with(http.request.uri.path, ".css") and not ends_with(http.request.uri.path, ".png") and not ends_with(http.request.uri.path, ".jpg") and not ends_with(http.request.uri.path, ".jpeg") and not ends_with(http.request.uri.path, ".webp") and not ends_with(http.request.uri.path, ".svg") and not ends_with(http.request.uri.path, ".ico") and not cf.client.bot)',
+      '(http.host in {"aituberkit.com" "www.aituberkit.com"} and http.request.method eq "GET" and http.request.uri.path ne "/aituber" and http.request.uri.path ne "/aituber/" and http.request.uri.path ne "/robots.txt" and http.request.uri.path ne "/sitemap.xml" and http.request.uri.path ne "/llms.txt" and not starts_with(http.request.uri.path, "/api/") and not starts_with(http.request.uri.path, "/_next/") and not starts_with(http.request.uri.path, "/assets/") and not ends_with(http.request.uri.path, ".js") and not ends_with(http.request.uri.path, ".css") and not ends_with(http.request.uri.path, ".png") and not ends_with(http.request.uri.path, ".jpg") and not ends_with(http.request.uri.path, ".jpeg") and not ends_with(http.request.uri.path, ".webp") and not ends_with(http.request.uri.path, ".svg") and not ends_with(http.request.uri.path, ".ico") and not cf.client.bot)',
     action: 'managed_challenge',
     enabled: true,
   },
@@ -119,7 +119,7 @@ describe('generate-waf-rules.mjs', () => {
     generated = JSON.parse(stdout)
   })
 
-  it('generates the same three rules as the legacy hardcoded workflow', () => {
+  it('generates the three expected rules including public SEO paths', () => {
     expect(generated).toHaveLength(LEGACY_RULES.length)
 
     generated.forEach((rule, index) => {

--- a/src/components/appInitializer.tsx
+++ b/src/components/appInitializer.tsx
@@ -1,0 +1,43 @@
+import '@charcoal-ui/icons'
+import { useEffect } from 'react'
+
+import { isLanguageSupported } from '@/features/constants/settings'
+import homeStore from '@/features/stores/home'
+import settingsStore from '@/features/stores/settings'
+import i18n from '@/lib/i18n'
+import migrateStore from '@/utils/migrateStore'
+
+export default function AppInitializer() {
+  useEffect(() => {
+    const hs = homeStore.getState()
+    const ss = settingsStore.getState()
+
+    if (hs.userOnboarded) {
+      i18n.changeLanguage(ss.selectLanguage)
+      document.documentElement.setAttribute('data-theme', ss.colorTheme)
+      return
+    }
+
+    migrateStore()
+
+    const browserLanguage = navigator.language
+    const languageCode =
+      browserLanguage === 'zh-TW'
+        ? 'zh-TW'
+        : browserLanguage.match(/^zh/i)
+          ? 'zh-CN'
+          : browserLanguage.split('-')[0].toLowerCase()
+
+    let language = ss.selectLanguage
+    if (!language) {
+      language = isLanguageSupported(languageCode) ? languageCode : 'ja'
+    }
+    i18n.changeLanguage(language)
+    settingsStore.setState({ selectLanguage: language })
+
+    document.documentElement.setAttribute('data-theme', ss.colorTheme)
+    homeStore.setState({ userOnboarded: true })
+  }, [])
+
+  return null
+}

--- a/src/components/meta.tsx
+++ b/src/components/meta.tsx
@@ -1,23 +1,97 @@
 import Head from 'next/head'
-export const Meta = () => {
-  const title = 'AITuberKit'
-  const description =
-    'Webブラウザだけで誰でも簡単にAIキャラと会話したり、Youtubeで配信したりできます。'
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://aituberkit.com'
-  const imageUrl = `${siteUrl}/ogp.png`
+
+export const SITE_NAME = 'AITuberKit'
+export const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ||
+  'https://aituberkit.com'
+export const SITE_TITLE =
+  'AITuberKit｜AIキャラクターとの会話・AITuber配信をブラウザで体験'
+export const SITE_DESCRIPTION =
+  'AITuberKitは、AIキャラクターとの会話やAITuber配信をブラウザで体験・構築できるオープンソースのツールキットです。VRM・Live2D・PNGTuber、各種LLM・音声合成、YouTubeコメント連携に対応しています。'
+
+const serializeStructuredData = (value: unknown) =>
+  JSON.stringify(value).replace(/</g, '\\u003c')
+
+type MetaProps = {
+  canonicalPath?: string
+  description?: string
+  title?: string
+  structuredData?: Record<string, unknown> | Record<string, unknown>[]
+}
+
+export const Meta = ({
+  canonicalPath = '/',
+  description = SITE_DESCRIPTION,
+  title = SITE_TITLE,
+  structuredData,
+}: MetaProps) => {
+  const canonicalUrl = `${SITE_URL}${canonicalPath}`
+  const imageUrl = `${SITE_URL}/ogp.png`
+  const defaultStructuredData = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      '@id': `${SITE_URL}/#website`,
+      name: SITE_NAME,
+      alternateName: ['AITuber Kit', 'AI Tuber Kit', 'AIチューバーキット'],
+      url: `${SITE_URL}/`,
+      inLanguage: 'ja',
+      description: SITE_DESCRIPTION,
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      '@id': `${SITE_URL}/#software`,
+      name: SITE_NAME,
+      alternateName: ['AITuber Kit', 'AI Tuber Kit', 'AIチューバーキット'],
+      applicationCategory: 'MultimediaApplication',
+      applicationSubCategory: 'AI character and VTuber application',
+      operatingSystem: 'Web browser, Windows, macOS, Linux',
+      url: `${SITE_URL}/`,
+      image: imageUrl,
+      description: SITE_DESCRIPTION,
+      inLanguage: 'ja',
+      codeRepository: 'https://github.com/tegnike/aituber-kit',
+      softwareHelp: 'https://docs.aituberkit.com/',
+    },
+  ]
+  const jsonLd = structuredData
+    ? [
+        ...defaultStructuredData,
+        ...(Array.isArray(structuredData) ? structuredData : [structuredData]),
+      ]
+    : defaultStructuredData
+
   return (
     <Head>
       <title>{title}</title>
       <meta name="description" content={description} />
+      <meta
+        name="robots"
+        content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1"
+      />
+      <link rel="canonical" href={canonicalUrl} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={imageUrl} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:image:alt" content="AITuberKit" />
       <meta property="og:type" content="website" />
-      {siteUrl && <meta property="og:url" content={siteUrl} />}
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:locale" content="ja_JP" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={imageUrl} />
+      <meta name="twitter:image:alt" content="AITuberKit" />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeStructuredData(jsonLd),
+        }}
+      />
     </Head>
   )
 }

--- a/src/components/seoSummary.tsx
+++ b/src/components/seoSummary.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export const SeoSummary = () => (
+  <section className="sr-only" aria-labelledby="aituberkit-summary-title">
+    <h1 id="aituberkit-summary-title">
+      AITuberKit - AIキャラクターとの会話・AITuber配信
+    </h1>
+    <p>
+      AITuberKitは、VRM・Live2D・PNGTuberに対応し、AIキャラクターとの会話やYouTubeでのAITuber配信をブラウザで体験できるオープンソースのツールキットです。
+    </p>
+    <Link href="/aituber/">AITuberとAITuberKitについて詳しく見る</Link>
+  </section>
+)

--- a/src/components/seoSummary.tsx
+++ b/src/components/seoSummary.tsx
@@ -1,13 +1,20 @@
 import Link from 'next/link'
 
 export const SeoSummary = () => (
-  <section className="sr-only" aria-labelledby="aituberkit-summary-title">
-    <h1 id="aituberkit-summary-title">
-      AITuberKit - AIキャラクターとの会話・AITuber配信
-    </h1>
-    <p>
-      AITuberKitは、VRM・Live2D・PNGTuberに対応し、AIキャラクターとの会話やYouTubeでのAITuber配信をブラウザで体験できるオープンソースのツールキットです。
-    </p>
-    <Link href="/aituber/">AITuberとAITuberKitについて詳しく見る</Link>
-  </section>
+  <>
+    <section className="sr-only" aria-labelledby="aituberkit-summary-title">
+      <h1 id="aituberkit-summary-title">
+        AITuberKit - AIキャラクターとの会話・AITuber配信
+      </h1>
+      <p>
+        AITuberKitは、VRM・Live2D・PNGTuberに対応し、AIキャラクターとの会話やYouTubeでのAITuber配信をブラウザで体験できるオープンソースのツールキットです。
+      </p>
+    </section>
+    <Link
+      href="/aituber/"
+      className="sr-only focus-visible:fixed focus-visible:top-4 focus-visible:left-4 focus-visible:z-50 focus-visible:m-0 focus-visible:h-auto focus-visible:w-auto focus-visible:overflow-visible focus-visible:rounded-lg focus-visible:bg-slate-950 focus-visible:px-4 focus-visible:py-3 focus-visible:text-white focus-visible:[clip:auto] focus-visible:[clip-path:none] focus-visible:whitespace-normal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-300"
+    >
+      AITuberとAITuberKitについて詳しく見る
+    </Link>
+  </>
 )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,52 +1,17 @@
-import '@charcoal-ui/icons'
 import type { AppProps } from 'next/app'
+import dynamic from 'next/dynamic'
 import Head from 'next/head'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Analytics } from '@vercel/analytics/react'
 
-import { isLanguageSupported } from '@/features/constants/settings'
-import homeStore from '@/features/stores/home'
-import settingsStore from '@/features/stores/settings'
 import '@/styles/globals.css'
 import '@/styles/themes.css'
-import migrateStore from '@/utils/migrateStore'
-import i18n from '../lib/i18n'
 
-export default function App({ Component, pageProps }: AppProps) {
-  useEffect(() => {
-    const hs = homeStore.getState()
-    const ss = settingsStore.getState()
+const AppInitializer = dynamic(() => import('@/components/appInitializer'), {
+  ssr: false,
+})
 
-    if (hs.userOnboarded) {
-      i18n.changeLanguage(ss.selectLanguage)
-      // 保存されたテーマを適用
-      document.documentElement.setAttribute('data-theme', ss.colorTheme)
-      return
-    }
-
-    migrateStore()
-
-    const browserLanguage = navigator.language
-    const languageCode =
-      browserLanguage === 'zh-TW'
-        ? 'zh-TW'
-        : browserLanguage.match(/^zh/i)
-          ? 'zh-CN'
-          : browserLanguage.split('-')[0].toLowerCase()
-
-    let language = ss.selectLanguage
-    if (!language) {
-      language = isLanguageSupported(languageCode) ? languageCode : 'ja'
-    }
-    i18n.changeLanguage(language)
-    settingsStore.setState({ selectLanguage: language })
-
-    // 初期テーマを適用
-    document.documentElement.setAttribute('data-theme', ss.colorTheme)
-
-    homeStore.setState({ userOnboarded: true })
-  }, [])
-
+export default function App({ Component, pageProps, router }: AppProps) {
   return (
     <>
       <Head>
@@ -54,7 +19,11 @@ export default function App({ Component, pageProps }: AppProps) {
           name="viewport"
           content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
+        {router.pathname !== '/' && router.pathname !== '/aituber' && (
+          <meta name="robots" content="noindex,nofollow" />
+        )}
       </Head>
+      {router.pathname !== '/aituber' && <AppInitializer />}
       <Component {...pageProps} />
       <Analytics />
     </>

--- a/src/pages/aituber.tsx
+++ b/src/pages/aituber.tsx
@@ -1,0 +1,216 @@
+import Link from 'next/link'
+import { Meta, SITE_URL } from '@/components/meta'
+
+const faq = [
+  {
+    question: 'AITuberとは何ですか？',
+    answer:
+      'AITuber（AI VTuber）は、生成AIによる会話、音声合成、2D・3Dアバターなどを組み合わせ、視聴者との対話や配信を行うAIキャラクターです。',
+  },
+  {
+    question: 'AITuberKitはブラウザだけで試せますか？',
+    answer:
+      'はい。デモサイトではインストールせずにAIキャラクターとの会話を体験できます。自分の環境で構築する場合は、GitHubのソースコードと公式ドキュメントを利用できます。',
+  },
+  {
+    question: 'どのキャラクターモデルに対応していますか？',
+    answer:
+      '3DのVRM、2DのLive2D、静止画や動画を使うPNGTuberに対応しています。用途や用意している素材に合わせて選べます。',
+  },
+  {
+    question: 'YouTubeでAITuber配信ができますか？',
+    answer:
+      'はい。YouTubeの配信コメントを取得し、AIキャラクターが応答する配信を構築できます。詳しい設定手順は公式ドキュメントで案内しています。',
+  },
+]
+
+const faqStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  '@id': `${SITE_URL}/aituber/#faq`,
+  mainEntity: faq.map(({ question, answer }) => ({
+    '@type': 'Question',
+    name: question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: answer,
+    },
+  })),
+}
+
+const features = [
+  {
+    title: 'AIキャラクターとの会話',
+    description:
+      'OpenAI、Anthropic Claude、Google Geminiなど、複数のLLMを使った会話に対応しています。',
+  },
+  {
+    title: 'VRM・Live2D・PNGTuber',
+    description:
+      '3D、2D、画像・動画ベースのキャラクターを選び、音声に合わせて表情や口元を動かせます。',
+  },
+  {
+    title: 'AITuber配信',
+    description:
+      'YouTubeコメントへの自動応答、アイドルモード、ゲーム実況など、ライブ配信向けの機能を備えています。',
+  },
+  {
+    title: '音声合成・音声認識',
+    description:
+      'VOICEVOX、AivisSpeech、OpenAI TTSなどの音声合成と、ブラウザ音声認識やWhisperに対応しています。',
+  },
+  {
+    title: 'オープンソース',
+    description:
+      'ソースコードをGitHubで公開しています。自分のAIキャラクターアプリや配信環境の土台として利用できます。',
+  },
+  {
+    title: 'ブラウザですぐ体験',
+    description:
+      'デモサイトなら、AITuberKitのAIキャラクターとの対話をインストールなしで試せます。',
+  },
+]
+
+export default function AITuberPage() {
+  return (
+    <>
+      <Meta
+        canonicalPath="/aituber/"
+        title="AITuberとは？AIキャラクター配信を作れるAITuberKit"
+        description="AITuber（AI VTuber）の仕組みと作り方を解説。AITuberKitなら、VRM・Live2D・PNGTuber、LLM、音声合成、YouTubeコメント連携を組み合わせ、AIキャラクターとの会話や配信をブラウザで体験・構築できます。"
+        structuredData={faqStructuredData}
+      />
+      <main className="min-h-screen bg-slate-950 px-5 py-12 font-M_PLUS_2 text-slate-100 sm:px-8">
+        <article className="mx-auto max-w-5xl">
+          <header className="rounded-3xl border border-cyan-400/20 bg-gradient-to-br from-cyan-400/10 via-slate-900 to-fuchsia-400/10 p-7 shadow-2xl shadow-cyan-950/30 sm:p-12">
+            <p className="mb-3 text-sm font-bold tracking-[0.2em] text-cyan-300">
+              OPEN-SOURCE AI CHARACTER TOOLKIT
+            </p>
+            <h1 className="text-3xl font-black leading-tight sm:text-5xl">
+              AITuberを、ブラウザから始めよう。
+            </h1>
+            <p className="mt-6 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
+              AITuberKitは、AIキャラクターとの会話やAITuber（AI
+              VTuber）配信を体験・構築できるオープンソースのツールキットです。
+              LLM、音声、アバター、配信コメント連携をひとつのWebアプリにまとめています。
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href="/"
+                className="rounded-full bg-cyan-300 px-6 py-3 text-center font-bold text-slate-950 transition hover:bg-cyan-200"
+              >
+                AITuberKitを体験する
+              </Link>
+              <a
+                href="https://docs.aituberkit.com/guide/quickstart"
+                className="rounded-full border border-slate-500 px-6 py-3 text-center font-bold transition hover:border-cyan-300 hover:text-cyan-300"
+              >
+                作り方を見る
+              </a>
+            </div>
+          </header>
+
+          <section className="py-14" aria-labelledby="about-aituber">
+            <h2 id="about-aituber" className="text-2xl font-black sm:text-3xl">
+              AITuber（AI VTuber）とは
+            </h2>
+            <p className="mt-5 max-w-4xl text-base leading-8 text-slate-300">
+              AITuberは、生成AIによる会話、音声合成、VRMやLive2Dなどのアバターを組み合わせて活動するAIキャラクターです。
+              視聴者のコメントに応答するライブ配信だけでなく、Webサイトでの接客、イベント案内、デジタルサイネージなどにも活用できます。
+              AITuberKitは、それらに必要な要素を自分で組み合わせて試せる実装基盤です。
+            </p>
+          </section>
+
+          <section aria-labelledby="features">
+            <h2 id="features" className="text-2xl font-black sm:text-3xl">
+              AITuberKitでできること
+            </h2>
+            <div className="mt-7 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {features.map((feature) => (
+                <section
+                  key={feature.title}
+                  className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6"
+                >
+                  <h3 className="text-lg font-bold text-cyan-300">
+                    {feature.title}
+                  </h3>
+                  <p className="mt-3 leading-7 text-slate-300">
+                    {feature.description}
+                  </p>
+                </section>
+              ))}
+            </div>
+          </section>
+
+          <section className="py-14" aria-labelledby="start">
+            <h2 id="start" className="text-2xl font-black sm:text-3xl">
+              AITuberを始める3つの方法
+            </h2>
+            <ol className="mt-6 grid gap-4 sm:grid-cols-3">
+              <li className="rounded-2xl bg-slate-900 p-6">
+                <span className="text-sm font-bold text-cyan-300">01</span>
+                <h3 className="mt-2 font-bold">デモで会話する</h3>
+                <p className="mt-2 leading-7 text-slate-300">
+                  ブラウザでAIキャラクターとの会話を体験します。
+                </p>
+              </li>
+              <li className="rounded-2xl bg-slate-900 p-6">
+                <span className="text-sm font-bold text-cyan-300">02</span>
+                <h3 className="mt-2 font-bold">ローカルで構築する</h3>
+                <p className="mt-2 leading-7 text-slate-300">
+                  GitHubから取得し、自分のAPIキーやモデルを設定します。
+                </p>
+              </li>
+              <li className="rounded-2xl bg-slate-900 p-6">
+                <span className="text-sm font-bold text-cyan-300">03</span>
+                <h3 className="mt-2 font-bold">配信・アプリへ発展</h3>
+                <p className="mt-2 leading-7 text-slate-300">
+                  YouTube連携や外部APIを使い、用途に合わせて拡張します。
+                </p>
+              </li>
+            </ol>
+          </section>
+
+          <section aria-labelledby="faq">
+            <h2 id="faq" className="text-2xl font-black sm:text-3xl">
+              AITuberKitについてよくある質問
+            </h2>
+            <div className="mt-6 space-y-4">
+              {faq.map(({ question, answer }) => (
+                <details
+                  key={question}
+                  className="rounded-2xl border border-slate-800 bg-slate-900 p-5 open:border-cyan-400/40"
+                >
+                  <summary className="cursor-pointer font-bold">
+                    {question}
+                  </summary>
+                  <p className="mt-4 leading-7 text-slate-300">{answer}</p>
+                </details>
+              ))}
+            </div>
+          </section>
+
+          <footer className="mt-14 border-t border-slate-800 py-10 text-sm text-slate-400">
+            <nav aria-label="関連リンク" className="flex flex-wrap gap-5">
+              <Link href="/" className="hover:text-cyan-300">
+                デモサイト
+              </Link>
+              <a
+                href="https://docs.aituberkit.com/"
+                className="hover:text-cyan-300"
+              >
+                公式ドキュメント
+              </a>
+              <a
+                href="https://github.com/tegnike/aituber-kit"
+                className="hover:text-cyan-300"
+              >
+                GitHub
+              </a>
+            </nav>
+          </footer>
+        </article>
+      </main>
+    </>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,6 +26,7 @@ import { MemoryServiceInitializer } from '@/components/memoryServiceInitializer'
 import toastStore from '@/features/stores/toast'
 import { usePresetLoader } from '@/features/presets/usePresetLoader'
 import { useLive2DEnabled } from '@/hooks/useLive2DEnabled'
+import { SeoSummary } from '@/components/seoSummary'
 
 const Home = () => {
   const webcamStatus = homeStore((s) => s.webcamStatus)
@@ -114,6 +115,7 @@ const Home = () => {
   return (
     <div className="h-[100svh] bg-cover" style={backgroundStyle}>
       <Meta />
+      <SeoSummary />
       <Introduction />
       {modelType === 'live2d' && isLive2DEnabled ? (
         <Live2DViewer />


### PR DESCRIPTION
## Summary

- ルートページのtitle・description・canonical・OG/Twitter Cardを強化し、WebSite / SoftwareApplicationの構造化データを追加
- AITuberの検索意図に応える静的な `/aituber/` 解説ページを追加し、FAQ構造化データ、内部導線、レスポンシブ表示を実装
- `robots.txt`、`sitemap.xml`、`llms.txt`を追加し、API・埋め込み・管理用ページはクロール対象から除外
- SEOページでは不要なアプリ初期化を遅延分離し、`/aituber/` のFirst Load JSを約671KBから約97KBへ削減
- SEO公開パスをCloudflareのブラウザチャレンジ対象外にし、保護対象APIのWAFルールは維持

## Verification

- `npm test -- --runInBand src/__tests__/scripts/generateWafRules.test.ts`
- `npm run lint`
- `npm run build`
- `npm run build:cloudflare`
- `xmllint --noout public/sitemap.xml`
- ローカル本番サーバーで `/`、`/aituber/`、`/robots.txt`、`/sitemap.xml` が200で返ることを確認
- 生成HTMLにcanonical、robots、description、JSON-LD、h1がSSR出力されることを確認
- Chromiumで `/aituber/` のデスクトップ（1440px）・モバイル（390px）表示を確認

## Notes

- 現行本番では `robots.txt` と `sitemap.xml` が404です。本PRがmainへ反映されると配信されます。
- WAFの公開パス除外を本番へ反映するには、マージ後に `Apply Cloudflare WAF` workflowのapply実行が必要です。
- 現行の `https://www.aituberkit.com/` はCloudflare 526を返しており、DNS/TLS側でapexへのリダイレクト設定が別途必要です。canonicalとsitemapは正常なapexへ統一しています。
- ビルド時の警告は既存コード由来で、今回変更したファイルに新規エラーはありません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * AITuberKitの概要、対応機能、FAQ、関連リンクをまとめた紹介ページを追加しました。
  * スクリーンリーダー向けのサービス概要と機能説明を追加しました。
  * 初回アクセス時に、言語・テーマ・オンボーディング設定を自動適用します。

* **改善**
  * ページごとのタイトル、説明、正規URL、SNS共有情報、構造化データを改善しました。
  * サイトマップ、クロール設定、LLM向け案内を追加しました。
  * 公開ページ以外が検索結果に表示されないよう設定しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->