### PR TITLE
feat: プレゼン表示原稿と発話テキストを分離

### DIFF
--- a/docs/external-presentation-api-spec.md
+++ b/docs/external-presentation-api-spec.md
@@ -241,6 +241,7 @@ export interface PresentationSourceV1 {
 | Slide総数                  |         200 |
 | 1 SlideのMarkdown          |  50,000文字 |
 | 1 SlideのNarration         |  10,000文字 |
+| 1 SlideのSpeechText        |  10,000文字 |
 | 1 SlideのNotes             |  10,000文字 |
 | 1 SlideのAsset数           |          20 |
 | 1 SectionのQ&A Brief       | 100,000文字 |

--- a/docs/external-presentation-api-spec.md
+++ b/docs/external-presentation-api-spec.md
@@ -189,6 +189,7 @@ export interface PresentationSlideV1 {
   id: string
   markdown: string
   narration?: string
+  speechText?: string
   notes?: string
   pauseAfter?: boolean
   assets?: PresentationAssetV1[]
@@ -211,6 +212,8 @@ export interface PresentationSourceV1 {
   publishedAt?: string
 }
 ```
+
+`narration`は画面表示や会話文脈へ使う原稿、`speechText`はTTSへ渡す発話文とする。発話時は`speechText ?? narration`、表示・文脈では`narration ?? speechText`の順でfallbackする。既存Producerとの互換性、および発話のない視覚専用Slideを維持するため、両方とも省略可能とする。
 
 ### 8.2 ID制約
 

--- a/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
@@ -1,0 +1,49 @@
+import { speakMessageHandler } from '@/features/chat/speechPipeline/speakMessageHandler'
+import { speakCharacter } from '@/features/messages/speakCharacter'
+import homeStore from '@/features/stores/home'
+
+jest.mock('@/features/messages/speakCharacter', () => ({
+  speakCharacter: jest.fn(),
+}))
+
+jest.mock('@/features/stores/home', () => ({
+  getState: jest.fn(),
+  setState: jest.fn(),
+}))
+
+jest.mock('@/features/stores/settings', () => ({
+  getState: jest.fn(() => ({ selectVoice: 'voicevox' })),
+}))
+
+describe('speakMessageHandler', () => {
+  const upsertMessage = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(homeStore.getState as jest.Mock).mockReturnValue({
+      upsertMessage,
+      incrementChatProcessingCount: jest.fn(),
+      decrementChatProcessingCount: jest.fn(),
+    })
+  })
+
+  it('表示文をchatLogへ残し、発話文だけをTTSへ渡す', async () => {
+    await speakMessageHandler('バンカーキッズを紹介します。', {
+      speechSessionId: 'presentation-1',
+      displayMessage: 'Bunkerkidsを紹介します。',
+    })
+
+    expect(upsertMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Bunkerkidsを紹介します。',
+      })
+    )
+    expect(speakCharacter).toHaveBeenCalledWith(
+      'presentation-1',
+      expect.objectContaining({ message: 'バンカーキッズを紹介します。' }),
+      expect.any(Function),
+      expect.any(Function)
+    )
+  })
+})

--- a/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
@@ -28,23 +28,33 @@ describe('speakMessageHandler', () => {
   })
 
   it('表示文をchatLogへ残し、発話文だけをTTSへ渡す', async () => {
-    await speakMessageHandler('バンカーキッズを紹介します。', {
+    await speakMessageHandler('バンカーキッズを紹介します。次はウィフです。', {
       speechSessionId: 'presentation-1',
-      displayMessage: 'Bunkerkidsを紹介します。',
+      displayMessage: 'Bunkerkidsを紹介します。次はWHIFです。',
     })
 
     expect(upsertMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         role: 'assistant',
-        content: 'Bunkerkidsを紹介します。',
+        content: 'Bunkerkidsを紹介します。 次はWHIFです。',
       })
     )
-    expect(speakCharacter).toHaveBeenCalledWith(
+    expect(speakCharacter).toHaveBeenCalledTimes(2)
+    expect(speakCharacter).toHaveBeenNthCalledWith(
+      1,
       'presentation-1',
       expect.objectContaining({ message: 'バンカーキッズを紹介します。' }),
       expect.any(Function),
       expect.any(Function),
       'Bunkerkidsを紹介します。'
+    )
+    expect(speakCharacter).toHaveBeenNthCalledWith(
+      2,
+      'presentation-1',
+      expect.objectContaining({ message: '次はウィフです。' }),
+      expect.any(Function),
+      expect.any(Function),
+      '次はWHIFです。'
     )
   })
 })

--- a/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
@@ -43,7 +43,8 @@ describe('speakMessageHandler', () => {
       'presentation-1',
       expect.objectContaining({ message: 'バンカーキッズを紹介します。' }),
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      'Bunkerkidsを紹介します。'
     )
   })
 })

--- a/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
@@ -145,10 +145,15 @@ describe('speechDispatcher', () => {
     })
     d.dispatch(speech('バンカーキッズを'))
     d.dispatch(speech('紹介します。'))
-    const [, , firstOnStart, firstOnComplete] = (speakCharacter as jest.Mock)
-      .mock.calls[0]
-    const [, , secondOnStart, secondOnComplete] = (speakCharacter as jest.Mock)
-      .mock.calls[1]
+    const [, , firstOnStart, firstOnComplete, firstDisplayText] = (
+      speakCharacter as jest.Mock
+    ).mock.calls[0]
+    const [, , secondOnStart, secondOnComplete, secondDisplayText] = (
+      speakCharacter as jest.Mock
+    ).mock.calls[1]
+
+    expect(firstDisplayText).toBe('Bunkerkidsを紹介します。')
+    expect(secondDisplayText).toBe('Bunkerkidsを紹介します。')
 
     firstOnStart()
     secondOnStart()
@@ -166,8 +171,10 @@ describe('speechDispatcher', () => {
   it('空の表示文を発話文へフォールバックしない', () => {
     const d = createSpeechDispatcher('session-1', { displayMessage: '' })
     d.dispatch(speech('バンカーキッズを紹介します。'))
-    const [, , onStart, onComplete] = (speakCharacter as jest.Mock).mock
-      .calls[0]
+    const [, , onStart, onComplete, displayText] = (speakCharacter as jest.Mock)
+      .mock.calls[0]
+
+    expect(displayText).toBe('')
 
     onStart()
     expect(homeStore.setState).toHaveBeenCalledWith({ slideMessages: [''] })

--- a/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
@@ -143,16 +143,23 @@ describe('speechDispatcher', () => {
     const d = createSpeechDispatcher('session-1', {
       displayMessage: 'Bunkerkidsを紹介します。',
     })
-    d.dispatch(speech('バンカーキッズを紹介します。'))
-    const [, , onStart, onComplete] = (speakCharacter as jest.Mock).mock
-      .calls[0]
+    d.dispatch(speech('バンカーキッズを'))
+    d.dispatch(speech('紹介します。'))
+    const [, , firstOnStart, firstOnComplete] = (speakCharacter as jest.Mock)
+      .mock.calls[0]
+    const [, , secondOnStart, secondOnComplete] = (speakCharacter as jest.Mock)
+      .mock.calls[1]
 
-    onStart()
+    firstOnStart()
+    secondOnStart()
     expect(homeStore.setState).toHaveBeenCalledWith({
       slideMessages: ['Bunkerkidsを紹介します。'],
     })
+    ;(homeStore.setState as jest.Mock).mockClear()
+    firstOnComplete()
+    expect(homeStore.setState).not.toHaveBeenCalledWith({ slideMessages: [] })
 
-    onComplete()
+    secondOnComplete()
     expect(homeStore.setState).toHaveBeenLastCalledWith({ slideMessages: [] })
   })
 

--- a/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
@@ -141,7 +141,7 @@ describe('speechDispatcher', () => {
 
   it('発話文と異なる表示文を字幕へ維持する', () => {
     const d = createSpeechDispatcher('session-1', {
-      displayMessage: 'Bunkerkidsを紹介します。',
+      displayMessages: ['Bunkerkidsを', '紹介します。'],
     })
     d.dispatch(speech('バンカーキッズを'))
     d.dispatch(speech('紹介します。'))
@@ -152,24 +152,26 @@ describe('speechDispatcher', () => {
       speakCharacter as jest.Mock
     ).mock.calls[1]
 
-    expect(firstDisplayText).toBe('Bunkerkidsを紹介します。')
-    expect(secondDisplayText).toBe('Bunkerkidsを紹介します。')
+    expect(firstDisplayText).toBe('Bunkerkidsを')
+    expect(secondDisplayText).toBe('紹介します。')
 
     firstOnStart()
     secondOnStart()
-    expect(homeStore.setState).toHaveBeenCalledWith({
-      slideMessages: ['Bunkerkidsを紹介します。'],
+    expect(homeStore.setState).toHaveBeenLastCalledWith({
+      slideMessages: ['Bunkerkidsを', '紹介します。'],
     })
     ;(homeStore.setState as jest.Mock).mockClear()
     firstOnComplete()
-    expect(homeStore.setState).not.toHaveBeenCalledWith({ slideMessages: [] })
+    expect(homeStore.setState).toHaveBeenLastCalledWith({
+      slideMessages: ['紹介します。'],
+    })
 
     secondOnComplete()
     expect(homeStore.setState).toHaveBeenLastCalledWith({ slideMessages: [] })
   })
 
   it('空の表示文を発話文へフォールバックしない', () => {
-    const d = createSpeechDispatcher('session-1', { displayMessage: '' })
+    const d = createSpeechDispatcher('session-1', { displayMessages: [''] })
     d.dispatch(speech('バンカーキッズを紹介します。'))
     const [, , onStart, onComplete, displayText] = (speakCharacter as jest.Mock)
       .mock.calls[0]

--- a/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
@@ -138,4 +138,21 @@ describe('speechDispatcher', () => {
     expect(mockHomeState.decrementChatProcessingCount).toHaveBeenCalled()
     expect(homeStore.setState).toHaveBeenLastCalledWith({ slideMessages: [] })
   })
+
+  it('発話文と異なる表示文を字幕へ維持する', () => {
+    const d = createSpeechDispatcher('session-1', {
+      displayMessage: 'Bunkerkidsを紹介します。',
+    })
+    d.dispatch(speech('バンカーキッズを紹介します。'))
+    const [, , onStart, onComplete] = (speakCharacter as jest.Mock).mock
+      .calls[0]
+
+    onStart()
+    expect(homeStore.setState).toHaveBeenCalledWith({
+      slideMessages: ['Bunkerkidsを紹介します。'],
+    })
+
+    onComplete()
+    expect(homeStore.setState).toHaveBeenLastCalledWith({ slideMessages: [] })
+  })
 })

--- a/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
@@ -155,4 +155,17 @@ describe('speechDispatcher', () => {
     onComplete()
     expect(homeStore.setState).toHaveBeenLastCalledWith({ slideMessages: [] })
   })
+
+  it('空の表示文を発話文へフォールバックしない', () => {
+    const d = createSpeechDispatcher('session-1', { displayMessage: '' })
+    d.dispatch(speech('バンカーキッズを紹介します。'))
+    const [, , onStart, onComplete] = (speakCharacter as jest.Mock).mock
+      .calls[0]
+
+    onStart()
+    expect(homeStore.setState).toHaveBeenCalledWith({ slideMessages: [''] })
+
+    onComplete()
+    expect(homeStore.setState).toHaveBeenLastCalledWith({ slideMessages: [] })
+  })
 })

--- a/src/__tests__/features/messages/speakQueue.test.ts
+++ b/src/__tests__/features/messages/speakQueue.test.ts
@@ -161,6 +161,38 @@ describe('SpeakQueue', () => {
       })
     })
 
+    it('should expose display text while speaking synthesized text', async () => {
+      const queue = SpeakQueue.getInstance()
+      queue.checkSessionId('session1')
+      const task = {
+        ...createTask('session1'),
+        displayText: 'Bunkerkidsを紹介します。',
+        talk: {
+          emotion: 'neutral' as const,
+          message: 'バンカーキッズを紹介します。',
+        },
+      }
+      mockModelSpeak.mockImplementationOnce(
+        async (_buffer, _talk, _isNeedDecode, observer) => {
+          observer?.onPlaybackStart?.()
+        }
+      )
+
+      await queue.addTask(task)
+
+      expect(mockModelSpeak).toHaveBeenCalledWith(
+        task.audioBuffer,
+        task.talk,
+        task.isNeedDecode,
+        { onPlaybackStart: expect.any(Function) }
+      )
+      expect(mockHomeSetState).toHaveBeenCalledWith({
+        activeSpeech: expect.objectContaining({
+          text: 'Bunkerkidsを紹介します。',
+        }),
+      })
+    })
+
     it('should process a PCM16 stream via the VRM model', async () => {
       const queue = SpeakQueue.getInstance()
       queue.checkSessionId('session1')

--- a/src/__tests__/features/presentation/presentation.test.ts
+++ b/src/__tests__/features/presentation/presentation.test.ts
@@ -128,6 +128,10 @@ describe('external presentation domain', () => {
     oversizedNarration.sections[0].slides[0].narration = 'x'.repeat(10_001)
     expect(validateExternalPresentation(oversizedNarration).ok).toBe(false)
 
+    const maxSpeechText = createManifest()
+    maxSpeechText.sections[0].slides[0].speechText = 'x'.repeat(10_000)
+    expect(validateExternalPresentation(maxSpeechText).ok).toBe(true)
+
     const oversizedSpeechText = createManifest()
     oversizedSpeechText.sections[0].slides[0].speechText = 'x'.repeat(10_001)
     expect(validateExternalPresentation(oversizedSpeechText).ok).toBe(false)

--- a/src/__tests__/features/presentation/presentation.test.ts
+++ b/src/__tests__/features/presentation/presentation.test.ts
@@ -6,6 +6,10 @@ import { buildPresentationPromptContext } from '@/features/presentation/presenta
 import { sanitizePresentationHtml } from '@/features/presentation/presentationSanitizer'
 import { validateExternalPresentation } from '@/features/presentation/presentationSchema'
 import {
+  getPresentationDisplayNarration,
+  getPresentationSpeechText,
+} from '@/features/presentation/presentationText'
+import {
   applyPresentationControlAction,
   completePresentationNarration,
 } from '@/features/presentation/presentationStateMachine'
@@ -57,6 +61,25 @@ describe('external presentation domain', () => {
     expect(document.sections[1].slides[0].pauseAfter).toBe(true)
   })
 
+  it('keeps display narration and speech text separate with compatible fallbacks', () => {
+    const separated = {
+      narration: 'Bunkerkidsを紹介します。',
+      speechText: 'バンカーキッズを紹介します。',
+    }
+    expect(getPresentationDisplayNarration(separated)).toBe(
+      'Bunkerkidsを紹介します。'
+    )
+    expect(getPresentationSpeechText(separated)).toBe(
+      'バンカーキッズを紹介します。'
+    )
+    expect(getPresentationDisplayNarration({ speechText: '発話だけ' })).toBe(
+      '発話だけ'
+    )
+    expect(getPresentationSpeechText({ narration: '従来の原稿' })).toBe(
+      '従来の原稿'
+    )
+  })
+
   it.each([
     [
       'duplicate slide IDs',
@@ -104,6 +127,10 @@ describe('external presentation domain', () => {
     const oversizedNarration = createManifest()
     oversizedNarration.sections[0].slides[0].narration = 'x'.repeat(10_001)
     expect(validateExternalPresentation(oversizedNarration).ok).toBe(false)
+
+    const oversizedSpeechText = createManifest()
+    oversizedSpeechText.sections[0].slides[0].speechText = 'x'.repeat(10_001)
+    expect(validateExternalPresentation(oversizedSpeechText).ok).toBe(false)
 
     const tooManySections = createManifest()
     tooManySections.sections = Array.from({ length: 51 }, (_, index) => ({

--- a/src/__tests__/pages/api/v1/presentationApi.test.ts
+++ b/src/__tests__/pages/api/v1/presentationApi.test.ts
@@ -23,7 +23,14 @@ const createManifest = (): PresentationManifestV1 => ({
     {
       id: 'section-1',
       title: 'Section',
-      slides: [{ id: 'slide-1', markdown: '# Test', narration: 'Hello' }],
+      slides: [
+        {
+          id: 'slide-1',
+          markdown: '# Test',
+          narration: 'Bunkerkidsを紹介します。',
+          speechText: 'バンカーキッズを紹介します。',
+        },
+      ],
     },
   ],
 })
@@ -94,6 +101,12 @@ describe('external presentation API', () => {
         ok: true,
         presentation: expect.objectContaining({ presentationId: 'api-test' }),
         contentHash: expect.stringMatching(/^sha256:/),
+      })
+    )
+    expect(fetched._json.presentation.sections[0].slides[0]).toEqual(
+      expect.objectContaining({
+        narration: 'Bunkerkidsを紹介します。',
+        speechText: 'バンカーキッズを紹介します。',
       })
     )
   })

--- a/src/components/slides.tsx
+++ b/src/components/slides.tsx
@@ -6,7 +6,10 @@ import presentationStore, {
   finishCurrentPresentationNarration,
 } from '@/features/stores/presentation'
 import { serializeExternalPresentationMarkdown } from '@/features/presentation/externalPresentationMarkdown'
-import { getPresentationSpeechText } from '@/features/presentation/presentationText'
+import {
+  getPresentationDisplayNarration,
+  getPresentationSpeechText,
+} from '@/features/presentation/presentationText'
 import homeStore from '@/features/stores/home'
 import { speakMessageHandler } from '@/features/chat/handlers'
 import { SpeakQueue } from '@/features/messages/speakQueue'
@@ -174,7 +177,9 @@ const Slides: React.FC<SlidesProps> = ({
       return
     }
 
-    void speakMessageHandler(speechText)
+    void speakMessageHandler(speechText, {
+      displayMessage: getPresentationDisplayNarration(current.slide),
+    })
       .catch((error) => {
         logger.error('Presentation narration failed:', error)
       })

--- a/src/components/slides.tsx
+++ b/src/components/slides.tsx
@@ -6,6 +6,7 @@ import presentationStore, {
   finishCurrentPresentationNarration,
 } from '@/features/stores/presentation'
 import { serializeExternalPresentationMarkdown } from '@/features/presentation/externalPresentationMarkdown'
+import { getPresentationSpeechText } from '@/features/presentation/presentationText'
 import homeStore from '@/features/stores/home'
 import { speakMessageHandler } from '@/features/chat/handlers'
 import { SpeakQueue } from '@/features/messages/speakQueue'
@@ -166,14 +167,14 @@ const Slides: React.FC<SlidesProps> = ({
 
     narrationKeyRef.current = key
     narrationObservedRef.current = false
-    const narration = current.slide.narration?.trim() ?? ''
-    if (!narration) {
+    const speechText = getPresentationSpeechText(current.slide)
+    if (!speechText) {
       narrationKeyRef.current = null
       finishCurrentPresentationNarration()
       return
     }
 
-    void speakMessageHandler(narration)
+    void speakMessageHandler(speechText)
       .catch((error) => {
         logger.error('Presentation narration failed:', error)
       })

--- a/src/features/chat/speechPipeline/speakMessageHandler.ts
+++ b/src/features/chat/speechPipeline/speakMessageHandler.ts
@@ -14,31 +14,55 @@ import settingsStore from '@/features/stores/settings'
  * （表示形式のみ現行の正規化フォーマットを踏襲。設計§5.1）。
  * chatProcessing管理・記憶保存・思考ポーズは行わない（現行踏襲）。
  */
+export type SpeakMessageOptions = {
+  speechSessionId?: string
+  displayMessage?: string
+}
+
 export const speakMessageHandler = async (
   receivedMessage: string,
-  speechSessionId?: string
+  speechSessionIdOrOptions?: string | SpeakMessageOptions
 ) => {
-  const sessionId = speechSessionId || generateMessageId()
+  const options =
+    typeof speechSessionIdOrOptions === 'string'
+      ? { speechSessionId: speechSessionIdOrOptions }
+      : (speechSessionIdOrOptions ?? {})
+  const sessionId = options.speechSessionId || generateMessageId()
   const writer = new NormalizedMessageLogWriter()
-  const dispatcher = createSpeechDispatcher(sessionId)
-  const segmenter = new SpeechSegmenter({
-    firstSpeechCommaMinChars: getFirstSpeechCommaMinChars(
-      settingsStore.getState().selectVoice
-    ),
+  const dispatcher = createSpeechDispatcher(sessionId, {
+    displayMessage: options.displayMessage?.trim(),
   })
+  const createSegmenter = () =>
+    new SpeechSegmenter({
+      firstSpeechCommaMinChars: getFirstSpeechCommaMinChars(
+        settingsStore.getState().selectVoice
+      ),
+    })
+  const speechSegmenter = createSegmenter()
+  const hasSeparateDisplayMessage =
+    options.displayMessage !== undefined &&
+    options.displayMessage !== receivedMessage
 
-  const handleEvent = (event: SegmenterEvent) => {
-    writer.handleEvent(event)
-    if (event.kind === 'speech') {
-      dispatcher.dispatch(event)
+  if (hasSeparateDisplayMessage) {
+    const displaySegmenter = createSegmenter()
+    for (const event of displaySegmenter.push(options.displayMessage ?? '')) {
+      writer.handleEvent(event)
+    }
+    for (const event of displaySegmenter.flush()) {
+      writer.handleEvent(event)
     }
   }
 
-  for (const event of segmenter.push(receivedMessage)) {
-    handleEvent(event)
+  const handleSpeechEvent = (event: SegmenterEvent) => {
+    if (!hasSeparateDisplayMessage) writer.handleEvent(event)
+    if (event.kind === 'speech') dispatcher.dispatch(event)
   }
-  for (const event of segmenter.flush()) {
-    handleEvent(event)
+
+  for (const event of speechSegmenter.push(receivedMessage)) {
+    handleSpeechEvent(event)
+  }
+  for (const event of speechSegmenter.flush()) {
+    handleSpeechEvent(event)
   }
   writer.finalize()
 }

--- a/src/features/chat/speechPipeline/speakMessageHandler.ts
+++ b/src/features/chat/speechPipeline/speakMessageHandler.ts
@@ -29,9 +29,6 @@ export const speakMessageHandler = async (
       : (speechSessionIdOrOptions ?? {})
   const sessionId = options.speechSessionId || generateMessageId()
   const writer = new NormalizedMessageLogWriter()
-  const dispatcher = createSpeechDispatcher(sessionId, {
-    displayMessage: options.displayMessage?.trim(),
-  })
   const createSegmenter = () =>
     new SpeechSegmenter({
       firstSpeechCommaMinChars: getFirstSpeechCommaMinChars(
@@ -39,19 +36,31 @@ export const speakMessageHandler = async (
       ),
     })
   const speechSegmenter = createSegmenter()
+  const normalizedDisplayMessage = options.displayMessage?.trim()
   const hasSeparateDisplayMessage =
-    options.displayMessage !== undefined &&
-    options.displayMessage !== receivedMessage
+    normalizedDisplayMessage !== undefined &&
+    normalizedDisplayMessage !== receivedMessage
+  const displaySpeechSegments: string[] = []
 
   if (hasSeparateDisplayMessage) {
     const displaySegmenter = createSegmenter()
-    for (const event of displaySegmenter.push(options.displayMessage ?? '')) {
+    const handleDisplayEvent = (event: SegmenterEvent) => {
       writer.handleEvent(event)
+      if (event.kind === 'speech') displaySpeechSegments.push(event.text)
+    }
+    for (const event of displaySegmenter.push(normalizedDisplayMessage ?? '')) {
+      handleDisplayEvent(event)
     }
     for (const event of displaySegmenter.flush()) {
-      writer.handleEvent(event)
+      handleDisplayEvent(event)
     }
   }
+
+  const dispatcher = createSpeechDispatcher(sessionId, {
+    displayMessages: hasSeparateDisplayMessage
+      ? displaySpeechSegments
+      : undefined,
+  })
 
   const handleSpeechEvent = (event: SegmenterEvent) => {
     if (!hasSeparateDisplayMessage) writer.handleEvent(event)

--- a/src/features/chat/speechPipeline/speechDispatcher.ts
+++ b/src/features/chat/speechPipeline/speechDispatcher.ts
@@ -27,6 +27,10 @@ export type SpeechDispatcher = {
   readonly disabled: boolean
 }
 
+export type SpeechDispatcherOptions = {
+  displayMessage?: string
+}
+
 /**
  * 応答セッション1回分の発話ディスパッチャ。
  *
@@ -37,13 +41,17 @@ export type SpeechDispatcher = {
  *   他セッション向けならトークンを追従して発話を継続する
  * - 自分より新しい応答セッションが登録されたら無効化
  */
-export const createSpeechDispatcher = (sessionId: string): SpeechDispatcher => {
+export const createSpeechDispatcher = (
+  sessionId: string,
+  options: SpeechDispatcherOptions = {}
+): SpeechDispatcher => {
   latestResponseSessionId = sessionId
   let capturedToken: number | null = null
   let disabled = false
   let anyDispatched = false
   // スライド字幕はこの応答の発話中文リストで全置換する（旧refベース実装の踏襲）
   const slideMessages: string[] = []
+  let activeDisplaySegments = 0
 
   const dispatch = (event: SpeechEvent): boolean => {
     if (disabled) return false
@@ -70,7 +78,15 @@ export const createSpeechDispatcher = (sessionId: string): SpeechDispatcher => {
     // ガード3: 発話可否（記号・空白のみは発話しない）
     if (!isSpeakableText(event.text)) return false
 
-    speakOne(sessionId, event, slideMessages)
+    speakOne(sessionId, event, slideMessages, options.displayMessage, {
+      start: () => {
+        activeDisplaySegments += 1
+      },
+      complete: () => {
+        activeDisplaySegments = Math.max(0, activeDisplaySegments - 1)
+        return activeDisplaySegments
+      },
+    })
     anyDispatched = true
     return true
   }
@@ -91,7 +107,9 @@ export const createSpeechDispatcher = (sessionId: string): SpeechDispatcher => {
 const speakOne = (
   sessionId: string,
   event: SpeechEvent,
-  slideMessages: string[]
+  slideMessages: string[],
+  displayMessage: string | undefined,
+  displaySegments: { start: () => void; complete: () => number }
 ) => {
   const hs = homeStore.getState()
   const emotion = event.emotionTag.includes('[')
@@ -107,13 +125,23 @@ const speakOne = (
     },
     () => {
       hs.incrementChatProcessingCount()
-      slideMessages.push(event.text)
-      homeStore.setState({ slideMessages: [...slideMessages] })
+      if (displayMessage) {
+        displaySegments.start()
+        homeStore.setState({ slideMessages: [displayMessage] })
+      } else {
+        slideMessages.push(event.text)
+        homeStore.setState({ slideMessages: [...slideMessages] })
+      }
     },
     () => {
       hs.decrementChatProcessingCount()
-      slideMessages.shift()
-      homeStore.setState({ slideMessages: [...slideMessages] })
+      if (displayMessage) {
+        const remaining = displaySegments.complete()
+        if (remaining === 0) homeStore.setState({ slideMessages: [] })
+      } else {
+        slideMessages.shift()
+        homeStore.setState({ slideMessages: [...slideMessages] })
+      }
     }
   )
 }

--- a/src/features/chat/speechPipeline/speechDispatcher.ts
+++ b/src/features/chat/speechPipeline/speechDispatcher.ts
@@ -28,7 +28,7 @@ export type SpeechDispatcher = {
 }
 
 export type SpeechDispatcherOptions = {
-  displayMessage?: string
+  displayMessages?: string[]
 }
 
 /**
@@ -51,7 +51,7 @@ export const createSpeechDispatcher = (
   let anyDispatched = false
   // スライド字幕はこの応答の発話中文リストで全置換する（旧refベース実装の踏襲）
   const slideMessages: string[] = []
-  let activeDisplaySegments = 0
+  let displayMessageIndex = 0
 
   const dispatch = (event: SpeechEvent): boolean => {
     if (disabled) return false
@@ -78,15 +78,9 @@ export const createSpeechDispatcher = (
     // ガード3: 発話可否（記号・空白のみは発話しない）
     if (!isSpeakableText(event.text)) return false
 
-    speakOne(sessionId, event, slideMessages, options.displayMessage, {
-      start: () => {
-        activeDisplaySegments += 1
-      },
-      complete: () => {
-        activeDisplaySegments = Math.max(0, activeDisplaySegments - 1)
-        return activeDisplaySegments
-      },
-    })
+    const displayMessage = options.displayMessages?.[displayMessageIndex]
+    displayMessageIndex += 1
+    speakOne(sessionId, event, slideMessages, displayMessage)
     anyDispatched = true
     return true
   }
@@ -108,8 +102,7 @@ const speakOne = (
   sessionId: string,
   event: SpeechEvent,
   slideMessages: string[],
-  displayMessage: string | undefined,
-  displaySegments: { start: () => void; complete: () => number }
+  displayMessage: string | undefined
 ) => {
   const hs = homeStore.getState()
   const emotion = event.emotionTag.includes('[')
@@ -123,23 +116,13 @@ const speakOne = (
   }
   const onStart = () => {
     hs.incrementChatProcessingCount()
-    if (displayMessage !== undefined) {
-      displaySegments.start()
-      homeStore.setState({ slideMessages: [displayMessage] })
-    } else {
-      slideMessages.push(event.text)
-      homeStore.setState({ slideMessages: [...slideMessages] })
-    }
+    slideMessages.push(displayMessage ?? event.text)
+    homeStore.setState({ slideMessages: [...slideMessages] })
   }
   const onComplete = () => {
     hs.decrementChatProcessingCount()
-    if (displayMessage !== undefined) {
-      const remaining = displaySegments.complete()
-      if (remaining === 0) homeStore.setState({ slideMessages: [] })
-    } else {
-      slideMessages.shift()
-      homeStore.setState({ slideMessages: [...slideMessages] })
-    }
+    slideMessages.shift()
+    homeStore.setState({ slideMessages: [...slideMessages] })
   }
 
   if (displayMessage !== undefined) {

--- a/src/features/chat/speechPipeline/speechDispatcher.ts
+++ b/src/features/chat/speechPipeline/speechDispatcher.ts
@@ -116,32 +116,35 @@ const speakOne = (
     ? (event.emotionTag.slice(1, -1).toLowerCase() as EmotionType)
     : 'neutral'
 
-  speakCharacter(
-    sessionId,
-    {
-      message: event.text,
-      emotion,
-      motion: event.motionTag || undefined,
-    },
-    () => {
-      hs.incrementChatProcessingCount()
-      if (displayMessage !== undefined) {
-        displaySegments.start()
-        homeStore.setState({ slideMessages: [displayMessage] })
-      } else {
-        slideMessages.push(event.text)
-        homeStore.setState({ slideMessages: [...slideMessages] })
-      }
-    },
-    () => {
-      hs.decrementChatProcessingCount()
-      if (displayMessage !== undefined) {
-        const remaining = displaySegments.complete()
-        if (remaining === 0) homeStore.setState({ slideMessages: [] })
-      } else {
-        slideMessages.shift()
-        homeStore.setState({ slideMessages: [...slideMessages] })
-      }
+  const talk = {
+    message: event.text,
+    emotion,
+    motion: event.motionTag || undefined,
+  }
+  const onStart = () => {
+    hs.incrementChatProcessingCount()
+    if (displayMessage !== undefined) {
+      displaySegments.start()
+      homeStore.setState({ slideMessages: [displayMessage] })
+    } else {
+      slideMessages.push(event.text)
+      homeStore.setState({ slideMessages: [...slideMessages] })
     }
-  )
+  }
+  const onComplete = () => {
+    hs.decrementChatProcessingCount()
+    if (displayMessage !== undefined) {
+      const remaining = displaySegments.complete()
+      if (remaining === 0) homeStore.setState({ slideMessages: [] })
+    } else {
+      slideMessages.shift()
+      homeStore.setState({ slideMessages: [...slideMessages] })
+    }
+  }
+
+  if (displayMessage !== undefined) {
+    speakCharacter(sessionId, talk, onStart, onComplete, displayMessage)
+  } else {
+    speakCharacter(sessionId, talk, onStart, onComplete)
+  }
 }

--- a/src/features/chat/speechPipeline/speechDispatcher.ts
+++ b/src/features/chat/speechPipeline/speechDispatcher.ts
@@ -125,7 +125,7 @@ const speakOne = (
     },
     () => {
       hs.incrementChatProcessingCount()
-      if (displayMessage) {
+      if (displayMessage !== undefined) {
         displaySegments.start()
         homeStore.setState({ slideMessages: [displayMessage] })
       } else {
@@ -135,7 +135,7 @@ const speakOne = (
     },
     () => {
       hs.decrementChatProcessingCount()
-      if (displayMessage) {
+      if (displayMessage !== undefined) {
         const remaining = displaySegments.complete()
         if (remaining === 0) homeStore.setState({ slideMessages: [] })
       } else {

--- a/src/features/messages/speakCharacter.ts
+++ b/src/features/messages/speakCharacter.ts
@@ -49,6 +49,7 @@ type PendingSpeakResult = {
   sessionId: string
   audio: SynthesizedSpeech | null
   talk: Talk
+  displayText?: string
   onComplete?: () => void
   tokenAtStart: number
 }
@@ -275,6 +276,7 @@ const createSpeakCharacter = () => {
       void speakQueue.addTask({
         sessionId: result.sessionId,
         talk: result.talk,
+        displayText: result.displayText,
         ...result.audio,
         onPlaybackStart: () =>
           markConversationLatency(result.sessionId, 'playback_started'),
@@ -287,7 +289,8 @@ const createSpeakCharacter = () => {
     sessionId: string,
     talk: Talk,
     onStart?: () => void,
-    onComplete?: () => void
+    onComplete?: () => void,
+    displayText?: string
   ) => {
     let called = false
     const ss = settingsStore.getState()
@@ -429,6 +432,7 @@ const createSpeakCharacter = () => {
         sessionId,
         audio,
         talk,
+        displayText,
         onComplete: guardedOnComplete,
         tokenAtStart: initialToken,
       }
@@ -445,6 +449,7 @@ const createSpeakCharacter = () => {
           sessionId,
           audio: result?.audio ?? null,
           talk,
+          displayText,
           onComplete: guardedOnComplete,
           tokenAtStart: result?.tokenAtStart ?? initialToken,
         })

--- a/src/features/messages/speakQueue.ts
+++ b/src/features/messages/speakQueue.ts
@@ -6,6 +6,7 @@ import { getCharacterRenderer } from './characterRenderer'
 type SpeakTaskBase = {
   sessionId: string
   talk: Talk
+  displayText?: string
   onPlaybackStart?: () => void
   onComplete?: () => void
 }
@@ -234,7 +235,7 @@ export class SpeakQueue {
           const renderer = getCharacterRenderer()
           const activeSpeech = {
             id: `speech-${Date.now()}-${++SpeakQueue.speechTaskCounter}`,
-            text: task.talk.message,
+            text: task.displayText ?? task.talk.message,
           }
           const observer = {
             onPlaybackStart: () => {

--- a/src/features/presentation/presentationPromptContext.ts
+++ b/src/features/presentation/presentationPromptContext.ts
@@ -1,5 +1,5 @@
-import type { PresentationDocument } from './presentationTypes'
-import { getPresentationDisplayNarration } from './presentationText'
+import type { PresentationDocument } from '@/features/presentation/presentationTypes'
+import { getPresentationDisplayNarration } from '@/features/presentation/presentationText'
 
 const escapeXml = (value: string) =>
   value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')

--- a/src/features/presentation/presentationPromptContext.ts
+++ b/src/features/presentation/presentationPromptContext.ts
@@ -1,4 +1,5 @@
 import type { PresentationDocument } from './presentationTypes'
+import { getPresentationDisplayNarration } from './presentationText'
 
 const escapeXml = (value: string) =>
   value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
@@ -25,8 +26,8 @@ export const buildPresentationPromptContext = (
     })
     .join('\n')
   const narrations = visibleSlides
-    .map((item) => item.narration)
-    .filter((item): item is string => Boolean(item))
+    .map(getPresentationDisplayNarration)
+    .filter(Boolean)
     .join('\n')
 
   const material = [

--- a/src/features/presentation/presentationSchema.ts
+++ b/src/features/presentation/presentationSchema.ts
@@ -7,6 +7,7 @@ export const PRESENTATION_LIMITS = {
   slides: 200,
   markdown: 50_000,
   narration: 10_000,
+  speechText: 10_000,
   qaBrief: 100_000,
   sources: 500,
   notes: 10_000,
@@ -70,6 +71,7 @@ const slideSchema = z.object({
       'Markdown cannot contain standalone slide separators'
     ),
   narration: z.string().max(PRESENTATION_LIMITS.narration).optional(),
+  speechText: z.string().max(PRESENTATION_LIMITS.speechText).optional(),
   notes: z.string().max(PRESENTATION_LIMITS.notes).optional(),
   pauseAfter: z.boolean().optional(),
   assets: z

--- a/src/features/presentation/presentationText.ts
+++ b/src/features/presentation/presentationText.ts
@@ -1,0 +1,9 @@
+import type { PresentationSlideV1 } from './presentationTypes'
+
+export const getPresentationDisplayNarration = (
+  slide: Pick<PresentationSlideV1, 'narration' | 'speechText'>
+) => (slide.narration ?? slide.speechText)?.trim() ?? ''
+
+export const getPresentationSpeechText = (
+  slide: Pick<PresentationSlideV1, 'narration' | 'speechText'>
+) => (slide.speechText ?? slide.narration)?.trim() ?? ''

--- a/src/features/presentation/presentationText.ts
+++ b/src/features/presentation/presentationText.ts
@@ -1,4 +1,4 @@
-import type { PresentationSlideV1 } from './presentationTypes'
+import type { PresentationSlideV1 } from '@/features/presentation/presentationTypes'
 
 export const getPresentationDisplayNarration = (
   slide: Pick<PresentationSlideV1, 'narration' | 'speechText'>

--- a/src/features/presentation/presentationTypes.ts
+++ b/src/features/presentation/presentationTypes.ts
@@ -25,6 +25,7 @@ export interface PresentationSlideV1 {
   id: string
   markdown: string
   narration?: string
+  speechText?: string
   notes?: string
   pauseAfter?: boolean
   assets?: PresentationAssetV1[]


### PR DESCRIPTION
## Summary

- 外部プレゼンテーションの画面・chatLog・発話中字幕・会話文脈・外部caption用原稿 `narration` と、TTS発話用テキスト `speechText` を分離しました。
- 発話は `speechText ?? narration`、表示・会話文脈は `narration ?? speechText` の順でフォールバックします。
- `speechText` をAPIスキーマ・型・仕様書へ追加し、10,000文字の上限とAPI往復テストを追加しました。
- `speakMessageHandler` に後方互換なオプション引数を追加し、表示文はchatLog writerと字幕、発話文だけはTTS dispatcherへ渡します。
- 表示文も既存の `SpeechSegmenter` で分割してTTS発話チャンクと順番に対応させ、各チャンクの正式表記を `activeSpeech.text`、`speech_chunk_started.text`、nikechan-live-studioの `/obs/captions` へ公開します。

## 仕様・後方互換性

- 既存Producerが `narration` のみ送る場合は、従来どおり同じ文言を表示・文脈・TTSに利用します。
- `speechText` のみの場合も表示・会話文脈へフォールバックします。
- 両方とも任意のため、発話のない視覚専用スライドも引き続き利用できます。
- `narration` が明示的な空文字列の場合も、字幕を `speechText` へ戻さず空表示を維持します。
- 字幕・外部captionの更新単位は従来どおり文・発話チャンク単位で、スライド全文を各チャンクへ重複表示しません。

## 背景

実運用では、画面表示と会話文脈にはブランド表記の `Bunkerkids` を残しつつ、TTSには自然な日本語読みの「バンカーキッズ」を渡す必要がありました。1つの `narration` では両方を同時に満たせないため、用途別に分離しています。

## Verification

- 関連4 suiteのフォーカステスト（78 tests passed）
- `npm run lint`（0 errors / 42 warnings。警告はすべて今回の変更外にある既知の警告）
- 変更対象のTypeScript/TSXファイルに対するESLint（0 errors / 0 warnings）
- `npm test -- --runInBand`（205 suites passed、2238 tests passed、7 skipped）
- `npm run build`（production build成功）
- 実動確認: `/api/obs/state` の `caption.text` が `Bunkerkidsを紹介します。` になることを確認

## Notes

- スキーマバージョンは1のまま、任意フィールド追加として後方互換を維持しています。
- 本作業ではマージ操作を行っていません（PRは別操作によりマージ済みです）。
