### PR TITLE
スター履歴チャートの表示崩れを修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ npm run deploy:cloudflare
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.com/#tegnike/aituber-kit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.dera.page/#tegnike/aituber-kit&Date)
 
 ## 謝辞
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -404,7 +404,7 @@ Plus multiple private sponsors
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.com/#tegnike/aituber-kit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.dera.page/#tegnike/aituber-kit&Date)
 
 ## Acknowledgments
 

--- a/docs/README_ko.md
+++ b/docs/README_ko.md
@@ -404,7 +404,7 @@ npm run deploy:cloudflare
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.com/#tegnike/aituber-kit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.dera.page/#tegnike/aituber-kit&Date)
 
 ## 감사의 말
 

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -404,7 +404,7 @@ Plus kilku prywatnych sponsorów
 
 ## Historia gwiazdek
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.com/#tegnike/aituber-kit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.dera.page/#tegnike/aituber-kit&Date)
 
 ## Podziękowania
 

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -406,7 +406,7 @@ npm run deploy:cloudflare
 
 ## Star历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.com/#tegnike/aituber-kit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.dera.page/#tegnike/aituber-kit&Date)
 
 ## 致谢
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -406,7 +406,7 @@ npm run deploy:cloudflare
 
 ## Star 歷史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.com/#tegnike/aituber-kit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tegnike/aituber-kit&type=Date)](https://star-history.dera.page/#tegnike/aituber-kit&Date)
 
 ## 致謝
 


### PR DESCRIPTION
現在のスター履歴チャートは GitHub Stargazer API の制限により表示が崩れており、修正が必要です。

本PRでは、追加のAPIキーを必要としない代替データソースを使用する star-history.dera.page へチャートを移行し、全README（日本語・英語・中国語・繁体中国語・韓国語・ポーランド語）でチャートが正しく表示されるようにします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - READMEおよび各言語版のStar Historyチャートの画像・リンク先を更新しました。
  - チャートが新しい表示先（`star-history.dera.page`）を参照するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->