### PR TITLE
fix: OBS字幕へ発話状態を即時通知する

### DIFF
--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -885,6 +885,133 @@ describe('/api/v1 external API', () => {
     ])
   })
 
+  it('reports active speech through the lightweight client endpoint', () => {
+    const {
+      getRecentApiEvents,
+      updateClientStatus,
+    } = require('@/features/api/messageGateway')
+    const speechStatus = require('@/pages/api/v1/client/speech-status').default
+
+    updateClientStatus('client1', {
+      connected: true,
+      chatProcessing: false,
+      isSpeaking: true,
+      activeSpeech: null,
+    })
+
+    const startedRes = createMockRes()
+    speechStatus(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { receiverId: 'client1' },
+        body: {
+          activeSpeech: {
+            id: 'speech-fast-1',
+            text: '再生開始と同時に表示します。',
+          },
+        },
+      }),
+      startedRes
+    )
+    expect(startedRes._status).toBe(200)
+
+    const endedRes = createMockRes()
+    speechStatus(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { receiverId: 'client1' },
+        body: { activeSpeech: null },
+      }),
+      endedRes
+    )
+    expect(endedRes._status).toBe(200)
+
+    expect(
+      getRecentApiEvents('client1').filter((event: { type: string }) =>
+        event.type.startsWith('speech_chunk_')
+      )
+    ).toEqual([
+      expect.objectContaining({
+        type: 'speech_chunk_started',
+        payload: {
+          speechChunkId: 'speech-fast-1',
+          text: '再生開始と同時に表示します。',
+        },
+      }),
+      expect.objectContaining({
+        type: 'speech_chunk_ended',
+        payload: { speechChunkId: 'speech-fast-1' },
+      }),
+    ])
+  })
+
+  it('rejects malformed active speech without ending the current chunk', () => {
+    const {
+      getClientStatus,
+      updateClientStatus,
+    } = require('@/features/api/messageGateway')
+    const speechStatus = require('@/pages/api/v1/client/speech-status').default
+    updateClientStatus('client1', {
+      connected: true,
+      chatProcessing: false,
+      isSpeaking: true,
+      activeSpeech: { id: 'speech-current', text: '再生中です。' },
+    })
+
+    const res = createMockRes()
+    speechStatus(
+      createMockReq({
+        method: 'POST',
+        headers: { authorization: 'Bearer test-api-key' },
+        query: { receiverId: 'client1' },
+        body: { activeSpeech: { id: 'missing-text' } },
+      }),
+      res
+    )
+
+    expect(res._status).toBe(400)
+    expect(getClientStatus('client1').activeSpeech).toEqual({
+      id: 'speech-current',
+      text: '再生中です。',
+    })
+  })
+
+  it('does not overwrite active speech when a general status omits it', () => {
+    const {
+      getClientStatus,
+      getRecentApiEvents,
+      updateClientActiveSpeech,
+      updateClientStatus,
+    } = require('@/features/api/messageGateway')
+    const baseStatus = {
+      connected: true,
+      chatProcessing: false,
+      isSpeaking: true,
+    }
+
+    updateClientStatus('client1', baseStatus)
+    updateClientActiveSpeech('client1', {
+      id: 'speech-current',
+      text: '現在再生しているチャンクです。',
+    })
+    updateClientStatus('client1', {
+      ...baseStatus,
+      modelType: 'vrm',
+    })
+
+    expect(getClientStatus('client1').activeSpeech).toEqual({
+      id: 'speech-current',
+      text: '現在再生しているチャンクです。',
+    })
+    expect(
+      getRecentApiEvents('client1').filter(
+        (event: { type: string }) => event.type === 'speech_chunk_ended'
+      )
+    ).toHaveLength(0)
+  })
+
   it('emits slide_changed only after a presentation finishes loading', () => {
     const {
       getRecentApiEvents,

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -549,28 +549,35 @@ const MessageReceiver = () => {
     ) => {
       const authHeaders = getClientApiHeaders()
       if (!authHeaders) return
-      let lastStatus = 0
+      let lastError: Error | null = null
       for (let attempt = 0; attempt < 3; attempt += 1) {
-        const response = await fetch(
-          `/api/v1/client/speech-status/?receiverId=${encodeURIComponent(receiverId)}`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              ...authHeaders,
-            },
-            body: JSON.stringify({ activeSpeech }),
-          }
-        )
-        if (response.ok) return
-        lastStatus = response.status
+        try {
+          const response = await fetch(
+            `/api/v1/client/speech-status/?receiverId=${encodeURIComponent(receiverId)}`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                ...authHeaders,
+              },
+              body: JSON.stringify({ activeSpeech }),
+            }
+          )
+          if (response.ok) return
+          lastError = new Error(`HTTP error! status: ${response.status}`)
+        } catch (error) {
+          lastError =
+            error instanceof Error
+              ? error
+              : new Error('Active speech status request failed')
+        }
         if (attempt < 2) {
           await new Promise((resolve) =>
             setTimeout(resolve, 50 * (attempt + 1))
           )
         }
       }
-      throw new Error(`HTTP error! status: ${lastStatus}`)
+      throw lastError ?? new Error('Active speech status request failed')
     }
 
     const fetchCommands = async (
@@ -774,7 +781,9 @@ const MessageReceiver = () => {
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
     void drainAllReceivers()
-    void safeReportStatus()
+    void safeReportStatus().then(() =>
+      enqueueActiveSpeechReport(homeStore.getState().activeSpeech)
+    )
 
     if (document.visibilityState === 'visible' && document.hasFocus()) {
       claimClientTabLeadership()

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -504,7 +504,6 @@ const MessageReceiver = () => {
                   }),
               connected: true,
               isSpeaking: hs.isSpeaking,
-              activeSpeech: hs.activeSpeech,
               chatProcessing: hs.chatProcessing,
               messageReceiverEnabled: ss.messageReceiverEnabled,
               modelType: ss.modelType,
@@ -543,6 +542,35 @@ const MessageReceiver = () => {
       } catch (error) {
         logger.error('Error reporting client status:', error)
       }
+    }
+
+    const reportActiveSpeech = async (
+      activeSpeech: { id: string; text: string } | null
+    ) => {
+      const authHeaders = getClientApiHeaders()
+      if (!authHeaders) return
+      let lastStatus = 0
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const response = await fetch(
+          `/api/v1/client/speech-status/?receiverId=${encodeURIComponent(receiverId)}`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...authHeaders,
+            },
+            body: JSON.stringify({ activeSpeech }),
+          }
+        )
+        if (response.ok) return
+        lastStatus = response.status
+        if (attempt < 2) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, 50 * (attempt + 1))
+          )
+        }
+      }
+      throw new Error(`HTTP error! status: ${lastStatus}`)
     }
 
     const fetchCommands = async (
@@ -643,6 +671,17 @@ const MessageReceiver = () => {
 
     let isReportingStatus = false
     let isStatusReportQueued = false
+    let activeSpeechReportChain = Promise.resolve()
+
+    const enqueueActiveSpeechReport = (
+      activeSpeech: { id: string; text: string } | null
+    ) => {
+      activeSpeechReportChain = activeSpeechReportChain
+        .then(() => reportActiveSpeech(activeSpeech))
+        .catch((error) =>
+          logger.error('Error reporting active speech status:', error)
+        )
+    }
 
     const drainReceiver = createOrderedReceiverDrainRunner({
       fetchCommands: () => fetchCommands(receiverId, 'receiver'),
@@ -691,6 +730,9 @@ const MessageReceiver = () => {
           state.activeSpeech?.id !== previousState.activeSpeech?.id
         ) {
           void safeReportStatus()
+        }
+        if (state.activeSpeech?.id !== previousState.activeSpeech?.id) {
+          enqueueActiveSpeechReport(state.activeSpeech)
         }
       }
     )

--- a/src/features/api/messageGateway.ts
+++ b/src/features/api/messageGateway.ts
@@ -471,13 +471,37 @@ export const dequeueCommands = (clientId: string): QueuedCommand[] => {
   return commands
 }
 
+const emitSpeechChunkTransition = (
+  clientId: string,
+  previousSpeech: ClientStatus['activeSpeech'],
+  nextSpeech: ClientStatus['activeSpeech']
+) => {
+  if (previousSpeech?.id === nextSpeech?.id) return
+  if (previousSpeech) {
+    emitApiEvent(clientId, 'speech_chunk_ended', {
+      speechChunkId: previousSpeech.id,
+    })
+  }
+  if (nextSpeech) {
+    emitApiEvent(clientId, 'speech_chunk_started', {
+      speechChunkId: nextSpeech.id,
+      text: nextSpeech.text,
+    })
+  }
+}
+
 export const updateClientStatus = (
   clientId: string,
   status: Omit<ClientStatus, 'clientId' | 'lastSeenAt'>
 ): ClientStatus => {
   const previousStatus = getGatewayState().statusesPerClient[clientId]
+  const activeSpeech =
+    status.activeSpeech === undefined
+      ? (previousStatus?.activeSpeech ?? null)
+      : status.activeSpeech
   const nextStatus: ClientStatus = {
     ...status,
+    activeSpeech,
     clientId,
     lastSeenAt: Date.now(),
   }
@@ -504,21 +528,11 @@ export const updateClientStatus = (
     )
   }
 
-  const previousSpeech = previousStatus?.activeSpeech ?? null
-  const nextSpeech = nextStatus.activeSpeech ?? null
-  if (previousSpeech?.id !== nextSpeech?.id) {
-    if (previousSpeech) {
-      emitApiEvent(clientId, 'speech_chunk_ended', {
-        speechChunkId: previousSpeech.id,
-      })
-    }
-    if (nextSpeech) {
-      emitApiEvent(clientId, 'speech_chunk_started', {
-        speechChunkId: nextSpeech.id,
-        text: nextSpeech.text,
-      })
-    }
-  }
+  emitSpeechChunkTransition(
+    clientId,
+    previousStatus?.activeSpeech ?? null,
+    nextStatus.activeSpeech ?? null
+  )
 
   const previousPresentation = previousStatus?.presentation
   const presentation = nextStatus.presentation
@@ -569,6 +583,25 @@ export const updateClientStatus = (
     }
   }
 
+  return nextStatus
+}
+
+export const updateClientActiveSpeech = (
+  clientId: string,
+  activeSpeech: ClientStatus['activeSpeech']
+): ClientStatus | null => {
+  const previousStatus = getGatewayState().statusesPerClient[clientId]
+  if (!previousStatus) return null
+
+  const previousSpeech = previousStatus.activeSpeech ?? null
+  const nextSpeech = activeSpeech ?? null
+  const nextStatus: ClientStatus = {
+    ...previousStatus,
+    activeSpeech: nextSpeech,
+    lastSeenAt: Date.now(),
+  }
+  getGatewayState().statusesPerClient[clientId] = nextStatus
+  emitSpeechChunkTransition(clientId, previousSpeech, nextSpeech)
   return nextStatus
 }
 

--- a/src/lib/accessPolicy/routePolicies.ts
+++ b/src/lib/accessPolicy/routePolicies.ts
@@ -583,6 +583,15 @@ export const routePolicies = {
     restrictedBehavior: 'deny',
     requiresApiKey: true,
   },
+  '/api/v1/client/speech-status': {
+    path: '/api/v1/client/speech-status',
+    featureName: 'v1/client/speech-status',
+    methods: ['POST'],
+    resources: ['external-control'],
+    secret: { kind: 'none' },
+    restrictedBehavior: 'deny',
+    requiresApiKey: true,
+  },
   '/api/v1/receivers': {
     path: '/api/v1/receivers',
     featureName: 'v1/receivers',

--- a/src/pages/api/v1/client/speech-status.ts
+++ b/src/pages/api/v1/client/speech-status.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { updateClientActiveSpeech } from '@/features/api/messageGateway'
+import { getClientIdFromRequest } from '@/features/api/http'
+import { withAccessPolicy } from '@/lib/accessPolicy/withAccessPolicy'
+import { routePolicies } from '@/lib/accessPolicy/routePolicies'
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  const clientId = getClientIdFromRequest(req, req.body?.clientId)
+  if (!clientId) {
+    return res.status(400).json({ error: 'Client ID is required' })
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(req.body ?? {}, 'activeSpeech')) {
+    return res.status(400).json({ error: 'activeSpeech is required' })
+  }
+  const value = req.body.activeSpeech
+  if (
+    value !== null &&
+    (!value || typeof value.id !== 'string' || typeof value.text !== 'string')
+  ) {
+    return res.status(400).json({ error: 'activeSpeech is invalid' })
+  }
+  const activeSpeech =
+    value && typeof value.id === 'string' && typeof value.text === 'string'
+      ? { id: value.id, text: value.text }
+      : null
+  const status = updateClientActiveSpeech(clientId, activeSpeech)
+  if (!status) {
+    return res.status(409).json({ error: 'Client status is not initialized' })
+  }
+  return res.status(200).json({ ok: true })
+}
+
+export default withAccessPolicy(
+  routePolicies['/api/v1/client/speech-status'],
+  handler
+)

--- a/src/pages/api/v1/client/status.ts
+++ b/src/pages/api/v1/client/status.ts
@@ -89,12 +89,19 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       : undefined,
     connected: req.body?.connected === true,
     isSpeaking: req.body?.isSpeaking === true,
-    activeSpeech:
-      req.body?.activeSpeech &&
-      typeof req.body.activeSpeech.id === 'string' &&
-      typeof req.body.activeSpeech.text === 'string'
-        ? { id: req.body.activeSpeech.id, text: req.body.activeSpeech.text }
-        : null,
+    ...(Object.prototype.hasOwnProperty.call(req.body ?? {}, 'activeSpeech')
+      ? {
+          activeSpeech:
+            req.body?.activeSpeech &&
+            typeof req.body.activeSpeech.id === 'string' &&
+            typeof req.body.activeSpeech.text === 'string'
+              ? {
+                  id: req.body.activeSpeech.id,
+                  text: req.body.activeSpeech.text,
+                }
+              : null,
+        }
+      : {}),
     chatProcessing: req.body?.chatProcessing === true,
     messageReceiverEnabled: req.body?.messageReceiverEnabled === true,
     modelType:


### PR DESCRIPTION
## Summary

- 発話チャンク開始・終了を通常のクライアント状態同期から分離し、軽量な専用APIで即時通知します
- 通常状態同期が専用通知を上書きしないよう、`activeSpeech`省略時は現在値を保持します
- 専用通知は順序を維持し、短い一時障害に対して最大3回再試行します
- 専用APIの認証・入力検証と、発話イベント順序をテストで保護します

## Verification

- `npm test -- --runInBand src/__tests__/pages/api/v1/externalApi.test.ts`（26件成功）
- `npm run lint`（エラー0、既存警告42件）
- `npm run build`（成功）
- 実ブラウザでスライドを再生し、AITuberKitの発話イベントから `/obs/captions` のDOM反映まで14〜49msであることを確認
- 先頭文を含む全8チャンクが順序どおり開始・終了することを確認

## Notes

- `npm test -- --runInBand`全体では、今回の変更と無関係な`src/__tests__/features/stores/images.test.ts`の14件がNode 24の`localStorage`未設定により失敗しました。他の205スイート・2230件は成功しています
- 操作から最初の発話までのTTS準備時間は字幕通知遅延とは別で、字幕は実際の再生開始イベントに同期します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 音声再生状態を専用APIで更新できるようになりました。
  * 音声チャンクの開始・終了イベントを記録できるようになりました。
  * 音声状態の送信に失敗した場合、自動的に最大3回再試行します。

* **改善**
  * 一般的なステータス更新時に音声再生状態が保持されるようになりました。
  * 不正な音声データに対して適切なエラーを返すようになりました。
  * 初回起動時にも現在の音声再生状態が正しく報告されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->