### PR TITLE
fix: 発話開始ステータスを字幕へ遅延なく通知

### DIFF
--- a/src/__tests__/features/presentation/assignmentReconciliation.test.ts
+++ b/src/__tests__/features/presentation/assignmentReconciliation.test.ts
@@ -48,6 +48,29 @@ describe('createAssignmentReconciliationRunner', () => {
     expect(reconciled).toEqual([assignment(false), null])
     expect(onError).not.toHaveBeenCalled()
   })
+
+  it('失敗した世代を無限再試行せず次の割当を処理する', async () => {
+    const reconciled: Array<PresentationAssignment | null> = []
+    const onError = jest.fn()
+    const runner = createAssignmentReconciliationRunner(async (value) => {
+      reconciled.push(value)
+      if (reconciled.length === 1) throw new Error('load failed')
+    }, onError)
+
+    runner(assignment(false))
+    await waitFor(() => onError.mock.calls.length === 1)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(reconciled).toEqual([assignment(false)])
+
+    runner(assignment(true, 'presentation-2'))
+    await waitFor(() => reconciled.length === 2)
+
+    expect(reconciled).toEqual([
+      assignment(false),
+      assignment(true, 'presentation-2'),
+    ])
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
 })
 
 const waitFor = async (condition: () => boolean) => {

--- a/src/__tests__/features/presentation/assignmentReconciliation.test.ts
+++ b/src/__tests__/features/presentation/assignmentReconciliation.test.ts
@@ -50,25 +50,24 @@ describe('createAssignmentReconciliationRunner', () => {
   })
 
   it('失敗した世代を無限再試行せず次の割当を処理する', async () => {
+    const failedAssignment = assignment(false)
+    const nextAssignment = assignment(true, 'presentation-2')
     const reconciled: Array<PresentationAssignment | null> = []
     const onError = jest.fn()
     const runner = createAssignmentReconciliationRunner(async (value) => {
       reconciled.push(value)
-      if (reconciled.length === 1) throw new Error('load failed')
+      if (value === failedAssignment) throw new Error('load failed')
     }, onError)
 
-    runner(assignment(false))
+    runner(failedAssignment)
     await waitFor(() => onError.mock.calls.length === 1)
-    await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(reconciled).toEqual([assignment(false)])
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(reconciled).toEqual([failedAssignment])
 
-    runner(assignment(true, 'presentation-2'))
+    runner(nextAssignment)
     await waitFor(() => reconciled.length === 2)
 
-    expect(reconciled).toEqual([
-      assignment(false),
-      assignment(true, 'presentation-2'),
-    ])
+    expect(reconciled).toEqual([failedAssignment, nextAssignment])
     expect(onError).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/__tests__/features/presentation/assignmentReconciliation.test.ts
+++ b/src/__tests__/features/presentation/assignmentReconciliation.test.ts
@@ -1,0 +1,59 @@
+import { createAssignmentReconciliationRunner } from '@/features/presentation/assignmentReconciliation'
+import type { PresentationAssignment } from '@/features/presentation/presentationTypes'
+
+const assignment = (
+  autoStart: boolean,
+  presentationId = 'presentation-1'
+): PresentationAssignment => ({ presentationId, revision: 1, autoStart })
+
+describe('createAssignmentReconciliationRunner', () => {
+  it('処理中に届いた同一Presentationの最新autoStartを再評価する', async () => {
+    let releaseFirst!: () => void
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const reconciled: Array<PresentationAssignment | null> = []
+    const onError = jest.fn()
+    const runner = createAssignmentReconciliationRunner(async (value) => {
+      reconciled.push(value)
+      if (reconciled.length === 1) await firstPending
+    }, onError)
+
+    runner(assignment(false))
+    runner(assignment(true))
+    releaseFirst()
+    await waitFor(() => reconciled.length === 2)
+
+    expect(reconciled).toEqual([assignment(false), assignment(true)])
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('処理中の古い割当より後に届いた解除を最後に適用する', async () => {
+    let releaseFirst!: () => void
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const reconciled: Array<PresentationAssignment | null> = []
+    const onError = jest.fn()
+    const runner = createAssignmentReconciliationRunner(async (value) => {
+      reconciled.push(value)
+      if (reconciled.length === 1) await firstPending
+    }, onError)
+
+    runner(assignment(false))
+    runner(null)
+    releaseFirst()
+    await waitFor(() => reconciled.length === 2)
+
+    expect(reconciled).toEqual([assignment(false), null])
+    expect(onError).not.toHaveBeenCalled()
+  })
+})
+
+const waitFor = async (condition: () => boolean) => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (condition()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error('condition was not met')
+}

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -526,10 +526,14 @@ const MessageReceiver = () => {
           const previouslyAssigned = receiverHasAssignment
           receiverHasAssignment = Boolean(assignment)
           if (assignment || previouslyAssigned) {
-            await reconcileAssignment(assignment)
+            // Assignment loading can take several seconds. Do not hold the
+            // serialized status reporter while it runs: activeSpeech changes
+            // must reach the gateway at playback start so external captions
+            // do not miss the first spoken segment.
+            void reconcileAssignment(assignment)
           }
         } else if (!receiverHasAssignment) {
-          await reconcileAssignment(assignment)
+          void reconcileAssignment(assignment)
         }
       } catch (error) {
         logger.error('Error reporting client status:', error)

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -40,6 +40,7 @@ import {
   createOrderedReceiverDrainRunner,
   subscribeReceiverEventStream,
 } from '@/features/api/receiverEventStream'
+import { createAssignmentReconciliationRunner } from '@/features/presentation/assignmentReconciliation'
 
 const CLIENT_TAB_LEASE_DURATION = 5000
 const CLIENT_TAB_LEASE_REFRESH_INTERVAL = 2000
@@ -458,6 +459,11 @@ const MessageReceiver = () => {
       }
     }
 
+    const scheduleAssignmentReconciliation =
+      createAssignmentReconciliationRunner(reconcileAssignment, (error) =>
+        logger.error('Error reconciling presentation assignment:', error)
+      )
+
     const reportStatus = async (
       targetId: string,
       mode: 'receiver' | 'legacy'
@@ -526,14 +532,13 @@ const MessageReceiver = () => {
           const previouslyAssigned = receiverHasAssignment
           receiverHasAssignment = Boolean(assignment)
           if (assignment || previouslyAssigned) {
-            // Assignment loading can take several seconds. Do not hold the
-            // serialized status reporter while it runs: activeSpeech changes
-            // must reach the gateway at playback start so external captions
-            // do not miss the first spoken segment.
-            void reconcileAssignment(assignment)
+            // Assignment loading can take several seconds. Keep only the
+            // latest assignment in a separate serial drain so activeSpeech
+            // reports are not delayed and autoStart/unload updates are kept.
+            scheduleAssignmentReconciliation(assignment)
           }
         } else if (!receiverHasAssignment) {
-          void reconcileAssignment(assignment)
+          scheduleAssignmentReconciliation(assignment)
         }
       } catch (error) {
         logger.error('Error reporting client status:', error)

--- a/src/features/presentation/assignmentReconciliation.ts
+++ b/src/features/presentation/assignmentReconciliation.ts
@@ -1,0 +1,36 @@
+import type { PresentationAssignment } from '@/features/presentation/presentationTypes'
+
+export const createAssignmentReconciliationRunner = (
+  reconcile: (assignment: PresentationAssignment | null) => Promise<void>,
+  onError: (error: unknown) => void
+) => {
+  let pending: {
+    generation: number
+    assignment: PresentationAssignment | null
+  } | null = null
+  let generation = 0
+  let completedGeneration = 0
+  let running = false
+
+  const drain = async () => {
+    if (running) return
+    running = true
+    try {
+      while (pending && pending.generation > completedGeneration) {
+        const current = pending
+        await reconcile(current.assignment)
+        completedGeneration = current.generation
+      }
+    } catch (error) {
+      onError(error)
+    } finally {
+      running = false
+      if (pending && pending.generation > completedGeneration) void drain()
+    }
+  }
+
+  return (assignment: PresentationAssignment | null) => {
+    pending = { generation: ++generation, assignment }
+    void drain()
+  }
+}

--- a/src/features/presentation/assignmentReconciliation.ts
+++ b/src/features/presentation/assignmentReconciliation.ts
@@ -18,11 +18,14 @@ export const createAssignmentReconciliationRunner = (
     try {
       while (pending && pending.generation > completedGeneration) {
         const current = pending
-        await reconcile(current.assignment)
-        completedGeneration = current.generation
+        try {
+          await reconcile(current.assignment)
+        } catch (error) {
+          onError(error)
+        } finally {
+          completedGeneration = current.generation
+        }
       }
-    } catch (error) {
-      onError(error)
     } finally {
       running = false
       if (pending && pending.generation > completedGeneration) void drain()


### PR DESCRIPTION
## Summary

- プレゼン割当の読み込み・照合処理を、クライアント状態報告の直列処理から分離
- `activeSpeech` の開始・終了が割当同期の完了待ちに巻き込まれないよう修正
- 外部OBS字幕が先頭の音声チャンクを遅延・欠落する競合を解消

## Verification

- `npx eslint src/components/messageReceiver.tsx`
- Node.js v24.13.0でローカルAITuberKitを再起動
- nikechan-live-studioから先頭スライドを実再生し、最初のチャンク「最初のニュースは、」がOBS字幕へ表示されることを確認
- AITuberKitイベントとOBS字幕SSEの開始・終了順序を実測

## Notes

- 割当の読み込み自体は従来どおり実行し、重複読み込み防止も既存の`loadingPresentationKeys`を維持します。
- 表示・発話内容やPresentation API契約は変更しません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * プレゼンテーション割り当ての更新が、最新の情報を優先して順序どおりに反映されるようになりました。
  * 割り当ての同期処理中もステータス報告が継続され、よりスムーズに表示されます。
  * 同期中の自動開始や終了処理への影響を抑え、安定性を向上しました。
  * 同期エラーが発生した場合も処理が停止せず、後続の割り当てを処理できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->