### PR TITLE
fix: 音声再生とスライド字幕の発話単位を同期する

### DIFF
--- a/src/__tests__/features/api/activeSpeechReporter.test.ts
+++ b/src/__tests__/features/api/activeSpeechReporter.test.ts
@@ -1,7 +1,7 @@
 import { createActiveSpeechReporter } from '@/features/api/activeSpeechReporter'
 
 describe('createActiveSpeechReporter', () => {
-  it('collapses transitions queued behind a slow report to the latest state', async () => {
+  it('reports every transition immediately with increasing versions', async () => {
     let releaseFirstReport: (() => void) | undefined
     const firstReport = new Promise<void>((resolve) => {
       releaseFirstReport = resolve
@@ -11,17 +11,23 @@ describe('createActiveSpeechReporter', () => {
       .mockImplementationOnce(() => firstReport)
       .mockResolvedValue(undefined)
     const reporter = createActiveSpeechReporter(report)
-    const latestSpeech = { id: 'speech-2', text: '現在の発話です。' }
+    const firstSpeech = { id: 'speech-1', text: '最初の発話です。' }
+    const secondSpeech = { id: 'speech-2', text: '次の発話です。' }
 
-    const idle = reporter.enqueue(null)
-    void reporter.enqueue({ id: 'speech-1', text: '終了済みの発話です。' })
-    void reporter.enqueue(null)
-    void reporter.enqueue(latestSpeech)
+    const first = reporter.enqueue(firstSpeech)
+    await reporter.enqueue(null)
+    await reporter.enqueue(secondSpeech)
     releaseFirstReport?.()
-    await idle
+    await first
 
-    expect(report).toHaveBeenCalledTimes(2)
-    expect(report).toHaveBeenNthCalledWith(1, null)
-    expect(report).toHaveBeenNthCalledWith(2, latestSpeech)
+    expect(report).toHaveBeenCalledTimes(3)
+    expect(report.mock.calls.map(([speech]) => speech)).toEqual([
+      firstSpeech,
+      null,
+      secondSpeech,
+    ])
+    const versions = report.mock.calls.map(([, version]) => version)
+    expect(versions[0]).toBeLessThan(versions[1])
+    expect(versions[1]).toBeLessThan(versions[2])
   })
 })

--- a/src/__tests__/features/api/activeSpeechReporter.test.ts
+++ b/src/__tests__/features/api/activeSpeechReporter.test.ts
@@ -1,0 +1,27 @@
+import { createActiveSpeechReporter } from '@/features/api/activeSpeechReporter'
+
+describe('createActiveSpeechReporter', () => {
+  it('collapses transitions queued behind a slow report to the latest state', async () => {
+    let releaseFirstReport: (() => void) | undefined
+    const firstReport = new Promise<void>((resolve) => {
+      releaseFirstReport = resolve
+    })
+    const report = jest
+      .fn()
+      .mockImplementationOnce(() => firstReport)
+      .mockResolvedValue(undefined)
+    const reporter = createActiveSpeechReporter(report)
+    const latestSpeech = { id: 'speech-2', text: '現在の発話です。' }
+
+    const idle = reporter.enqueue(null)
+    void reporter.enqueue({ id: 'speech-1', text: '終了済みの発話です。' })
+    void reporter.enqueue(null)
+    void reporter.enqueue(latestSpeech)
+    releaseFirstReport?.()
+    await idle
+
+    expect(report).toHaveBeenCalledTimes(2)
+    expect(report).toHaveBeenNthCalledWith(1, null)
+    expect(report).toHaveBeenNthCalledWith(2, latestSpeech)
+  })
+})

--- a/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
@@ -46,7 +46,8 @@ describe('speakMessageHandler', () => {
       expect.objectContaining({ message: 'バンカーキッズを紹介します。' }),
       expect.any(Function),
       expect.any(Function),
-      'Bunkerkidsを紹介します。'
+      'Bunkerkidsを紹介します。',
+      expect.any(Function)
     )
     expect(speakCharacter).toHaveBeenNthCalledWith(
       2,
@@ -54,7 +55,8 @@ describe('speakMessageHandler', () => {
       expect.objectContaining({ message: '次はウィフです。' }),
       expect.any(Function),
       expect.any(Function),
-      '次はWHIFです。'
+      '次はWHIFです。',
+      expect.any(Function)
     )
   })
 
@@ -71,7 +73,8 @@ describe('speakMessageHandler', () => {
       expect.objectContaining({ message: '一文目です。' }),
       expect.any(Function),
       expect.any(Function),
-      ''
+      '',
+      expect.any(Function)
     )
     expect(speakCharacter).toHaveBeenNthCalledWith(
       2,
@@ -79,7 +82,8 @@ describe('speakMessageHandler', () => {
       expect.objectContaining({ message: '二文目です。' }),
       expect.any(Function),
       expect.any(Function),
-      ''
+      '',
+      expect.any(Function)
     )
   })
 })

--- a/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speakMessageHandler.test.ts
@@ -86,4 +86,39 @@ describe('speakMessageHandler', () => {
       expect.any(Function)
     )
   })
+
+  it('読み置換で読点分割が増えても表示文を同じ句読点位置へ割り当てる', async () => {
+    await speakMessageHandler(
+      '最初に見た目を分けます。ピーエヌジーチューバーは、声に合わせてピーエヌジー画像を動かす表示方法で、これだけではコメントを理解して返事を作ることはできません。',
+      {
+        speechSessionId: 'presentation-pngtuber',
+        displayMessage:
+          '最初に見た目を分けます。PNGtuberは、声に合わせてPNG画像を動かす表示方法で、これだけではコメントを理解して返事を作ることはできません。',
+      }
+    )
+
+    expect(
+      (speakCharacter as jest.Mock).mock.calls.map((call) => ({
+        speech: call[1].message,
+        display: call[4],
+      }))
+    ).toEqual([
+      {
+        speech: '最初に見た目を分けます。',
+        display: '最初に見た目を分けます。',
+      },
+      {
+        speech: 'ピーエヌジーチューバーは、',
+        display: 'PNGtuberは、',
+      },
+      {
+        speech: '声に合わせてピーエヌジー画像を動かす表示方法で、',
+        display: '声に合わせてPNG画像を動かす表示方法で、',
+      },
+      {
+        speech: 'これだけではコメントを理解して返事を作ることはできません。',
+        display: 'これだけではコメントを理解して返事を作ることはできません。',
+      },
+    ])
+  })
 })

--- a/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
+++ b/src/__tests__/features/chat/speechPipeline/speechDispatcher.test.ts
@@ -47,6 +47,8 @@ describe('speechDispatcher', () => {
       'session-1',
       { message: 'こんにちは。', emotion: 'happy', motion: 'wave' },
       expect.any(Function),
+      expect.any(Function),
+      undefined,
       expect.any(Function)
     )
     expect(d.anyDispatched).toBe(true)
@@ -59,6 +61,8 @@ describe('speechDispatcher', () => {
       'session-1',
       { message: 'やあ。', emotion: 'neutral', motion: undefined },
       expect.any(Function),
+      expect.any(Function),
+      undefined,
       expect.any(Function)
     )
   })
@@ -122,14 +126,20 @@ describe('speechDispatcher', () => {
     expect(speakCharacter).toHaveBeenCalledTimes(1)
   })
 
-  it('onStart/onCompleteでスライド字幕とchatProcessingCountを連動する', () => {
+  it('実再生開始と完了でスライド字幕を切り替える', () => {
     const d = createSpeechDispatcher('session-1')
     d.dispatch(speech('一文目。'))
-    const [, , onStart, onComplete] = (speakCharacter as jest.Mock).mock
-      .calls[0]
+    const [, , onStart, onComplete, , onPlaybackStart] = (
+      speakCharacter as jest.Mock
+    ).mock.calls[0]
 
     onStart()
     expect(mockHomeState.incrementChatProcessingCount).toHaveBeenCalled()
+    expect(homeStore.setState).not.toHaveBeenCalledWith({
+      slideMessages: ['一文目。'],
+    })
+
+    onPlaybackStart()
     expect(homeStore.setState).toHaveBeenCalledWith({
       slideMessages: ['一文目。'],
     })
@@ -145,18 +155,33 @@ describe('speechDispatcher', () => {
     })
     d.dispatch(speech('バンカーキッズを'))
     d.dispatch(speech('紹介します。'))
-    const [, , firstOnStart, firstOnComplete, firstDisplayText] = (
-      speakCharacter as jest.Mock
-    ).mock.calls[0]
-    const [, , secondOnStart, secondOnComplete, secondDisplayText] = (
-      speakCharacter as jest.Mock
-    ).mock.calls[1]
+    const [
+      ,
+      ,
+      firstOnStart,
+      firstOnComplete,
+      firstDisplayText,
+      firstOnPlaybackStart,
+    ] = (speakCharacter as jest.Mock).mock.calls[0]
+    const [
+      ,
+      ,
+      secondOnStart,
+      secondOnComplete,
+      secondDisplayText,
+      secondOnPlaybackStart,
+    ] = (speakCharacter as jest.Mock).mock.calls[1]
 
     expect(firstDisplayText).toBe('Bunkerkidsを')
     expect(secondDisplayText).toBe('紹介します。')
 
     firstOnStart()
     secondOnStart()
+    expect(homeStore.setState).not.toHaveBeenCalledWith({
+      slideMessages: ['Bunkerkidsを', '紹介します。'],
+    })
+    firstOnPlaybackStart()
+    secondOnPlaybackStart()
     expect(homeStore.setState).toHaveBeenLastCalledWith({
       slideMessages: ['Bunkerkidsを', '紹介します。'],
     })
@@ -173,15 +198,32 @@ describe('speechDispatcher', () => {
   it('空の表示文を発話文へフォールバックしない', () => {
     const d = createSpeechDispatcher('session-1', { displayMessages: [''] })
     d.dispatch(speech('バンカーキッズを紹介します。'))
-    const [, , onStart, onComplete, displayText] = (speakCharacter as jest.Mock)
-      .mock.calls[0]
+    const [, , onStart, onComplete, displayText, onPlaybackStart] = (
+      speakCharacter as jest.Mock
+    ).mock.calls[0]
 
     expect(displayText).toBe('')
 
     onStart()
+    expect(homeStore.setState).not.toHaveBeenCalledWith({ slideMessages: [''] })
+
+    onPlaybackStart()
     expect(homeStore.setState).toHaveBeenCalledWith({ slideMessages: [''] })
 
     onComplete()
     expect(homeStore.setState).toHaveBeenLastCalledWith({ slideMessages: [] })
+  })
+
+  it('再生前に破棄された発話は字幕キューを進めない', () => {
+    const d = createSpeechDispatcher('session-1')
+    d.dispatch(speech('再生されない文。'))
+    const [, , onStart, onComplete] = (speakCharacter as jest.Mock).mock
+      .calls[0]
+
+    onStart()
+    onComplete()
+
+    expect(mockHomeState.decrementChatProcessingCount).toHaveBeenCalled()
+    expect(homeStore.setState).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/features/messages/concurrencyLimiter.test.ts
+++ b/src/__tests__/features/messages/concurrencyLimiter.test.ts
@@ -20,4 +20,25 @@ describe('createConcurrencyLimiter', () => {
     releaseSecond()
     releaseThird()
   })
+
+  it('transfers a released slot to the existing waiter before a newcomer', async () => {
+    const acquire = createConcurrencyLimiter(1)
+    const releaseFirst = await acquire()
+    const waiting = acquire()
+
+    releaseFirst()
+    let newcomerAcquired = false
+    const newcomer = acquire().then((release) => {
+      newcomerAcquired = true
+      return release
+    })
+    const releaseWaiting = await waiting
+    await Promise.resolve()
+
+    expect(newcomerAcquired).toBe(false)
+    releaseWaiting()
+    const releaseNewcomer = await newcomer
+    expect(newcomerAcquired).toBe(true)
+    releaseNewcomer()
+  })
 })

--- a/src/__tests__/features/messages/concurrencyLimiter.test.ts
+++ b/src/__tests__/features/messages/concurrencyLimiter.test.ts
@@ -1,0 +1,23 @@
+import { createConcurrencyLimiter } from '@/features/messages/concurrencyLimiter'
+
+describe('createConcurrencyLimiter', () => {
+  it('keeps later work waiting until a slot is released', async () => {
+    const acquire = createConcurrencyLimiter(2)
+    const releaseFirst = await acquire()
+    const releaseSecond = await acquire()
+    let thirdAcquired = false
+    const third = acquire().then((release) => {
+      thirdAcquired = true
+      return release
+    })
+
+    await Promise.resolve()
+    expect(thirdAcquired).toBe(false)
+    releaseFirst()
+    const releaseThird = await third
+    expect(thirdAcquired).toBe(true)
+
+    releaseSecond()
+    releaseThird()
+  })
+})

--- a/src/__tests__/features/messages/speakCharacterConcurrency.test.ts
+++ b/src/__tests__/features/messages/speakCharacterConcurrency.test.ts
@@ -87,8 +87,9 @@ function createDeferred<T>() {
 }
 
 const flushPromises = async () => {
-  await Promise.resolve()
-  await Promise.resolve()
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve()
+  }
 }
 
 describe('speakCharacter concurrency', () => {

--- a/src/__tests__/features/messages/speakCharacterConcurrency.test.ts
+++ b/src/__tests__/features/messages/speakCharacterConcurrency.test.ts
@@ -138,6 +138,27 @@ describe('speakCharacter concurrency', () => {
     })
   })
 
+  it('forwards the display callback to the actual playback start', async () => {
+    const onPlaybackStart = jest.fn()
+    mockSynthesizeVoicevoxApi.mockResolvedValueOnce(new ArrayBuffer(1))
+
+    speakCharacter(
+      'session-playback',
+      { message: 'spoken', emotion: 'neutral' },
+      undefined,
+      undefined,
+      'displayed',
+      onPlaybackStart
+    )
+    await flushPromises()
+
+    expect(onPlaybackStart).not.toHaveBeenCalled()
+    const queuedTask = mockAddTask.mock.calls[0][0]
+    queuedTask.onPlaybackStart()
+
+    expect(onPlaybackStart).toHaveBeenCalledTimes(1)
+  })
+
   it('drops old synthesis results after a session switch', async () => {
     const oldTask = createDeferred<ArrayBuffer>()
     const newTask = createDeferred<ArrayBuffer>()

--- a/src/__tests__/pages/api/v1/externalApi.test.ts
+++ b/src/__tests__/pages/api/v1/externalApi.test.ts
@@ -1012,6 +1012,38 @@ describe('/api/v1 external API', () => {
     ).toHaveLength(0)
   })
 
+  it('ignores an older active speech report that arrives late', () => {
+    const {
+      getClientStatus,
+      getRecentApiEvents,
+      updateClientActiveSpeech,
+      updateClientStatus,
+    } = require('@/features/api/messageGateway')
+    const staleSpeech = {
+      id: 'speech-stale',
+      text: 'すでに終了した発話です。',
+    }
+
+    updateClientStatus('client1', {
+      connected: true,
+      chatProcessing: false,
+      isSpeaking: true,
+      activeSpeech: null,
+    })
+    updateClientActiveSpeech('client1', staleSpeech, 10)
+    updateClientActiveSpeech('client1', null, 11)
+    updateClientActiveSpeech('client1', staleSpeech, 10)
+
+    expect(getClientStatus('client1').activeSpeech).toBeNull()
+    expect(
+      getRecentApiEvents('client1')
+        .filter((event: { type: string }) =>
+          event.type.startsWith('speech_chunk_')
+        )
+        .map((event: { type: string }) => event.type)
+    ).toEqual(['speech_chunk_started', 'speech_chunk_ended'])
+  })
+
   it('emits slide_changed only after a presentation finishes loading', () => {
     const {
       getRecentApiEvents,

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -41,6 +41,7 @@ import {
   subscribeReceiverEventStream,
 } from '@/features/api/receiverEventStream'
 import { createAssignmentReconciliationRunner } from '@/features/presentation/assignmentReconciliation'
+import { createActiveSpeechReporter } from '@/features/api/activeSpeechReporter'
 
 const CLIENT_TAB_LEASE_DURATION = 5000
 const CLIENT_TAB_LEASE_REFRESH_INTERVAL = 2000
@@ -678,17 +679,16 @@ const MessageReceiver = () => {
 
     let isReportingStatus = false
     let isStatusReportQueued = false
-    let activeSpeechReportChain = Promise.resolve()
-
-    const enqueueActiveSpeechReport = (
-      activeSpeech: { id: string; text: string } | null
-    ) => {
-      activeSpeechReportChain = activeSpeechReportChain
-        .then(() => reportActiveSpeech(activeSpeech))
-        .catch((error) =>
+    let activeSpeechReporterReady = false
+    const activeSpeechReporter = createActiveSpeechReporter(
+      async (activeSpeech) => {
+        try {
+          await reportActiveSpeech(activeSpeech)
+        } catch (error) {
           logger.error('Error reporting active speech status:', error)
-        )
-    }
+        }
+      }
+    )
 
     const drainReceiver = createOrderedReceiverDrainRunner({
       fetchCommands: () => fetchCommands(receiverId, 'receiver'),
@@ -708,6 +708,7 @@ const MessageReceiver = () => {
     }
 
     const safeReportStatus = async () => {
+      if (!activeSpeechReporterReady) return
       isStatusReportQueued = true
       if (isReportingStatus) return
       isReportingStatus = true
@@ -739,7 +740,7 @@ const MessageReceiver = () => {
           void safeReportStatus()
         }
         if (state.activeSpeech?.id !== previousState.activeSpeech?.id) {
-          enqueueActiveSpeechReport(state.activeSpeech)
+          void activeSpeechReporter.enqueue(state.activeSpeech)
         }
       }
     )
@@ -781,9 +782,12 @@ const MessageReceiver = () => {
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
     void drainAllReceivers()
-    void safeReportStatus().then(() =>
-      enqueueActiveSpeechReport(homeStore.getState().activeSpeech)
-    )
+    void activeSpeechReporter
+      .enqueue(homeStore.getState().activeSpeech)
+      .then(() => {
+        activeSpeechReporterReady = true
+        return safeReportStatus()
+      })
 
     if (document.visibilityState === 'visible' && document.hasFocus()) {
       claimClientTabLeadership()

--- a/src/components/messageReceiver.tsx
+++ b/src/components/messageReceiver.tsx
@@ -546,7 +546,8 @@ const MessageReceiver = () => {
     }
 
     const reportActiveSpeech = async (
-      activeSpeech: { id: string; text: string } | null
+      activeSpeech: { id: string; text: string } | null,
+      version: number
     ) => {
       const authHeaders = getClientApiHeaders()
       if (!authHeaders) return
@@ -561,7 +562,7 @@ const MessageReceiver = () => {
                 'Content-Type': 'application/json',
                 ...authHeaders,
               },
-              body: JSON.stringify({ activeSpeech }),
+              body: JSON.stringify({ activeSpeech, version }),
             }
           )
           if (response.ok) return
@@ -681,9 +682,9 @@ const MessageReceiver = () => {
     let isStatusReportQueued = false
     let activeSpeechReporterReady = false
     const activeSpeechReporter = createActiveSpeechReporter(
-      async (activeSpeech) => {
+      async (activeSpeech, version) => {
         try {
-          await reportActiveSpeech(activeSpeech)
+          await reportActiveSpeech(activeSpeech, version)
         } catch (error) {
           logger.error('Error reporting active speech status:', error)
         }

--- a/src/features/api/activeSpeechReporter.ts
+++ b/src/features/api/activeSpeechReporter.ts
@@ -1,0 +1,37 @@
+export type ActiveSpeech = { id: string; text: string } | null
+
+/**
+ * Reports speech state serially while collapsing queued transitions to the
+ * latest value. A slow request must not replay already-finished captions.
+ */
+export const createActiveSpeechReporter = (
+  report: (activeSpeech: ActiveSpeech) => Promise<void>
+) => {
+  let pending: ActiveSpeech | undefined
+  let draining: Promise<void> | null = null
+
+  const drain = async () => {
+    while (pending !== undefined) {
+      const activeSpeech = pending
+      pending = undefined
+      await report(activeSpeech)
+    }
+  }
+
+  const startDrain = () => {
+    if (!draining) {
+      draining = drain().finally(() => {
+        draining = null
+        if (pending !== undefined) void startDrain()
+      })
+    }
+    return draining
+  }
+
+  return {
+    enqueue(activeSpeech: ActiveSpeech) {
+      pending = activeSpeech
+      return startDrain()
+    },
+  }
+}

--- a/src/features/api/activeSpeechReporter.ts
+++ b/src/features/api/activeSpeechReporter.ts
@@ -1,37 +1,18 @@
 export type ActiveSpeech = { id: string; text: string } | null
 
 /**
- * Reports speech state serially while collapsing queued transitions to the
- * latest value. A slow request must not replay already-finished captions.
+ * Reports every transition immediately with a monotonically increasing
+ * version. The server uses the version to discard late, out-of-order requests.
  */
 export const createActiveSpeechReporter = (
-  report: (activeSpeech: ActiveSpeech) => Promise<void>
+  report: (activeSpeech: ActiveSpeech, version: number) => Promise<void>
 ) => {
-  let pending: ActiveSpeech | undefined
-  let draining: Promise<void> | null = null
-
-  const drain = async () => {
-    while (pending !== undefined) {
-      const activeSpeech = pending
-      pending = undefined
-      await report(activeSpeech)
-    }
-  }
-
-  const startDrain = () => {
-    if (!draining) {
-      draining = drain().finally(() => {
-        draining = null
-        if (pending !== undefined) void startDrain()
-      })
-    }
-    return draining
-  }
+  let lastVersion = Date.now() * 1000
 
   return {
     enqueue(activeSpeech: ActiveSpeech) {
-      pending = activeSpeech
-      return startDrain()
+      lastVersion = Math.max(lastVersion + 1, Date.now() * 1000)
+      return report(activeSpeech, lastVersion)
     },
   }
 }

--- a/src/features/api/messageGateway.ts
+++ b/src/features/api/messageGateway.ts
@@ -143,6 +143,7 @@ interface ClientQueue {
 interface MessageGatewayState {
   queuesPerClient: Record<string, ClientQueue>
   statusesPerClient: Record<string, ClientStatus>
+  activeSpeechVersionsPerClient: Record<string, number>
   responseCallbacks: Record<
     string,
     ResponseCallback & { expiresAt: number; claimed: boolean }
@@ -180,6 +181,7 @@ const getGatewayState = (): MessageGatewayState => {
     globalState.__aituberKitMessageGateway = {
       queuesPerClient: {},
       statusesPerClient: {},
+      activeSpeechVersionsPerClient: {},
       responseCallbacks: {},
       recentEvents: [],
       eventListeners: [],
@@ -267,6 +269,7 @@ export const cleanupClientQueues = () => {
   for (const clientId of Object.keys(state.statusesPerClient)) {
     if (now - state.statusesPerClient[clientId].lastSeenAt > CLIENT_TIMEOUT) {
       delete state.statusesPerClient[clientId]
+      delete state.activeSpeechVersionsPerClient[clientId]
     }
   }
   for (const handle of Object.keys(state.responseCallbacks)) {
@@ -588,10 +591,21 @@ export const updateClientStatus = (
 
 export const updateClientActiveSpeech = (
   clientId: string,
-  activeSpeech: ClientStatus['activeSpeech']
+  activeSpeech: ClientStatus['activeSpeech'],
+  version?: number
 ): ClientStatus | null => {
-  const previousStatus = getGatewayState().statusesPerClient[clientId]
+  const state = getGatewayState()
+  const previousStatus = state.statusesPerClient[clientId]
   if (!previousStatus) return null
+  if (
+    version !== undefined &&
+    version <= (state.activeSpeechVersionsPerClient[clientId] ?? -1)
+  ) {
+    return previousStatus
+  }
+  if (version !== undefined) {
+    state.activeSpeechVersionsPerClient[clientId] = version
+  }
 
   const previousSpeech = previousStatus.activeSpeech ?? null
   const nextSpeech = activeSpeech ?? null
@@ -600,7 +614,7 @@ export const updateClientActiveSpeech = (
     activeSpeech: nextSpeech,
     lastSeenAt: Date.now(),
   }
-  getGatewayState().statusesPerClient[clientId] = nextStatus
+  state.statusesPerClient[clientId] = nextStatus
   emitSpeechChunkTransition(clientId, previousSpeech, nextSpeech)
   return nextStatus
 }
@@ -662,6 +676,7 @@ export const __resetMessageGatewayForTests = () => {
 
   state.queuesPerClient = {}
   state.statusesPerClient = {}
+  state.activeSpeechVersionsPerClient = {}
   state.responseCallbacks = {}
   state.recentEvents = []
   state.eventListeners = []

--- a/src/features/chat/speechPipeline/speakMessageHandler.ts
+++ b/src/features/chat/speechPipeline/speakMessageHandler.ts
@@ -5,6 +5,63 @@ import { createSpeechDispatcher } from './speechDispatcher'
 import { SegmenterEvent } from './types'
 import settingsStore from '@/features/stores/settings'
 
+const sentenceBoundaryMarks = (text: string) => {
+  const marks: { mark: string; end: number }[] = []
+  for (let index = 0; index < text.length; index += 1) {
+    const mark = text[index]
+    if (!mark) continue
+    if ('、。．!?！？\n'.includes(mark)) {
+      marks.push({ mark, end: index + 1 })
+      continue
+    }
+    if (mark === '.' || mark === ',') {
+      const previousIsDigit = /\d/.test(text[index - 1] ?? '')
+      const nextIsDigit = /\d/.test(text[index + 1] ?? '')
+      if (!(previousIsDigit && nextIsDigit)) {
+        marks.push({ mark, end: index + 1 })
+      }
+    }
+  }
+  return marks
+}
+
+export const alignDisplayMessagesToSpeech = (
+  speechMessages: string[],
+  displayMessage: string
+): string[] | null => {
+  if (displayMessage === '') return speechMessages.map(() => '')
+
+  const speechBoundaryGroups = speechMessages.map(sentenceBoundaryMarks)
+  if (
+    speechBoundaryGroups
+      .slice(0, -1)
+      .some((boundaries) => boundaries.length === 0)
+  ) {
+    return null
+  }
+  const speechMarks = speechBoundaryGroups.flat().map(({ mark }) => mark)
+  const displayBoundaries = sentenceBoundaryMarks(displayMessage)
+  if (
+    speechMarks.length !== displayBoundaries.length ||
+    speechMarks.some((mark, index) => mark !== displayBoundaries[index]?.mark)
+  ) {
+    return null
+  }
+
+  let displayStart = 0
+  let boundaryIndex = 0
+  return speechBoundaryGroups.map((boundaries, speechIndex) => {
+    boundaryIndex += boundaries.length
+    const isLast = speechIndex === speechBoundaryGroups.length - 1
+    const displayEnd = isLast
+      ? displayMessage.length
+      : (displayBoundaries[boundaryIndex - 1]?.end ?? displayStart)
+    const aligned = displayMessage.slice(displayStart, displayEnd).trim()
+    displayStart = displayEnd
+    return aligned
+  })
+}
+
 /**
  * 受け取った完成テキストを処理し、発話させる。
  * WebSocketの direct_send / スライド自動再生の台本読みで使用される。
@@ -41,6 +98,7 @@ export const speakMessageHandler = async (
     normalizedDisplayMessage !== undefined &&
     normalizedDisplayMessage !== receivedMessage
   const displaySpeechSegments: string[] = []
+  const speechEvents: Extract<SegmenterEvent, { kind: 'speech' }>[] = []
 
   if (hasSeparateDisplayMessage) {
     const displaySegmenter = createSegmenter()
@@ -56,23 +114,31 @@ export const speakMessageHandler = async (
     }
   }
 
+  const collectSpeechEvent = (event: SegmenterEvent) => {
+    if (!hasSeparateDisplayMessage) writer.handleEvent(event)
+    if (event.kind === 'speech') speechEvents.push(event)
+  }
+
+  for (const event of speechSegmenter.push(receivedMessage)) {
+    collectSpeechEvent(event)
+  }
+  for (const event of speechSegmenter.flush()) {
+    collectSpeechEvent(event)
+  }
+
+  const alignedDisplayMessages = hasSeparateDisplayMessage
+    ? alignDisplayMessagesToSpeech(
+        speechEvents.map(({ text }) => text),
+        normalizedDisplayMessage ?? ''
+      )
+    : undefined
   const dispatcher = createSpeechDispatcher(sessionId, {
     displayMessages: hasSeparateDisplayMessage
-      ? displaySpeechSegments
+      ? (alignedDisplayMessages ?? displaySpeechSegments)
       : undefined,
     displayMessageFallback: hasSeparateDisplayMessage ? '' : undefined,
   })
 
-  const handleSpeechEvent = (event: SegmenterEvent) => {
-    if (!hasSeparateDisplayMessage) writer.handleEvent(event)
-    if (event.kind === 'speech') dispatcher.dispatch(event)
-  }
-
-  for (const event of speechSegmenter.push(receivedMessage)) {
-    handleSpeechEvent(event)
-  }
-  for (const event of speechSegmenter.flush()) {
-    handleSpeechEvent(event)
-  }
+  speechEvents.forEach((event) => dispatcher.dispatch(event))
   writer.finalize()
 }

--- a/src/features/chat/speechPipeline/speechDispatcher.ts
+++ b/src/features/chat/speechPipeline/speechDispatcher.ts
@@ -117,20 +117,40 @@ const speakOne = (
     emotion,
     motion: event.motionTag || undefined,
   }
+  let playbackStarted = false
   const onStart = () => {
     hs.incrementChatProcessingCount()
+  }
+  const onPlaybackStart = () => {
+    playbackStarted = true
     slideMessages.push(displayMessage ?? event.text)
     homeStore.setState({ slideMessages: [...slideMessages] })
   }
   const onComplete = () => {
     hs.decrementChatProcessingCount()
-    slideMessages.shift()
-    homeStore.setState({ slideMessages: [...slideMessages] })
+    if (playbackStarted) {
+      slideMessages.shift()
+      homeStore.setState({ slideMessages: [...slideMessages] })
+    }
   }
 
   if (displayMessage !== undefined) {
-    speakCharacter(sessionId, talk, onStart, onComplete, displayMessage)
+    speakCharacter(
+      sessionId,
+      talk,
+      onStart,
+      onComplete,
+      displayMessage,
+      onPlaybackStart
+    )
   } else {
-    speakCharacter(sessionId, talk, onStart, onComplete)
+    speakCharacter(
+      sessionId,
+      talk,
+      onStart,
+      onComplete,
+      undefined,
+      onPlaybackStart
+    )
   }
 }

--- a/src/features/messages/concurrencyLimiter.ts
+++ b/src/features/messages/concurrencyLimiter.ts
@@ -1,0 +1,22 @@
+export const createConcurrencyLimiter = (limit: number) => {
+  let active = 0
+  const waiters: (() => void)[] = []
+
+  const release = () => {
+    active -= 1
+    waiters.shift()?.()
+  }
+
+  return async () => {
+    if (active >= limit) {
+      await new Promise<void>((resolve) => waiters.push(resolve))
+    }
+    active += 1
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      release()
+    }
+  }
+}

--- a/src/features/messages/concurrencyLimiter.ts
+++ b/src/features/messages/concurrencyLimiter.ts
@@ -3,15 +3,20 @@ export const createConcurrencyLimiter = (limit: number) => {
   const waiters: (() => void)[] = []
 
   const release = () => {
+    const next = waiters.shift()
+    if (next) {
+      next()
+      return
+    }
     active -= 1
-    waiters.shift()?.()
   }
 
   return async () => {
     if (active >= limit) {
       await new Promise<void>((resolve) => waiters.push(resolve))
+    } else {
+      active += 1
     }
-    active += 1
     let released = false
     return () => {
       if (released) return

--- a/src/features/messages/speakCharacter.ts
+++ b/src/features/messages/speakCharacter.ts
@@ -29,7 +29,7 @@ import {
   containsEnglish,
 } from '@/utils/textProcessing'
 import { markConversationLatency } from '@/features/chat/conversationLatency'
-import { createConcurrencyLimiter } from './concurrencyLimiter'
+import { createConcurrencyLimiter } from '@/features/messages/concurrencyLimiter'
 
 const speakQueue = SpeakQueue.getInstance()
 const SYNTHESIS_START_GAP_MS = 250

--- a/src/features/messages/speakCharacter.ts
+++ b/src/features/messages/speakCharacter.ts
@@ -50,6 +50,7 @@ type PendingSpeakResult = {
   audio: SynthesizedSpeech | null
   talk: Talk
   displayText?: string
+  onPlaybackStart?: () => void
   onComplete?: () => void
   tokenAtStart: number
 }
@@ -278,8 +279,10 @@ const createSpeakCharacter = () => {
         talk: result.talk,
         displayText: result.displayText,
         ...result.audio,
-        onPlaybackStart: () =>
-          markConversationLatency(result.sessionId, 'playback_started'),
+        onPlaybackStart: () => {
+          markConversationLatency(result.sessionId, 'playback_started')
+          result.onPlaybackStart?.()
+        },
         onComplete: result.onComplete,
       })
     }
@@ -290,7 +293,8 @@ const createSpeakCharacter = () => {
     talk: Talk,
     onStart?: () => void,
     onComplete?: () => void,
-    displayText?: string
+    displayText?: string,
+    onPlaybackStart?: () => void
   ) => {
     let called = false
     const ss = settingsStore.getState()
@@ -433,6 +437,7 @@ const createSpeakCharacter = () => {
         audio,
         talk,
         displayText,
+        onPlaybackStart,
         onComplete: guardedOnComplete,
         tokenAtStart: initialToken,
       }
@@ -450,6 +455,7 @@ const createSpeakCharacter = () => {
           audio: result?.audio ?? null,
           talk,
           displayText,
+          onPlaybackStart,
           onComplete: guardedOnComplete,
           tokenAtStart: result?.tokenAtStart ?? initialToken,
         })
@@ -465,6 +471,7 @@ const createSpeakCharacter = () => {
           sessionId,
           audio: null,
           talk,
+          onPlaybackStart,
           onComplete: guardedOnComplete,
           tokenAtStart: initialToken,
         })

--- a/src/features/messages/speakCharacter.ts
+++ b/src/features/messages/speakCharacter.ts
@@ -29,9 +29,11 @@ import {
   containsEnglish,
 } from '@/utils/textProcessing'
 import { markConversationLatency } from '@/features/chat/conversationLatency'
+import { createConcurrencyLimiter } from './concurrencyLimiter'
 
 const speakQueue = SpeakQueue.getInstance()
 const SYNTHESIS_START_GAP_MS = 250
+const MAX_CONCURRENT_SYNTHESIS = 3
 
 type SynthesizedSpeech =
   | {
@@ -237,6 +239,9 @@ async function synthesizeVoice(
 }
 
 const createSpeakCharacter = () => {
+  const acquireSynthesisSlot = createConcurrencyLimiter(
+    MAX_CONCURRENT_SYNTHESIS
+  )
   let lastSynthesisStartAt = 0
   let currentSessionId: string | null = null
   let nextSynthesisOrder = 0
@@ -353,28 +358,29 @@ const createSpeakCharacter = () => {
         await wait(waitTime)
       }
 
-      // ボタン停止でキャンセルされた場合はここで終了
-      if (SpeakQueue.currentStopToken !== initialToken) {
-        return null
-      }
-
-      if (
-        processedMessage &&
-        ss.changeEnglishToJapanese &&
-        ss.selectLanguage === 'ja' &&
-        containsEnglish(processedMessage)
-      ) {
-        try {
-          const convertedText =
-            await asyncConvertEnglishToJapaneseReading(processedMessage)
-          talk.message = convertedText
-        } catch (error) {
-          logger.error('Error converting English to Japanese:', error)
-        }
-      }
-
-      let audio: SynthesizedSpeech | null
+      const releaseSynthesisSlot = await acquireSynthesisSlot()
       try {
+        // ボタン停止でキャンセルされた場合はここで終了
+        if (SpeakQueue.currentStopToken !== initialToken) {
+          return null
+        }
+
+        if (
+          processedMessage &&
+          ss.changeEnglishToJapanese &&
+          ss.selectLanguage === 'ja' &&
+          containsEnglish(processedMessage)
+        ) {
+          try {
+            const convertedText =
+              await asyncConvertEnglishToJapaneseReading(processedMessage)
+            talk.message = convertedText
+          } catch (error) {
+            logger.error('Error converting English to Japanese:', error)
+          }
+        }
+
+        let audio: SynthesizedSpeech | null
         if (talk.message == '' && talk.buffer) {
           audio = {
             kind: 'buffer',
@@ -427,19 +433,20 @@ const createSpeakCharacter = () => {
         } else {
           audio = null
         }
+        return {
+          sessionId,
+          audio,
+          talk,
+          displayText,
+          onPlaybackStart,
+          onComplete: guardedOnComplete,
+          tokenAtStart: initialToken,
+        }
       } catch (error) {
         handleTTSError(error, ss.selectVoice)
         return null
-      }
-
-      return {
-        sessionId,
-        audio,
-        talk,
-        displayText,
-        onPlaybackStart,
-        onComplete: guardedOnComplete,
-        tokenAtStart: initialToken,
+      } finally {
+        releaseSynthesisSlot()
       }
     })()
 

--- a/src/pages/api/v1/client/speech-status.ts
+++ b/src/pages/api/v1/client/speech-status.ts
@@ -24,7 +24,14 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     value && typeof value.id === 'string' && typeof value.text === 'string'
       ? { id: value.id, text: value.text }
       : null
-  const status = updateClientActiveSpeech(clientId, activeSpeech)
+  const version = req.body?.version
+  if (
+    version !== undefined &&
+    (!Number.isSafeInteger(version) || version < 0)
+  ) {
+    return res.status(400).json({ error: 'version is invalid' })
+  }
+  const status = updateClientActiveSpeech(clientId, activeSpeech, version)
   if (!status) {
     return res.status(409).json({ error: 'Client status is not initialized' })
   }


### PR DESCRIPTION
## Summary

- スライド字幕の切り替えをTTS依頼時ではなく、実際の音声再生開始時へ変更
- 遅延した発話状態通知が終了済み字幕を再送しないよう、通知順序をバージョン管理
- 表示用原文とTTS用読みの分割差を句読点境界で整列し、`PNGtuber` などの読み置換でも字幕を同じ発話単位へ割り当て
- TTS合成の同時実行数を制限し、字幕状態通知用のHTTP接続枠を確保

## Verification

- `npm test -- --runInBand src/__tests__/features/api/activeSpeechReporter.test.ts src/__tests__/pages/api/v1/externalApi.test.ts src/__tests__/features/chat/speechPipeline src/__tests__/features/messages/concurrencyLimiter.test.ts src/__tests__/features/messages/speakCharacter.test.ts src/__tests__/features/messages/speakQueue.test.ts`（176 tests passed）
- 対象ファイルの `npx eslint ...`
- `npm run build`
- ローカル実アプリで対象スライドを再生し、`PNGtuberは、` → `声に合わせてPNG画像を動かす表示方法で、` → `これだけではコメントを理解して…` の順に表示されることを確認
- 発話状態通知の遅延が18〜33msであることを確認

## Notes

- ビルド時に既存のReact Hooksおよび`img`関連警告が出ますが、ビルドは成功しています
- 表示用テキストは原文表記、TTSには読み置換済みテキストを引き続き使用します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 音声再生の開始に合わせて字幕が表示され、再生前に破棄された発話では不要な字幕が表示されなくなりました。
  - 文章の句読点と音声区切りの対応が改善され、字幕表示がより自然になりました。
  - 音声合成の同時処理数を制御し、発話が集中した場合の安定性を向上しました。
  - 音声状態の更新順序を管理し、古い状態による表示の巻き戻りや重複イベントを防止しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->