### PR TITLE
GPT-Live-1の双方向音声会話モードを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,6 +186,7 @@ NEXT_PUBLIC_SELECT_AI_SERVICE="openai"
 NEXT_PUBLIC_SELECT_AI_MODEL="gpt-4o-2024-11-20"
 
 # 過去のメッセージ保持数 / Number of past messages to retain
+# GPT-Live使用時: 最大128件・履歴合計8,192トークン（本文は文字数で切り捨てません）
 NEXT_PUBLIC_MAX_PAST_MESSAGES=10
 
 # 会話のランダム性を調整する温度パラメータ（0.0～2.0） /
@@ -802,3 +803,9 @@ NEXT_PUBLIC_KIOSK_GUIDANCE_MESSAGE=""
 
 # ガイダンスメッセージ表示時間（秒） / Guidance message display timeout (seconds)
 NEXT_PUBLIC_KIOSK_GUIDANCE_TIMEOUT="60"
+
+# GPT-Live full-duplex voice (OpenAI API key required; backend billed separately)
+NEXT_PUBLIC_LIVE_MODE=false
+NEXT_PUBLIC_LIVE_VOICE=marin
+NEXT_PUBLIC_LIVE_BACKEND_MODEL=gpt-5.6-terra
+NEXT_PUBLIC_LIVE_WEB_SEARCH=false

--- a/docs/gpt-live.md
+++ b/docs/gpt-live.md
@@ -1,0 +1,39 @@
+# GPT-Live-1 音声会話
+
+AI設定でOpenAIを選び、GPT-Live-1をONにする。OpenAI APIキーは既存の入力欄、またはサーバーの `OPENAI_KEY` / `OPENAI_API_KEY` を使用する。GPT-Liveのアクセス権が必要。サーバーのキーを使う場合は、既存の `AITUBERKIT_SERVER_SECRET_ACCESS_MODE` によるアクセス許可も必要（既定値は `disabled`）。拒否された場合は専用エラーを表示する。
+
+- 声: `marin`（初期値）と公式の追加12音声。公式のPresentation分類を女性・男性として併記し、分類未記載の `marin` は未公表と表示する。
+- 推論モデル: `gpt-5.6-terra`（初期値）。GPT-LiveのResponses delegationで利用可能なモデルIDを入力する。
+- Web検索: 初期値OFF。ON時はバックエンドに `web_search` を設定する。
+- 会話画面の「会話を開始」でマイク接続。「会話を終了」でマイク送信を止め、終了通知を待って接続を解放する。開始は自動では行わない。
+- キャラクターのシステムプロンプトを音声側と推論側の両方に渡す。言語設定、直近のテキスト履歴も引き継ぐ。設定変更は次回接続から適用。履歴件数は「過去のメッセージ保持数」に従う（API上限128件）。文字列のユーザー・アシスタント発言を直近から選び、本文を切り捨てずに送る。公式上限は履歴合計8,192トークン、プロンプトはアプリの追加指示込みで16,384トークン。文字数への固定換算は行わず、正確な判定はAPIに委ねる。超過時は専用エラーを表示し、自動で履歴を削ったり再試行したりしない。AI設定・記憶設定の件数入力と説明はGPT-Live時のみ上限128件に切り替わる（通常モードの保存値は維持）。
+- メイン画面は既存フォームと同じ幅・背景のコンパクトな操作バー。音声の自動再生がブロックされた場合だけ再生ボタンを表示する。
+
+音声は接続時間に応じて課金される。推論モデルと検索には別料金が発生する。WebRTC作成時には15秒分の初期化料金があり、開始後の時間課金に充当される。マイクが無音でも接続中の時間は進む。
+
+## 実装
+
+`/api/ai/live-session` が既存のアクセスポリシーを適用し、`POST https://api.openai.com/v1/live/sessions` へSDPとサーバーで構成したセッションを送る。SDK・依存パッケージの更新は不要。キーとセッション設定を返さず、セッションIDとSDP answerだけ返す。
+
+専用WebRTCクライアントが `session.started` を待つ。マイク入力はアシスタント発話中も維持し、音声はメディアトラックから直接再生する。出力音声の解析値をVRM / Live2D / PNGTuberの口パクへ渡す。音声を既存のTTSキューへ再投入しない。
+
+`session.input_transcript.delta` と `session.output_transcript.delta` は別々に集約し、会話ログへ表示する。1500ms以内の間隔は表示上のまとまりとするが、ターン完了やバックエンド実行のトリガーにはしない。元の断片とセッション内時刻はメッセージの `liveTranscript` に保持する。
+
+終了は `session.close` → `session.closed`。終了通知が15秒以内に来ない場合もローカル資源を解放するが、最終利用時間は未確認と表示する。接続障害時の自動再接続は行わない。
+
+## 範囲と検証
+
+今回はOpenAI管理のResponses delegationを実装。既存Realtimeのfunction calling、他社モデルへのclient delegation、RAG検索、画像入力、テキスト送信は接続していない。競合する音声認識、TTS、自動発話、YouTube、スライド、外部メッセージ受信モードは同時利用しない。
+
+ローカル自動テストはAPIリクエスト形状とアクセス制御、接続中キャンセル・終了通知待ち、字幕の重複・遅延・同時発話、モード排他を検証する。ブラウザテストの接続・字幕はモックであり、実APIの音声品質・日本語会話・割り込み・口パクの実機確認を代替しない。
+
+検証環境の実行ランタイムはNode.js 22.21.1（arm64）。プロジェクトの指定はNode.js 24.xのため、Node 24での実行確認は別途必要。
+
+実API確認時は短い会話で、マイク入力→応答音声→字幕→口パク、発話中の割り込み、推論とWeb検索の結果、終了通知とマイク解放を個別に確認する。
+
+公式資料（2026-09-10確認）:
+
+- https://developers.openai.com/api/docs/guides/live
+- https://developers.openai.com/api/docs/guides/voice-webrtc?api=live
+- https://developers.openai.com/api/docs/guides/live-delegation
+- https://developers.openai.com/api/docs/guides/live-conversations

--- a/locales/ja/translation.json
+++ b/locales/ja/translation.json
@@ -913,5 +913,41 @@
     "send": "実行",
     "response": "レスポンス",
     "noResponse": "まだレスポンスはありません。"
+  },
+  "Live": {
+    "Description": "聞きながら話せる音声会話モードです。音声はGPT-Live-1、推論は別のOpenAIモデルが担当します。音声は接続時間、推論とWeb検索は別途課金されます。",
+    "SettingsHint": "会話画面の「会話を開始」でマイクに接続します。設定の変更は次の接続から適用されます。通常の音声合成・音声認識設定は使用しません。",
+    "Voice": "GPT-Liveの声",
+    "VoicePresentation": {
+      "Female": "女性",
+      "Male": "男性",
+      "Unspecified": "未公表"
+    },
+    "HistoryInfo": "接続開始時に直近最大{{count}}件を渡します。GPT-Liveの上限は128件・合計8,192トークンです。文字数での切り捨ては行いません。トークン上限を超えた場合は件数を減らして再接続してください。",
+    "HistoryLimitExceeded": "会話履歴がGPT-Liveの上限（合計8,192トークン）を超えています。「過去のメッセージ保持数」を減らすか、履歴を整理して再接続してください。",
+    "InstructionsLimitExceeded": "システムプロンプトがGPT-Liveの上限（アプリが追加する指示を含め16,384トークン）を超えています。プロンプトを短くして再接続してください。",
+    "TokenLimitExceeded": "GPT-Liveのトークン上限を超えています。履歴件数またはシステムプロンプトを減らして再接続してください。",
+    "PromptHint": "AI設定のシステムプロンプトを、音声と推論の両方に適用します。変更は次の接続から反映されます。GPT-Liveのプロンプト上限はアプリの追加指示を含め16,384トークンです。",
+    "Backend": "推論モデル（Responses API対応）",
+    "WebSearch": "推論モデルのWeb検索",
+    "Start": "会話を開始",
+    "Stop": "会話を終了",
+    "Playback": "GPT-Live音声の再生",
+    "BackendBusy": "推論モデルが処理中です…",
+    "ConnectionError": "接続できませんでした。マイクの許可とネットワーク接続を確認してください。",
+    "ServerSecretAccessDenied": "サーバー側のAPIキー利用が許可されていません。サーバーのアクセス設定を確認するか、設定画面にOpenAI APIキーを入力してください。",
+    "SessionError": "セッションを作成できませんでした。OpenAI APIキー、GPT-Liveへのアクセス権、推論モデル名を確認してください。",
+    "ServerError": "GPT-Liveがエラーを返しました。会話を終了して再接続してください。",
+    "UnconfirmedClose": "接続が終了しました。サーバーからの終了確認と最終利用時間は取得できていません。",
+    "PlaybackBlocked": "音声を再生できませんでした。音声の再生ボタンを押してください。",
+    "BackendError": "推論モデルの処理が完了しませんでした。設定と利用状況を確認してください。",
+    "State": {
+      "idle": "音声で会話する",
+      "connecting": "接続中…",
+      "connected": "会話中・マイクON",
+      "closing": "終了を確認中…",
+      "closed": "会話を終了しました",
+      "error": "接続が終了しました"
+    }
   }
 }

--- a/src/__tests__/components/formVisibility.test.tsx
+++ b/src/__tests__/components/formVisibility.test.tsx
@@ -3,12 +3,14 @@ import { render, screen } from '@testing-library/react'
 import { Form } from '@/components/form'
 
 let mockShowInputForm = true
+let mockLiveMode = false
 
 jest.mock('@/features/stores/settings', () => ({
   __esModule: true,
   default: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       slideMode: false,
+      liveMode: mockLiveMode,
       showInputForm: mockShowInputForm,
       selectAIService: 'openai',
       selectAIModel: 'gpt-4',
@@ -65,6 +67,7 @@ jest.mock('@/components/slideText', () => ({
 describe('Form visibility', () => {
   beforeEach(() => {
     mockShowInputForm = true
+    mockLiveMode = false
   })
 
   it('shows the message input when enabled', () => {
@@ -80,4 +83,12 @@ describe('Form visibility', () => {
     expect(screen.queryByTestId('message-input')).toBeNull()
     expect(screen.getByTestId('preset-questions')).toBeTruthy()
   })
+})
+
+it('keeps live controls mounted when the ordinary input is hidden', () => {
+  mockShowInputForm = false
+  mockLiveMode = true
+  render(<Form />)
+  expect(screen.getByTestId('message-input')).toBeTruthy()
+  expect(screen.queryByTestId('preset-questions')).toBeNull()
 })

--- a/src/__tests__/features/live/history.test.ts
+++ b/src/__tests__/features/live/history.test.ts
@@ -1,0 +1,30 @@
+import { selectLiveHistory } from '@/features/live/history'
+
+const messages = Array.from({ length: 150 }, (_, i) => ({
+  role: i % 2 ? 'assistant' : 'user',
+  content: String(i),
+}))
+
+test.each([1, 10, 35])('honors the configured history count %i', (count) => {
+  expect(selectLiveHistory(messages, count)).toEqual(messages.slice(-count))
+})
+test('caps at the API limit and handles zero without sending all history', () => {
+  expect(selectLiveHistory(messages, 9999)).toEqual(messages.slice(-128))
+  expect(selectLiveHistory(messages, 0)).toEqual([])
+})
+test('filters unsupported content without truncating long messages', () => {
+  const history = selectLiveHistory(
+    [
+      ...Array.from({ length: 5 }, () => ({
+        role: 'user',
+        content: 'x'.repeat(3000),
+      })),
+      { role: 'system', content: 'not history' },
+      { role: 'user', content: [] },
+    ],
+    10
+  )
+  expect(history).toHaveLength(5)
+  expect(history.every((m) => m.content === 'x'.repeat(3000))).toBe(true)
+  expect(history.reduce((n, m) => n + m.content.length, 0)).toBe(15000)
+})

--- a/src/__tests__/features/live/session.test.ts
+++ b/src/__tests__/features/live/session.test.ts
@@ -1,0 +1,165 @@
+import { LiveSession } from '@/features/live/session'
+
+class MockPeer {
+  static last: MockPeer
+  channel = {
+    readyState: 'open',
+    send: jest.fn(),
+    close: jest.fn(),
+    onmessage: null as null | ((event: { data: string }) => void),
+    onclose: null as null | (() => void),
+    onerror: null,
+  }
+  localDescription = { sdp: 'v=0\r\n' }
+  iceGatheringState = 'complete'
+  connectionState = 'connected'
+  ontrack = null
+  onconnectionstatechange = null
+  addTrack = jest.fn()
+  createOffer = jest.fn(async () => ({ type: 'offer', sdp: 'v=0' }))
+  setLocalDescription = jest.fn(async () => {})
+  setRemoteDescription = jest.fn(async () => {})
+  close = jest.fn()
+  createDataChannel = jest.fn(() => this.channel)
+  constructor() {
+    MockPeer.last = this
+  }
+  emit(type: string) {
+    this.channel.onmessage?.({ data: JSON.stringify({ type }) })
+  }
+}
+const savedPeer = global.RTCPeerConnection
+const savedFetch = global.fetch
+const savedMedia = navigator.mediaDevices
+let track: { stop: jest.Mock; enabled: boolean }
+let callbacks: {
+  state: jest.Mock
+  event: jest.Mock
+  stream: jest.Mock
+  cleanup: jest.Mock
+}
+beforeEach(() => {
+  jest.useFakeTimers()
+  track = { stop: jest.fn(), enabled: true }
+  callbacks = {
+    state: jest.fn(),
+    event: jest.fn(),
+    stream: jest.fn(),
+    cleanup: jest.fn(),
+  }
+  global.RTCPeerConnection = MockPeer as unknown as typeof RTCPeerConnection
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      getUserMedia: jest.fn(async () => ({
+        getTracks: () => [track],
+        getAudioTracks: () => [track],
+      })),
+    },
+  })
+  global.fetch = jest.fn(async () => ({
+    ok: true,
+    json: async () => ({ transport: { sdp: 'v=0' } }),
+  })) as unknown as typeof fetch
+})
+afterEach(() => {
+  jest.useRealTimers()
+  global.RTCPeerConnection = savedPeer
+  global.fetch = savedFetch
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: savedMedia,
+  })
+})
+test('waits for session.started, uses WebRTC, closes only after finalization', async () => {
+  const session = new LiveSession(callbacks)
+  await session.start({ voice: 'marin' })
+  const peer = MockPeer.last
+  expect(peer.channel.send).not.toHaveBeenCalled()
+  expect(callbacks.state).not.toHaveBeenCalledWith('connected', undefined)
+  peer.emit('session.started')
+  expect(callbacks.state).toHaveBeenCalledWith('connected', undefined)
+  session.close()
+  expect(track.enabled).toBe(false)
+  expect(peer.channel.send).toHaveBeenCalledWith(
+    JSON.stringify({ type: 'session.close' })
+  )
+  expect(peer.close).not.toHaveBeenCalled()
+  peer.emit('session.closed')
+  expect(peer.close).toHaveBeenCalledTimes(1)
+  expect(track.stop).toHaveBeenCalledTimes(1)
+  expect(callbacks.cleanup).toHaveBeenCalledTimes(1)
+})
+test('stopping during permission prompt releases late microphone without creating a session', async () => {
+  let resolve!: (stream: MediaStream) => void
+  ;(navigator.mediaDevices.getUserMedia as jest.Mock).mockReturnValue(
+    new Promise<MediaStream>((done) => {
+      resolve = done
+    })
+  )
+  const session = new LiveSession(callbacks)
+  const pending = session.start({})
+  session.close()
+  resolve({ getTracks: () => [track] } as unknown as MediaStream)
+  await pending
+  expect(track.stop).toHaveBeenCalled()
+  expect(global.fetch).not.toHaveBeenCalled()
+})
+test('missing final event times out and releases resources once', async () => {
+  const session = new LiveSession(callbacks)
+  await session.start({})
+  MockPeer.last.emit('session.started')
+  session.close()
+  jest.advanceTimersByTime(15000)
+  expect(callbacks.state).toHaveBeenCalledWith('error', 'Live.UnconfirmedClose')
+  expect(callbacks.cleanup).toHaveBeenCalledTimes(1)
+})
+test('HTTP failure and startup timeout never leave the microphone running', async () => {
+  ;(global.fetch as jest.Mock).mockResolvedValue({ ok: false })
+  const session = new LiveSession(callbacks)
+  await session.start({})
+  expect(callbacks.state).toHaveBeenCalledWith('error', 'Live.SessionError')
+  expect(track.stop).toHaveBeenCalled()
+})
+
+test('an open data channel is not sufficient to send commands before session.started', async () => {
+  const session = new LiveSession(callbacks)
+  await session.start({})
+  session.close()
+  expect(MockPeer.last.channel.send).not.toHaveBeenCalled()
+  MockPeer.last.emit('session.started')
+  expect(MockPeer.last.channel.send).toHaveBeenCalledWith(
+    JSON.stringify({ type: 'session.close' })
+  )
+  MockPeer.last.emit('session.closed')
+})
+
+test('identifies server secret access denial and releases the microphone', async () => {
+  ;(global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    json: async () => ({ errorCode: 'ServerSecretAccessDenied' }),
+  })
+  const session = new LiveSession(callbacks)
+  await session.start({})
+  expect(callbacks.state).toHaveBeenCalledWith(
+    'error',
+    'Live.ServerSecretAccessDenied'
+  )
+  expect(track.stop).toHaveBeenCalled()
+  expect(MockPeer.last.setRemoteDescription).not.toHaveBeenCalled()
+})
+
+test.each([
+  ['LiveHistoryLimitExceeded', 'Live.HistoryLimitExceeded'],
+  ['LiveInstructionsLimitExceeded', 'Live.InstructionsLimitExceeded'],
+  ['LiveTokenLimitExceeded', 'Live.TokenLimitExceeded'],
+])('shows %s and releases the microphone', async (errorCode, message) => {
+  ;(global.fetch as jest.Mock).mockResolvedValue({
+    ok: false,
+    json: async () => ({ errorCode }),
+  })
+  const session = new LiveSession(callbacks)
+  await session.start({})
+  expect(callbacks.state).toHaveBeenCalledWith('error', message)
+  expect(track.stop).toHaveBeenCalled()
+})

--- a/src/__tests__/features/live/settings.test.ts
+++ b/src/__tests__/features/live/settings.test.ts
@@ -1,0 +1,48 @@
+import settingsStore, {
+  CURRENT_SETTINGS_VERSION,
+  selectPersistedSettings,
+} from '@/features/stores/settings'
+
+afterEach(() => {
+  settingsStore.setState({ liveMode: false })
+  localStorage.clear()
+})
+test('Live settings are included in backup/persistence', () => {
+  settingsStore.setState({
+    liveMode: true,
+    liveVoice: 'quartz',
+    liveBackendModel: 'gpt-5.6-terra',
+    liveWebSearch: true,
+  })
+  expect(selectPersistedSettings(settingsStore.getState())).toMatchObject({
+    liveMode: true,
+    liveVoice: 'quartz',
+    liveBackendModel: 'gpt-5.6-terra',
+    liveWebSearch: true,
+  })
+})
+test('restored Live mode disables competing microphones and automatic speech', async () => {
+  localStorage.setItem(
+    'aitube-kit-settings',
+    JSON.stringify({
+      version: CURRENT_SETTINGS_VERSION,
+      state: {
+        liveMode: true,
+        realtimeAPIMode: true,
+        audioMode: true,
+        youtubeMode: true,
+        idleModeEnabled: true,
+        speechRecognitionMode: 'live-transcription',
+      },
+    })
+  )
+  await settingsStore.persist.rehydrate()
+  expect(settingsStore.getState()).toMatchObject({
+    liveMode: true,
+    realtimeAPIMode: false,
+    audioMode: false,
+    youtubeMode: false,
+    idleModeEnabled: false,
+    speechRecognitionMode: 'browser',
+  })
+})

--- a/src/__tests__/features/live/transcripts.test.ts
+++ b/src/__tests__/features/live/transcripts.test.ts
@@ -1,0 +1,28 @@
+import { LiveTranscripts } from '@/features/live/transcripts'
+
+test('overlapping speakers, exact fragments, duplicates and late delivery', () => {
+  const captions = new LiveTranscripts('test')
+  const add = (
+    delta: string,
+    start_ms: number,
+    type = 'session.input_transcript.delta',
+    event_id = delta
+  ) =>
+    captions.append({
+      type,
+      delta,
+      start_ms,
+      end_ms: start_ms + 200,
+      event_id,
+    })!
+  const user = add('Hello', 1000)
+  const assistant = add('Yes', 1100, 'session.output_transcript.delta')
+  expect(user.id).not.toBe(assistant.id)
+  const later = add(' world', 1400)
+  expect(later.id).toBe(user.id)
+  expect(later.content).toBe('Hello world')
+  expect(add(' world', 1400)).toBeNull()
+  expect(add('Oh, ', 800).content).toBe('Oh, Hello world')
+  expect(add('Next', 5000).id).not.toBe(user.id)
+  expect(later.fragments).toHaveLength(2)
+})

--- a/src/__tests__/features/pngTuber/pngTuberEngine.test.ts
+++ b/src/__tests__/features/pngTuber/pngTuberEngine.test.ts
@@ -514,6 +514,9 @@ describe('PNGTuberEngine インスタンス動作', () => {
   // privateフィールドの検証用に内部状態の型を宣言しておく
   // （プロパティ名はコンパイル時に保証されないが、as anyの散在を避けて一箇所に集約する）
   type EngineInternals = {
+    mouthState: MouthState
+    mouthSprites: Record<string, HTMLImageElement>
+    lastMouthChange: number
     sensitivity: number
     chromaKeyEnabled: boolean
     chromaKeyTolerance: number
@@ -543,6 +546,21 @@ describe('PNGTuberEngine インスタンス動作', () => {
 
   beforeEach(() => {
     engine = createEngine()
+  })
+
+  it('closes immediately on zero volume even inside the mouth transition interval', () => {
+    const state = internals(engine)
+    state.mouthSprites = {
+      open: document.createElement('img'),
+      closed: document.createElement('img'),
+    }
+    state.mouthState = 'open'
+    state.lastMouthChange = performance.now()
+    engine.setExternalAudioLevel(0)
+    expect(state.mouthState).toBe('closed')
+    const lastChange = state.lastMouthChange
+    engine.setExternalAudioLevel(0)
+    expect(state.lastMouthChange).toBe(lastChange)
   })
 
   describe('setSensitivity', () => {

--- a/src/__tests__/features/stores/exclusionEngine.test.ts
+++ b/src/__tests__/features/stores/exclusionEngine.test.ts
@@ -792,3 +792,33 @@ describe('disabled条件 (computeDisabledConditions)', () => {
     expect(conditions.presenceDetectionEnabled).toBe(true)
   })
 })
+
+describe('GPT-Live exclusions', () => {
+  it('disables competing modes and keeps the ordinary model selection', () => {
+    const prev = createBaseState({
+      realtimeAPIMode: true,
+      youtubeMode: true,
+      idleModeEnabled: true,
+    })
+    const { corrections } = computeExclusions({ liveMode: true }, prev)
+    expect(corrections).toMatchObject({
+      realtimeAPIMode: false,
+      youtubeMode: false,
+      idleModeEnabled: false,
+      continuousMicListeningMode: false,
+    })
+  })
+  it.each([
+    { realtimeAPIMode: true },
+    { audioMode: true },
+    { selectAIService: 'anthropic' },
+    { speechRecognitionMode: 'live-transcription' },
+    { youtubeMode: true },
+  ])('leaves Live when another mode is selected', (incoming) => {
+    const { corrections } = computeExclusions(
+      incoming as Partial<SettingsState>,
+      createBaseState({ liveMode: true })
+    )
+    expect(corrections.liveMode).toBe(false)
+  })
+})

--- a/src/__tests__/pages/api/ai-live-session.test.ts
+++ b/src/__tests__/pages/api/ai-live-session.test.ts
@@ -1,0 +1,150 @@
+import handler from '@/pages/api/ai/live-session'
+import {
+  createMockReq,
+  createMockRes,
+  mockServerSecretGuard,
+} from '../../helpers/apiRouteTestUtils'
+const originalFetch = global.fetch
+const originalEnv = process.env
+const mockFetch = jest.fn()
+const body = {
+  apiKey: 'test-key',
+  sdp: 'v=0\r\n',
+  instructions: 'Be helpful',
+  history: [{ role: 'assistant', content: 'Hello' }],
+}
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env = { ...originalEnv }
+  delete process.env.OPENAI_KEY
+  delete process.env.OPENAI_API_KEY
+  global.fetch = mockFetch
+  mockServerSecretGuard('disabled')
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      session: { id: 'live_123', private: 'do not forward' },
+      transport: { sdp: 'v=0\r\n' },
+    }),
+  })
+})
+afterEach(() => {
+  process.env = originalEnv
+  global.fetch = originalFetch
+})
+test('dedicated API, server-shaped Responses delegation and safe response', async () => {
+  const res = createMockRes()
+  await handler(createMockReq({ body: { ...body, webSearch: true } }), res)
+  expect(res._status).toBe(201)
+  const [url, request] = mockFetch.mock.calls[0]
+  expect(url).toBe('https://api.openai.com/v1/live/sessions')
+  const payload = JSON.parse(request.body)
+  expect(payload.session.model).toBe('gpt-live-1')
+  expect(payload.session.delegation.responses.tools).toEqual([
+    { type: 'web_search' },
+  ])
+  expect(payload.session.input[0].content[0].type).toBe('output_text')
+  expect(payload.session.audio).toEqual({ output: { voice: 'marin' } })
+  expect(payload.transport.type).toBe('webrtc')
+  expect(res._json).toEqual({
+    session: { id: 'live_123' },
+    transport: { type: 'webrtc', sdp: 'v=0\r\n' },
+  })
+})
+test.each([
+  { sdp: '' },
+  { voice: 'unknown' },
+  { backendModel: '' },
+  { history: [{ role: 'system', content: 'x' }] },
+])('rejects invalid configuration before billing: %j', async (invalid) => {
+  const res = createMockRes()
+  await handler(createMockReq({ body: { ...body, ...invalid } }), res)
+  expect(res._status).toBe(400)
+  expect(mockFetch).not.toHaveBeenCalled()
+})
+test('requires credentials', async () => {
+  const res = createMockRes()
+  await handler(createMockReq({ body: { ...body, apiKey: '' } }), res)
+  expect(res._status).toBe(400)
+  expect(mockFetch).not.toHaveBeenCalled()
+})
+test('upstream rejection is sanitized', async () => {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 403,
+    json: async () => ({}),
+  })
+  const res = createMockRes()
+  await handler(createMockReq({ body }), res)
+  expect(res._status).toBe(403)
+  expect(res._json).toEqual({
+    error: 'GPT-Live session creation failed',
+    errorCode: 'LiveSessionCreationFailed',
+  })
+})
+
+test('server keys obey the existing access policy', async () => {
+  process.env.OPENAI_API_KEY = 'server-test-key'
+  mockServerSecretGuard('protected')
+  const res = createMockRes()
+  await handler(createMockReq({ body: { ...body, apiKey: '' } }), res)
+  expect(res._status).toBe(403)
+  expect(mockFetch).not.toHaveBeenCalled()
+})
+
+test.each([
+  [35, 201],
+  [129, 400],
+])('history length %i respects API limit', async (count, status) => {
+  const res = createMockRes()
+  await handler(
+    createMockReq({
+      body: {
+        ...body,
+        history: Array.from({ length: count }, () => ({
+          role: 'user',
+          content: 'Hi',
+        })),
+      },
+    }),
+    res
+  )
+  expect(res._status).toBe(status)
+})
+
+test('forwards long text unchanged instead of imposing character limits', async () => {
+  const res = createMockRes()
+  const content = 'hello '.repeat(1500)
+  const instructions = 'hi '.repeat(6000)
+  await handler(
+    createMockReq({
+      body: { ...body, instructions, history: [{ role: 'user', content }] },
+    }),
+    res
+  )
+  expect(res._status).toBe(201)
+  const payload = JSON.parse(mockFetch.mock.calls[0][1].body)
+  expect(payload.session.input[0].content[0].text).toBe(content)
+  expect(payload.session.instructions.startsWith(instructions)).toBe(true)
+})
+test.each([
+  ['session.input', 'LiveHistoryLimitExceeded'],
+  ['session.instructions', 'LiveInstructionsLimitExceeded'],
+  ['', 'LiveTokenLimitExceeded'],
+])(
+  'reports official token limit error for %s without leaking upstream text',
+  async (param, errorCode) => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        error: { param, message: 'Maximum token limit exceeded: private-text' },
+      }),
+    })
+    const res = createMockRes()
+    await handler(createMockReq({ body }), res)
+    expect(res._status).toBe(400)
+    expect(res._json.errorCode).toBe(errorCode)
+    expect(JSON.stringify(res._json)).not.toContain('private-text')
+  }
+)

--- a/src/__tests__/scripts/generateWafRules.test.ts
+++ b/src/__tests__/scripts/generateWafRules.test.ts
@@ -35,13 +35,14 @@ type WafRule = {
  *   （audioモードのサーバー中継ルート。docs/audio-mode-auth-design.md）
  * - 2026-07-08 Realtime API ephemeral化:
  *   `/api/ai/realtime-client-secret` を embed許可集合へ追加
+ * - GPT-Live: `/api/ai/live-session` を embed許可集合へ追加
  */
 const LEGACY_RULES: WafRule[] = [
   {
     ref: 'aituberkit-nikechan-embed-skip',
     description: 'AITuberKit: allow embedded widget on nikechan.com',
     expression:
-      '(http.host in {"aituberkit.com" "www.aituberkit.com"} and ((http.referer contains "https://nikechan.com" and starts_with(http.request.uri.path, "/embed")) or ((http.referer contains "https://aituberkit.com/" or http.referer contains "https://www.aituberkit.com/") and (starts_with(http.request.uri.path, "/vrm/") or starts_with(http.request.uri.path, "/live2d/") or starts_with(http.request.uri.path, "/pngtuber/") or starts_with(http.request.uri.path, "/models/") or starts_with(http.request.uri.path, "/poses/") or ends_with(http.request.uri.path, ".vrma"))) or (http.request.method eq "POST" and (http.referer contains "https://aituberkit.com/embed" or http.referer contains "https://www.aituberkit.com/embed") and http.request.uri.path in {"/api/ai/audio" "/api/ai/custom" "/api/ai/realtime-client-secret" "/api/ai/vercel" "/api/tts-aivis-cloud-api" "/api/save-chat-log"})))',
+      '(http.host in {"aituberkit.com" "www.aituberkit.com"} and ((http.referer contains "https://nikechan.com" and starts_with(http.request.uri.path, "/embed")) or ((http.referer contains "https://aituberkit.com/" or http.referer contains "https://www.aituberkit.com/") and (starts_with(http.request.uri.path, "/vrm/") or starts_with(http.request.uri.path, "/live2d/") or starts_with(http.request.uri.path, "/pngtuber/") or starts_with(http.request.uri.path, "/models/") or starts_with(http.request.uri.path, "/poses/") or ends_with(http.request.uri.path, ".vrma"))) or (http.request.method eq "POST" and (http.referer contains "https://aituberkit.com/embed" or http.referer contains "https://www.aituberkit.com/embed") and http.request.uri.path in {"/api/ai/audio" "/api/ai/custom" "/api/ai/live-session" "/api/ai/realtime-client-secret" "/api/ai/vercel" "/api/tts-aivis-cloud-api" "/api/save-chat-log"})))',
     action: 'skip',
     action_parameters: {
       ruleset: 'current',

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -28,6 +28,7 @@ export const Form = ({ focusOnMount = true }: Props) => {
   const customModel = settingsStore((s) => s.customModel)
   const gameCommentaryEnabled = settingsStore((s) => s.gameCommentaryEnabled)
   const gameCommentaryPlaying = settingsStore((s) => s.gameCommentaryPlaying)
+  const liveMode = settingsStore((s) => s.liveMode)
   const [delayedText, setDelayedText] = useState('')
   const handleSendChat = handleSendChatFn()
 
@@ -101,7 +102,7 @@ export const Form = ({ focusOnMount = true }: Props) => {
     <SlideText />
   ) : (
     <>
-      <PresetQuestionButtons onSelectQuestion={hookSendChat} />
+      {!liveMode && <PresetQuestionButtons onSelectQuestion={hookSendChat} />}
       {showInputForm && (
         <MessageInputContainer
           focusOnMount={focusOnMount}

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -103,7 +103,7 @@ export const Form = ({ focusOnMount = true }: Props) => {
   ) : (
     <>
       {!liveMode && <PresetQuestionButtons onSelectQuestion={hookSendChat} />}
-      {showInputForm && (
+      {(showInputForm || liveMode) && (
         <MessageInputContainer
           focusOnMount={focusOnMount}
           onChatProcessStart={hookSendChat}

--- a/src/components/liveConversation.tsx
+++ b/src/components/liveConversation.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import settingsStore from '@/features/stores/settings'
+import homeStore from '@/features/stores/home'
+import { SpeakQueue } from '@/features/messages/speakQueue'
+import { LiveSession, type LiveState } from '@/features/live/session'
+import { LivePlayback } from '@/features/live/playback'
+import { selectLiveHistory } from '@/features/live/history'
+import { LiveTranscripts } from '@/features/live/transcripts'
+import { TextButton } from './textButton'
+
+export const LiveConversation = () => {
+  const { t } = useTranslation()
+  const [state, setState] = useState<LiveState>('idle')
+  const [error, setError] = useState('')
+  const [seconds, setSeconds] = useState(0)
+  const [backendBusy, setBackendBusy] = useState(false)
+  const session = useRef<LiveSession | null>(null)
+  const audio = useRef<HTMLAudioElement | null>(null)
+  const mounted = useRef(false)
+  const playbackRef = useRef<LivePlayback | null>(null)
+  useEffect(() => {
+    mounted.current = true
+    const close = () => {
+      playbackRef.current?.close()
+      session.current?.close()
+    }
+    window.addEventListener('pagehide', close)
+    return () => {
+      mounted.current = false
+      window.removeEventListener('pagehide', close)
+      close()
+    }
+  }, [])
+
+  const start = () => {
+    if (
+      !audio.current ||
+      ['connecting', 'connected', 'closing'].includes(state)
+    )
+      return
+    setError('')
+    setSeconds(0)
+    setBackendBusy(false)
+    SpeakQueue.stopAll()
+    let playback: LivePlayback
+    try {
+      playback = new LivePlayback(audio.current)
+      playbackRef.current = playback
+    } catch {
+      setError('Live.ConnectionError')
+      return
+    }
+    const captions = new LiveTranscripts(crypto.randomUUID())
+    const connection = new LiveSession({
+      state: (next, message) => {
+        if (!mounted.current) return
+        setState(next)
+        if (message) setError(message)
+      },
+      stream: (stream) => {
+        void playback.attach(stream).catch(() => {
+          if (mounted.current) setError('Live.PlaybackBlocked')
+        })
+      },
+      cleanup: () => playback.close(),
+      event: (event) => {
+        if (!mounted.current) return
+        const row = captions.append(event)
+        if (row) {
+          homeStore.getState().upsertMessage({
+            id: row.id,
+            role: row.role,
+            content: row.content,
+            liveTranscript: row.fragments,
+          })
+          if (row.role === 'assistant')
+            homeStore.setState({
+              activeSpeech: { id: row.id, text: row.content },
+            })
+        }
+        if (!mounted.current) return
+        if (typeof event.usage?.seconds === 'number')
+          setSeconds(event.usage.seconds)
+        if (event.type === 'response.event' && event.event?.type) {
+          if (event.event.type === 'response.created') setBackendBusy(true)
+          if (
+            [
+              'response.completed',
+              'response.failed',
+              'response.incomplete',
+              'response.cancelled',
+            ].includes(event.event.type)
+          ) {
+            setBackendBusy(false)
+            if (event.event.type !== 'response.completed')
+              setError('Live.BackendError')
+          }
+        }
+      },
+    })
+    session.current = connection
+    const settings = settingsStore.getState()
+    const history = selectLiveHistory(
+      homeStore.getState().chatLog,
+      settings.maxPastMessages
+    )
+    void connection.start({
+      apiKey: settings.openaiKey,
+      voice: settings.liveVoice,
+      backendModel: settings.liveBackendModel,
+      webSearch: settings.liveWebSearch,
+      instructions: settings.systemPrompt,
+      language: settings.selectLanguage,
+      history,
+    })
+  }
+
+  const active = ['connecting', 'connected'].includes(state)
+  return (
+    <div
+      className="absolute bottom-0 z-20 w-screen"
+      data-testid="live-conversation"
+    >
+      <div className="mx-auto w-full max-w-[680px] px-3 pb-2 pt-2 sm:pb-6">
+        {error && (
+          <div
+            role="alert"
+            className="theme-surface-elevated mb-2 rounded-2xl border p-3 text-sm text-theme-default"
+          >
+            {t(error)}
+            {error === 'Live.PlaybackBlocked' && (
+              <TextButton
+                type="button"
+                className="ml-2"
+                onClick={() => {
+                  void audio.current
+                    ?.play()
+                    .then(() => setError(''))
+                    .catch(() => setError('Live.PlaybackBlocked'))
+                }}
+              >
+                {t('Live.Playback')}
+              </TextButton>
+            )}
+          </div>
+        )}
+        <div className="aurora-glass-capsule flex items-center gap-2 rounded-[31px] p-2 pl-4 text-theme-default">
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-bold">GPT-Live-1</p>
+            <p role="status" className="text-sm">
+              {backendBusy && state === 'connected'
+                ? t('Live.BackendBusy')
+                : t(`Live.State.${state}`)}
+              {seconds > 0 && ` · ${Math.ceil(seconds)}s`}
+            </p>
+          </div>
+          <TextButton
+            type="button"
+            className="shrink-0 text-sm"
+            onClick={active ? () => session.current?.close() : start}
+            disabled={state === 'closing'}
+          >
+            {t(active ? 'Live.Stop' : 'Live.Start')}
+          </TextButton>
+        </div>
+        <audio ref={audio} autoPlay aria-label={t('Live.Playback')} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/messageInputContainer.tsx
+++ b/src/components/messageInputContainer.tsx
@@ -1,3 +1,4 @@
+import { LiveConversation } from './liveConversation'
 import { useEffect } from 'react'
 import { MessageInput } from '@/components/messageInput'
 import homeStore from '@/features/stores/home'
@@ -10,7 +11,16 @@ type Props = {
   onChatProcessStart: (text: string) => void
 }
 
-export const MessageInputContainer = ({
+export const MessageInputContainer = (props: Props) => {
+  const liveMode = settingsStore((s) => s.liveMode)
+  return liveMode ? (
+    <LiveConversation />
+  ) : (
+    <StandardMessageInputContainer {...props} />
+  )
+}
+
+const StandardMessageInputContainer = ({
   focusOnMount = true,
   onChatProcessStart,
 }: Props) => {

--- a/src/components/settings/memorySettings.tsx
+++ b/src/components/settings/memorySettings.tsx
@@ -1,3 +1,4 @@
+import { LIVE_HISTORY_MAX_MESSAGES } from '@/features/live/history'
 /**
  * MemorySettings Component
  *
@@ -58,6 +59,7 @@ const MemorySettings = () => {
   const memoryMaxContextTokens = settingsStore((s) => s.memoryMaxContextTokens)
   const openaiKey = settingsStore((s) => s.openaiKey)
   const selectAIService = settingsStore((s) => s.selectAIService)
+  const liveMode = settingsStore((s) => s.liveMode)
   const maxPastMessages = settingsStore((s) => s.maxPastMessages)
 
   // 会話履歴
@@ -633,7 +635,11 @@ const MemorySettings = () => {
           </div>
           <div className="my-2 text-sm whitespace-pre-wrap">
             {selectAIService !== 'dify'
-              ? t('ConversationHistoryInfo', { count: maxPastMessages })
+              ? t(liveMode ? 'Live.HistoryInfo' : 'ConversationHistoryInfo', {
+                  count: liveMode
+                    ? Math.min(maxPastMessages, LIVE_HISTORY_MAX_MESSAGES)
+                    : maxPastMessages,
+                })
               : t('DifyInfo2')}
           </div>
 
@@ -647,12 +653,20 @@ const MemorySettings = () => {
                 <input
                   type="number"
                   min="1"
-                  max="9999"
+                  max={liveMode ? LIVE_HISTORY_MAX_MESSAGES : 9999}
                   className="w-24 px-4 py-2 bg-white border border-gray-300 rounded-lg"
-                  value={maxPastMessages}
+                  value={
+                    liveMode
+                      ? Math.min(maxPastMessages, LIVE_HISTORY_MAX_MESSAGES)
+                      : maxPastMessages
+                  }
                   onChange={(e) => {
                     const value = parseInt(e.target.value)
-                    if (!Number.isNaN(value) && value >= 1 && value <= 9999) {
+                    if (
+                      !Number.isNaN(value) &&
+                      value >= 1 &&
+                      value <= (liveMode ? LIVE_HISTORY_MAX_MESSAGES : 9999)
+                    ) {
                       settingsStore.setState({ maxPastMessages: value })
                     }
                   }}

--- a/src/components/settings/modelProvider.tsx
+++ b/src/components/settings/modelProvider.tsx
@@ -1,3 +1,4 @@
+import { LIVE_HISTORY_MAX_MESSAGES } from '@/features/live/history'
 import { useTranslation } from 'react-i18next'
 import { Listbox } from '@headlessui/react'
 import settingsStore from '@/features/stores/settings'
@@ -23,6 +24,7 @@ import { settingsControlClass } from '@/components/settings/formStyles'
 const ModelProvider = () => {
   const { t } = useTranslation()
   const state = useModelProviderState()
+  const liveMode = settingsStore((s) => s.liveMode)
   const { updateMultiModalModeForModel, handleAIServiceChange } =
     useAIServiceHandlers()
 
@@ -391,7 +393,8 @@ const ModelProvider = () => {
 
       {state.selectAIService !== 'dify' && (
         <>
-          {!state.realtimeAPIMode &&
+          {!liveMode &&
+            !state.realtimeAPIMode &&
             !state.audioMode &&
             state.selectAIService !== 'custom-api' && (
               <>
@@ -540,18 +543,30 @@ const ModelProvider = () => {
           <div className="border-t border-gray-300 pt-6 my-6">
             <div className="my-4 text-xl font-bold">{t('MaxPastMessages')}</div>
             <div className="my-2 text-sm whitespace-pre-wrap">
-              {t('ConversationHistoryInfo', { count: state.maxPastMessages })}
+              {t(liveMode ? 'Live.HistoryInfo' : 'ConversationHistoryInfo', {
+                count: liveMode
+                  ? Math.min(state.maxPastMessages, LIVE_HISTORY_MAX_MESSAGES)
+                  : state.maxPastMessages,
+              })}
             </div>
             <div className="my-2">
               <input
                 type="number"
                 min="1"
-                max="9999"
+                max={liveMode ? LIVE_HISTORY_MAX_MESSAGES : 9999}
                 className="px-4 py-2 w-24 bg-white hover:bg-white-hover rounded-lg"
-                value={state.maxPastMessages}
+                value={
+                  liveMode
+                    ? Math.min(state.maxPastMessages, LIVE_HISTORY_MAX_MESSAGES)
+                    : state.maxPastMessages
+                }
                 onChange={(e) => {
                   const value = parseInt(e.target.value)
-                  if (!Number.isNaN(value) && value >= 1 && value <= 9999) {
+                  if (
+                    !Number.isNaN(value) &&
+                    value >= 1 &&
+                    value <= (liveMode ? LIVE_HISTORY_MAX_MESSAGES : 9999)
+                  ) {
                     settingsStore.setState({ maxPastMessages: value })
                   }
                 }}

--- a/src/components/settings/modelProvider/LiveConfig.tsx
+++ b/src/components/settings/modelProvider/LiveConfig.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next'
+import settingsStore from '@/features/stores/settings'
+import {
+  liveVoices,
+  liveVoicePresentation,
+  type LiveVoice,
+} from '@/features/live/config'
+import { ToggleSwitch } from '@/components/toggleSwitch'
+import { settingsControlClass } from '@/components/settings/formStyles'
+
+export const LiveConfig = () => {
+  const { t } = useTranslation()
+  const enabled = settingsStore((s) => s.liveMode)
+  const voice = settingsStore((s) => s.liveVoice)
+  const backend = settingsStore((s) => s.liveBackendModel)
+  const webSearch = settingsStore((s) => s.liveWebSearch)
+  return (
+    <div className="my-6">
+      <div className="my-4 text-xl font-bold">GPT-Live-1</div>
+      <p className="my-2">{t('Live.Description')}</p>
+      <ToggleSwitch
+        enabled={enabled}
+        onChange={(liveMode) => settingsStore.setState({ liveMode })}
+        testId="live-mode-toggle"
+      />
+      {enabled && (
+        <>
+          <p className="my-2">{t('Live.SettingsHint')}</p>
+          <p className="my-2">{t('Live.PromptHint')}</p>
+          <label className="my-4 block">
+            <span className="mb-2 block font-bold">{t('Live.Voice')}</span>
+            <select
+              aria-label={t('Live.Voice')}
+              className={settingsControlClass.compact}
+              value={voice}
+              onChange={(e) =>
+                settingsStore.setState({
+                  liveVoice: e.target.value as LiveVoice,
+                })
+              }
+            >
+              {liveVoices.map((v) => (
+                <option key={v} value={v}>
+                  {v}（{t(`Live.VoicePresentation.${liveVoicePresentation[v]}`)}
+                  ）
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="my-4 block">
+            <span className="mb-2 block font-bold">{t('Live.Backend')}</span>
+            <input
+              className={settingsControlClass.medium}
+              value={backend}
+              maxLength={128}
+              onChange={(e) =>
+                settingsStore.setState({ liveBackendModel: e.target.value })
+              }
+            />
+          </label>
+          <div className="my-4 font-bold">{t('Live.WebSearch')}</div>
+          <ToggleSwitch
+            enabled={webSearch}
+            onChange={(liveWebSearch) =>
+              settingsStore.setState({ liveWebSearch })
+            }
+            testId="live-web-search-toggle"
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/settings/modelProvider/OpenAIConfig.tsx
+++ b/src/components/settings/modelProvider/OpenAIConfig.tsx
@@ -1,3 +1,4 @@
+import { LiveConfig } from './LiveConfig'
 import { useTranslation } from 'react-i18next'
 import { useCallback } from 'react'
 import settingsStore from '@/features/stores/settings'
@@ -53,6 +54,7 @@ export const OpenAIConfig = ({
   updateMultiModalModeForModel,
 }: OpenAIConfigProps) => {
   const { t } = useTranslation()
+  const liveMode = settingsStore((s) => s.liveMode)
 
   const handleRealtimeAPIModeChange = useCallback((newMode: boolean) => {
     settingsStore.setState({ realtimeAPIMode: newMode })
@@ -99,6 +101,8 @@ export const OpenAIConfig = ({
         linkUrl="https://platform.openai.com/account/api-keys"
         linkLabel="OpenAI Platform"
       />
+
+      <LiveConfig />
 
       <div className="my-6">
         <div className="my-4 text-xl font-bold">{t('RealtimeAPIMode')}</div>
@@ -242,7 +246,7 @@ export const OpenAIConfig = ({
         </>
       )}
 
-      {!realtimeAPIMode && !audioMode && (
+      {!liveMode && !realtimeAPIMode && !audioMode && (
         <>
           <ModelSelector
             aiService="openai"

--- a/src/components/settings/shell/Header.tsx
+++ b/src/components/settings/shell/Header.tsx
@@ -21,6 +21,8 @@ export const Header = ({ onClickClose }: HeaderProps) => {
   const settingsSearchQuery = menuStore((state) => state.settingsSearchQuery)
   const [showMobileSearch, setShowMobileSearch] = useState(false)
   const youtubeMode = settingsStore((s) => s.youtubeMode)
+  const liveMode = settingsStore((s) => s.liveMode)
+  const liveVoice = settingsStore((s) => s.liveVoice)
   const realtimeAPIMode = settingsStore((s) => s.realtimeAPIMode)
   const audioMode = settingsStore((s) => s.audioMode)
   const slideMode = settingsStore((s) => s.slideMode)
@@ -32,6 +34,7 @@ export const Header = ({ onClickClose }: HeaderProps) => {
   const kioskModeEnabled = settingsStore((s) => s.kioskModeEnabled)
   const gameCommentaryEnabled = settingsStore((s) => s.gameCommentaryEnabled)
   const modeItems: ModeStatusItem[] = [
+    { label: 'GPT-Live', active: liveMode, tab: 'ai' },
     { label: t('SettingsModeYoutube'), active: youtubeMode, tab: 'youtube' },
     {
       label: t('SettingsModeRealtimeAPI'),
@@ -140,8 +143,12 @@ export const Header = ({ onClickClose }: HeaderProps) => {
         />
         <StatusChip
           label={t('SettingsVoice')}
-          value={formatStatusValue(selectVoice)}
-          onClick={() => openHeaderTab('voice')}
+          value={
+            liveMode
+              ? `GPT-Live (${liveVoice})`
+              : formatStatusValue(selectVoice)
+          }
+          onClick={() => openHeaderTab(liveMode ? 'ai' : 'voice')}
         />
         <ModeStatusSummary items={modeItems} onSelect={openHeaderTab} />
         <a

--- a/src/components/settings/speechInput.tsx
+++ b/src/components/settings/speechInput.tsx
@@ -24,6 +24,7 @@ const SpeechInput = () => {
     (s) => s.continuousMicListeningMode
   )
   const initialSpeechTimeout = settingsStore((s) => s.initialSpeechTimeout)
+  const liveMode = settingsStore((s) => s.liveMode)
   const realtimeAPIMode = settingsStore((s) => s.realtimeAPIMode)
   const audioMode = settingsStore((s) => s.audioMode)
   const voiceInputShortcut =
@@ -33,6 +34,8 @@ const SpeechInput = () => {
     DEFAULT_SETTINGS_TOGGLE_SHORTCUT
 
   const { t } = useTranslation()
+
+  if (liveMode) return <p>{t('Live.SettingsHint')}</p>
 
   const whisperModels: { value: WhisperTranscriptionModel; label: string }[] =
     getOpenAIWhisperModels().map((m) => ({

--- a/src/components/settings/voice.tsx
+++ b/src/components/settings/voice.tsx
@@ -23,6 +23,7 @@ const Voice = () => {
   const elevenlabsApiKey = settingsStore((s) => s.elevenlabsApiKey)
   const cartesiaApiKey = settingsStore((s) => s.cartesiaApiKey)
 
+  const liveMode = settingsStore((s) => s.liveMode)
   const realtimeAPIMode = settingsStore((s) => s.realtimeAPIMode)
   const audioMode = settingsStore((s) => s.audioMode)
 
@@ -90,6 +91,8 @@ const Voice = () => {
   const azureTTSKey = settingsStore((s) => s.azureTTSKey)
   const azureTTSEndpoint = settingsStore((s) => s.azureTTSEndpoint)
   const { t } = useTranslation()
+
+  if (liveMode) return <p>{t('Live.SettingsHint')}</p>
 
   // 追加: realtimeAPIMode または audioMode が true の場合にメッセージを表示
   if (realtimeAPIMode || audioMode) {

--- a/src/features/live/config.ts
+++ b/src/features/live/config.ts
@@ -1,0 +1,40 @@
+// GPT-Live has a dedicated protocol; these are not Realtime API models.
+export const LIVE_MODEL = 'gpt-live-1'
+export const DEFAULT_LIVE_BACKEND = 'gpt-5.6-terra'
+export const liveVoices = [
+  'marin',
+  'quartz',
+  'ripple',
+  'vesper',
+  'willow',
+  'stone',
+  'gleam',
+  'meridian',
+  'bossa',
+  'tempo',
+  'beacon',
+  'delta',
+  'cinder',
+] as const
+export type LiveVoice = (typeof liveVoices)[number]
+
+// Presentation in the official GPT-Live voice table; marin is not classified.
+// https://developers.openai.com/api/docs/guides/live-conversations#voice-options
+export const liveVoicePresentation: Record<
+  LiveVoice,
+  'Female' | 'Male' | 'Unspecified'
+> = {
+  marin: 'Unspecified',
+  quartz: 'Female',
+  ripple: 'Male',
+  vesper: 'Male',
+  willow: 'Female',
+  stone: 'Male',
+  gleam: 'Female',
+  meridian: 'Male',
+  bossa: 'Female',
+  tempo: 'Male',
+  beacon: 'Male',
+  delta: 'Female',
+  cinder: 'Male',
+}

--- a/src/features/live/history.ts
+++ b/src/features/live/history.ts
@@ -1,0 +1,25 @@
+// GPT-Live startup input accepts at most 128 messages.
+export const LIVE_HISTORY_MAX_MESSAGES = 128
+export const LIVE_HISTORY_MAX_TOKENS = 8192
+export const LIVE_INSTRUCTIONS_MAX_TOKENS = 16384
+
+export function selectLiveHistory(
+  messages: readonly { role: string; content?: unknown }[],
+  maxPastMessages: number
+): { role: 'user' | 'assistant'; content: string }[] {
+  const count = Number.isFinite(maxPastMessages)
+    ? Math.min(
+        LIVE_HISTORY_MAX_MESSAGES,
+        Math.max(0, Math.floor(maxPastMessages))
+      )
+    : 0
+  if (count === 0) return []
+  return messages
+    .filter(
+      (message): message is { role: 'user' | 'assistant'; content: string } =>
+        ['user', 'assistant'].includes(message.role) &&
+        typeof message.content === 'string'
+    )
+    .slice(-count)
+    .map(({ role, content }) => ({ role, content }))
+}

--- a/src/features/live/playback.ts
+++ b/src/features/live/playback.ts
@@ -1,0 +1,103 @@
+import homeStore from '@/features/stores/home'
+
+interface Live2DInternal {
+  coreModel: {
+    setParameterValueById?: (id: string, value: number) => void
+    setParamFloat?: (id: string, value: number) => void
+  }
+  motionManager?: { lipSyncIds?: string[] }
+  on: (event: string, listener: () => void) => void
+  off: (event: string, listener: () => void) => void
+}
+
+// Analyse the actual WebRTC media track. Never queue copies of its audio.
+export class LivePlayback {
+  private context: AudioContext
+  private analyser: AnalyserNode
+  private source: MediaStreamAudioSourceNode | null = null
+  private frame = 0
+  private volume = 0
+  private closed = false
+  private vrm = homeStore.getState().viewer.model
+  private png = homeStore.getState().pngTuberViewer
+  private live2d = homeStore.getState().live2dViewer
+  private get internal() {
+    return this.live2d?.internalModel as unknown as Live2DInternal | undefined
+  }
+  private updateMouth = () => {
+    const core = this.internal?.coreModel
+    for (const id of this.internal?.motionManager?.lipSyncIds || [
+      'ParamMouthOpenY',
+    ]) {
+      core?.setParameterValueById?.(id, this.volume)
+    }
+    core?.setParamFloat?.('PARAM_MOUTH_OPEN_Y', this.volume)
+  }
+
+  constructor(private audio: HTMLAudioElement) {
+    this.context = new AudioContext()
+    this.analyser = this.context.createAnalyser()
+    this.analyser.fftSize = 2048
+    void this.context.resume().catch(() => {})
+  }
+
+  attach(stream: MediaStream) {
+    if (this.closed) return Promise.resolve()
+    this.source?.disconnect()
+    this.source = this.context.createMediaStreamSource(stream)
+    this.source.connect(this.analyser)
+    this.audio.srcObject = stream
+    const samples = new Float32Array(this.analyser.fftSize)
+    cancelAnimationFrame(this.frame)
+    this.internal?.off('beforeModelUpdate', this.updateMouth)
+    this.internal?.on('beforeModelUpdate', this.updateMouth)
+    const tick = () => {
+      const home = homeStore.getState()
+      if (this.vrm !== home.viewer.model) {
+        if (this.vrm) this.vrm.externalLipSyncVolume = null
+        this.vrm = home.viewer.model
+      }
+      if (this.png !== home.pngTuberViewer) {
+        this.png?.setExternalAudioLevel(0)
+        this.png = home.pngTuberViewer
+      }
+      if (this.live2d !== home.live2dViewer) {
+        this.internal?.off('beforeModelUpdate', this.updateMouth)
+        this.live2d = home.live2dViewer
+        this.internal?.on('beforeModelUpdate', this.updateMouth)
+      }
+      this.analyser.getFloatTimeDomainData(samples)
+      const rms = Math.sqrt(
+        samples.reduce((sum, sample) => sum + sample * sample, 0) /
+          samples.length
+      )
+      this.volume =
+        this.audio.paused || this.audio.muted ? 0 : Math.min(1, rms * 8)
+      if (this.vrm) this.vrm.externalLipSyncVolume = this.volume
+      this.png?.setExternalAudioLevel(this.volume)
+      const speaking = this.volume > 0.02
+      if (homeStore.getState().isSpeaking !== speaking)
+        homeStore.setState({ isSpeaking: speaking })
+      this.frame = requestAnimationFrame(tick)
+    }
+    tick()
+    return this.audio.play()
+  }
+
+  close() {
+    if (this.closed) return
+    this.closed = true
+    cancelAnimationFrame(this.frame)
+    this.source?.disconnect()
+    this.analyser.disconnect()
+    this.internal?.off('beforeModelUpdate', this.updateMouth)
+    this.volume = 0
+    this.updateMouth()
+    if (this.vrm) this.vrm.externalLipSyncVolume = null
+    this.png?.setExternalAudioLevel(0)
+    this.audio.pause()
+    this.audio.srcObject = null
+    void this.context.close().catch(() => {})
+    homeStore.setState({ isSpeaking: false, activeSpeech: null })
+  }
+}

--- a/src/features/live/session.ts
+++ b/src/features/live/session.ts
@@ -1,0 +1,233 @@
+export type LiveState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'closing'
+  | 'closed'
+  | 'error'
+export interface LiveEvent {
+  type: string
+  event_id?: string
+  delta?: string
+  start_ms?: number
+  end_ms?: number
+  usage?: { seconds?: number }
+  event?: { type?: string; response?: { status?: string } }
+}
+
+// One instance owns one connection. A late microphone/fetch result cannot revive it.
+export class LiveSession {
+  private peer: RTCPeerConnection | null = null
+  private channel: RTCDataChannel | null = null
+  private microphone: MediaStream | null = null
+  private controller = new AbortController()
+  private startupTimer?: ReturnType<typeof setTimeout>
+  private closeTimer?: ReturnType<typeof setTimeout>
+  private disconnectTimer?: ReturnType<typeof setTimeout>
+  private cancelled = false
+  private released = false
+  private state: LiveState = 'idle'
+
+  constructor(
+    private callbacks: {
+      state: (state: LiveState, error?: string) => void
+      event: (event: LiveEvent) => void
+      stream: (stream: MediaStream) => void
+      cleanup: () => void
+    }
+  ) {}
+
+  private update(state: LiveState, error?: string) {
+    this.state = state
+    this.callbacks.state(state, error)
+  }
+
+  private release() {
+    if (this.released) return
+    this.released = true
+    this.cancelled = true
+    clearTimeout(this.startupTimer)
+    clearTimeout(this.closeTimer)
+    clearTimeout(this.disconnectTimer)
+    this.controller.abort()
+    this.microphone?.getTracks().forEach((track) => track.stop())
+    this.channel?.close()
+    this.peer?.close()
+    this.callbacks.cleanup()
+  }
+
+  private fail(error = 'Live.ConnectionError') {
+    if (this.released) return
+    this.update('error', error)
+    this.release()
+  }
+
+  async start(configuration: Record<string, unknown>) {
+    if (this.state !== 'idle') return
+    this.update('connecting')
+    this.startupTimer = setTimeout(() => this.fail(), 45000)
+    try {
+      const peer = new RTCPeerConnection()
+      this.peer = peer
+      peer.ontrack = ({ track }) => {
+        if (!this.cancelled) this.callbacks.stream(new MediaStream([track]))
+      }
+      peer.onconnectionstatechange = () => {
+        clearTimeout(this.disconnectTimer)
+        if (!this.released && peer.connectionState === 'disconnected') {
+          this.disconnectTimer = setTimeout(() => this.fail(), 10000)
+        }
+        if (
+          !this.released &&
+          ['failed', 'closed'].includes(peer.connectionState)
+        )
+          this.fail()
+      }
+      const microphone = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      })
+      if (this.cancelled) {
+        microphone.getTracks().forEach((track) => track.stop())
+        return
+      }
+      this.microphone = microphone
+      microphone
+        .getAudioTracks()
+        .forEach((track) => peer.addTrack(track, microphone))
+      const channel = peer.createDataChannel('oai-events')
+      this.channel = channel
+      channel.onmessage = ({ data }) => {
+        if (this.released) return
+        try {
+          const event = JSON.parse(data) as LiveEvent
+          if (event.type === 'session.closed') {
+            this.callbacks.event(event)
+            this.update('closed')
+            this.release()
+            return
+          }
+          if (event.type === 'session.started') {
+            clearTimeout(this.startupTimer)
+            if (this.cancelled) {
+              channel.send(JSON.stringify({ type: 'session.close' }))
+            } else this.update('connected')
+          }
+          if (event.type === 'error') {
+            this.callbacks.state(this.state, 'Live.ServerError')
+          }
+          this.callbacks.event(event)
+        } catch {
+          this.fail('Live.ServerError')
+        }
+      }
+      channel.onclose = () => {
+        if (!this.released) this.fail('Live.UnconfirmedClose')
+      }
+      channel.onerror = () => this.fail()
+      await peer.setLocalDescription(await peer.createOffer())
+      if (this.cancelled) return
+      await this.waitForIce(peer)
+      if (this.cancelled) return
+      const response = await fetch('/api/ai/live-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...configuration,
+          sdp: peer.localDescription?.sdp,
+        }),
+        signal: this.controller.signal,
+      })
+      if (this.cancelled) return
+      if (!response.ok) {
+        let errorCode: unknown
+        try {
+          errorCode = (await response.json())?.errorCode
+        } catch {
+          // Non-JSON errors still need to release the microphone.
+        }
+        const errors: Record<string, string> = {
+          ServerSecretAccessDenied: 'Live.ServerSecretAccessDenied',
+          LiveHistoryLimitExceeded: 'Live.HistoryLimitExceeded',
+          LiveInstructionsLimitExceeded: 'Live.InstructionsLimitExceeded',
+          LiveTokenLimitExceeded: 'Live.TokenLimitExceeded',
+        }
+        this.fail(
+          typeof errorCode === 'string'
+            ? errors[errorCode] || 'Live.SessionError'
+            : 'Live.SessionError'
+        )
+        return
+      }
+      const result = await response.json()
+      if (this.cancelled) return
+      await peer.setRemoteDescription({
+        type: 'answer',
+        sdp: result.transport.sdp,
+      })
+    } catch (error) {
+      if (!this.cancelled)
+        this.fail(
+          error instanceof Error && error.message === 'Live.SessionError'
+            ? error.message
+            : 'Live.ConnectionError'
+        )
+    }
+  }
+
+  private waitForIce(peer: RTCPeerConnection): Promise<void> {
+    if (peer.iceGatheringState === 'complete') return Promise.resolve()
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(timer)
+        peer.removeEventListener('icegatheringstatechange', check)
+        this.controller.signal.removeEventListener('abort', abort)
+      }
+      const check = () => {
+        if (peer.iceGatheringState !== 'complete') return
+        cleanup()
+        resolve()
+      }
+      const abort = () => {
+        cleanup()
+        reject(new Error('Cancelled'))
+      }
+      const timer = setTimeout(() => {
+        cleanup()
+        reject(new Error('ICE timeout'))
+      }, 10000)
+      peer.addEventListener('icegatheringstatechange', check)
+      this.controller.signal.addEventListener('abort', abort, { once: true })
+      check()
+    })
+  }
+
+  close() {
+    if (this.released || this.state === 'closing') return
+    const started = this.state === 'connected'
+    this.cancelled = true
+    // Stop transmitting immediately, but keep the event channel for final usage.
+    this.microphone?.getAudioTracks().forEach((track) => {
+      track.enabled = false
+    })
+    if (this.channel?.readyState === 'open') {
+      this.update('closing')
+      this.closeTimer = setTimeout(
+        () => this.fail('Live.UnconfirmedClose'),
+        15000
+      )
+      try {
+        if (started)
+          this.channel.send(JSON.stringify({ type: 'session.close' }))
+      } catch {
+        this.fail('Live.UnconfirmedClose')
+      }
+    } else {
+      this.update('closed')
+      this.release()
+    }
+  }
+}

--- a/src/features/live/transcripts.ts
+++ b/src/features/live/transcripts.ts
@@ -1,0 +1,62 @@
+import type { LiveEvent } from './session'
+
+export interface LiveFragment {
+  delta: string
+  start_ms: number
+  end_ms: number
+}
+export interface LiveCaption {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  fragments: LiveFragment[]
+}
+
+// Display grouping only: gaps never trigger model calls or terminate a turn.
+export class LiveTranscripts {
+  private rows: LiveCaption[] = []
+  private seen = new Set<string>()
+  constructor(private prefix: string) {}
+  append(event: LiveEvent): LiveCaption | null {
+    if (
+      ![
+        'session.input_transcript.delta',
+        'session.output_transcript.delta',
+      ].includes(event.type) ||
+      typeof event.delta !== 'string' ||
+      typeof event.start_ms !== 'number' ||
+      typeof event.end_ms !== 'number'
+    )
+      return null
+    if (event.event_id && this.seen.has(event.event_id)) return null
+    if (event.event_id) this.seen.add(event.event_id)
+    const role =
+      event.type === 'session.input_transcript.delta' ? 'user' : 'assistant'
+    let row = this.rows.find(
+      (item) =>
+        item.role === role &&
+        item.fragments.some(
+          (f) =>
+            event.start_ms! <= f.end_ms + 1500 &&
+            event.end_ms! >= f.start_ms - 1500
+        )
+    )
+    if (!row) {
+      row = {
+        id: `${this.prefix}-${this.rows.length}`,
+        role,
+        content: '',
+        fragments: [],
+      }
+      this.rows.push(row)
+    }
+    row.fragments.push({
+      delta: event.delta,
+      start_ms: event.start_ms,
+      end_ms: event.end_ms,
+    })
+    row.fragments.sort((a, b) => a.start_ms - b.start_ms)
+    row.content = row.fragments.map((f) => f.delta).join('')
+    return { ...row, fragments: [...row.fragments] }
+  }
+}

--- a/src/features/messages/messages.ts
+++ b/src/features/messages/messages.ts
@@ -4,6 +4,7 @@ export type Message = {
   content?:
     | string
     | [{ type: 'text'; text: string }, { type: 'image'; image: string }] // マルチモーダル拡張
+  liveTranscript?: { delta: string; start_ms: number; end_ms: number }[]
   audio?: { id: string }
   timestamp?: string
   embedding?: number[] // メモリ機能用のembedding

--- a/src/features/pngTuber/pngTuberEngine.ts
+++ b/src/features/pngTuber/pngTuberEngine.ts
@@ -361,9 +361,8 @@ export class PNGTuberEngine implements IPNGTuberEngine {
    * 音声データを処理
    */
   public setExternalAudioLevel(volume: number): void {
-    this.setMouthState(
-      volume > 0.35 ? 'open' : volume > 0.08 ? 'half' : 'closed'
-    )
+    const state = volume > 0.35 ? 'open' : volume > 0.08 ? 'half' : 'closed'
+    this.setMouthState(state, volume <= 0 && state !== this.mouthState)
   }
 
   private handleAudioData(data: VolumeAnalyzerData): void {

--- a/src/features/pngTuber/pngTuberEngine.ts
+++ b/src/features/pngTuber/pngTuberEngine.ts
@@ -360,6 +360,12 @@ export class PNGTuberEngine implements IPNGTuberEngine {
   /**
    * 音声データを処理
    */
+  public setExternalAudioLevel(volume: number): void {
+    this.setMouthState(
+      volume > 0.35 ? 'open' : volume > 0.08 ? 'half' : 'closed'
+    )
+  }
+
   private handleAudioData(data: VolumeAnalyzerData): void {
     if (!data) return
 

--- a/src/features/stores/exclusionEngine.ts
+++ b/src/features/stores/exclusionEngine.ts
@@ -107,17 +107,24 @@ export function computeDisabledConditions(
 
   return {
     conversationContinuityMode:
-      !multiModalAvail || state.slideMode || state.externalLinkageMode,
-    slideMode: !multiModalAvail,
-    speechRecognitionModeSwitcher: state.realtimeAPIMode || state.audioMode,
-    voiceSettings: state.realtimeAPIMode || state.audioMode,
-    temperatureMaxTokens: state.realtimeAPIMode || state.audioMode,
+      state.liveMode ||
+      !multiModalAvail ||
+      state.slideMode ||
+      state.externalLinkageMode,
+    slideMode: state.liveMode || !multiModalAvail,
+    speechRecognitionModeSwitcher:
+      state.liveMode || state.realtimeAPIMode || state.audioMode,
+    voiceSettings: state.liveMode || state.realtimeAPIMode || state.audioMode,
+    temperatureMaxTokens:
+      state.liveMode || state.realtimeAPIMode || state.audioMode,
     idleModeEnabled:
+      state.liveMode ||
       state.realtimeAPIMode ||
       state.audioMode ||
       state.externalLinkageMode ||
       state.slideMode,
     presenceDetectionEnabled:
+      state.liveMode ||
       state.realtimeAPIMode ||
       state.audioMode ||
       state.externalLinkageMode ||

--- a/src/features/stores/exclusionRules.ts
+++ b/src/features/stores/exclusionRules.ts
@@ -43,6 +43,54 @@ const JA_ONLY_VOICES: AIVoice[] = [
 ]
 
 export const exclusionRules: ExclusionRule[] = [
+  {
+    id: 'live-incompatible-mode',
+    description:
+      '別の入力・自動発話モードやAIサービスへ切り替えたらGPT-Liveを停止',
+    trigger: (incoming, merged) =>
+      merged.liveMode &&
+      ((wasSet(incoming, 'selectAIService') &&
+        merged.selectAIService !== 'openai') ||
+        (wasSet(incoming, 'speechRecognitionMode') &&
+          merged.speechRecognitionMode !== 'browser') ||
+        (
+          [
+            'realtimeAPIMode',
+            'audioMode',
+            'externalLinkageMode',
+            'slideMode',
+            'youtubeMode',
+            'idleModeEnabled',
+            'presenceDetectionEnabled',
+            'gameCommentaryEnabled',
+            'conversationContinuityMode',
+            'messageReceiverEnabled',
+          ] as const
+        ).some((key) => incoming[key] === true)),
+    apply: () => ({ liveMode: false }),
+  },
+  {
+    id: 'live-on',
+    description: 'GPT-Liveのマイクと発話を他の入力・自動発話モードから分離',
+    trigger: (_incoming, merged) => merged.liveMode === true,
+    apply: () => ({
+      selectAIService: 'openai',
+      realtimeAPIMode: false,
+      audioMode: false,
+      externalLinkageMode: false,
+      slideMode: false,
+      youtubeMode: false,
+      idleModeEnabled: false,
+      presenceDetectionEnabled: false,
+      gameCommentaryEnabled: false,
+      gameCommentaryPlaying: false,
+      conversationContinuityMode: false,
+      messageReceiverEnabled: false,
+      continuousMicListeningMode: false,
+      speechRecognitionMode: 'browser',
+    }),
+    crossStoreEffects: () => [{ store: 'slide', state: { isPlaying: false } }],
+  },
   // Rule 1: externalLinkageMode ON
   {
     id: 'externalLinkage-on',

--- a/src/features/stores/home.ts
+++ b/src/features/stores/home.ts
@@ -245,6 +245,9 @@ const homeStore = create<HomeState>()(
               id: messageId,
               role: message.role,
               content: message.content,
+              ...(message.liveTranscript && {
+                liveTranscript: message.liveTranscript,
+              }),
               ...(message.audio && { audio: message.audio }),
               ...(message.timestamp && { timestamp: message.timestamp }),
               ...(message.userName && { userName: message.userName }),

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -1,3 +1,9 @@
+import { computeExclusions } from './exclusionEngine'
+import {
+  DEFAULT_LIVE_BACKEND,
+  liveVoices,
+  type LiveVoice,
+} from '@/features/live/config'
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { exclusivityMiddleware } from './exclusionMiddleware'
@@ -246,6 +252,10 @@ interface General {
   showQuickMenu: boolean
   externalLinkageMode: boolean
   externalLinkageUrl: string
+  liveMode: boolean
+  liveVoice: LiveVoice
+  liveBackendModel: string
+  liveWebSearch: boolean
   realtimeAPIMode: boolean
   realtimeAPIModeContentType: RealtimeAPIModeContentType
   realtimeAPIModeVoice: RealtimeAPIModeVoice | RealtimeAPIModeAzureVoice
@@ -588,6 +598,13 @@ const getInitialValuesFromEnv = (): SettingsState => ({
   externalLinkageMode: process.env.NEXT_PUBLIC_EXTERNAL_LINKAGE_MODE === 'true',
   externalLinkageUrl:
     process.env.NEXT_PUBLIC_EXTERNAL_LINKAGE_URL || 'ws://localhost:8000/ws',
+  liveMode: process.env.NEXT_PUBLIC_LIVE_MODE === 'true',
+  liveVoice:
+    liveVoices.find((voice) => voice === process.env.NEXT_PUBLIC_LIVE_VOICE) ||
+    'marin',
+  liveBackendModel:
+    process.env.NEXT_PUBLIC_LIVE_BACKEND_MODEL || DEFAULT_LIVE_BACKEND,
+  liveWebSearch: process.env.NEXT_PUBLIC_LIVE_WEB_SEARCH === 'true',
   realtimeAPIMode:
     process.env.NEXT_PUBLIC_REALTIME_API_MODE === 'true' &&
     ['openai', 'azure'].includes(
@@ -1071,6 +1088,11 @@ export const runSettingsMigrations = (
   return migrated as Partial<SettingsState>
 }
 
+const normalizeLiveSettings = (state: SettingsState): SettingsState =>
+  state.liveMode
+    ? { ...state, ...computeExclusions({ liveMode: true }, state).corrections }
+    : state
+
 const mergePersistedSettings = (
   persistedState: unknown,
   currentState: SettingsState
@@ -1081,13 +1103,13 @@ const mergePersistedSettings = (
   }
 
   if (process.env.NEXT_PUBLIC_ALWAYS_OVERRIDE_WITH_ENV_VARIABLES === 'true') {
-    return {
+    return normalizeLiveSettings({
       ...mergedState,
       ...getInitialValuesFromEnv(),
-    }
+    })
   }
 
-  return mergedState
+  return normalizeLiveSettings(mergedState)
 }
 
 export const selectPersistedSettings = (state: SettingsState) => ({
@@ -1198,6 +1220,10 @@ export const selectPersistedSettings = (state: SettingsState) => ({
   voiceInputShortcut: state.voiceInputShortcut,
   externalLinkageMode: state.externalLinkageMode,
   externalLinkageUrl: state.externalLinkageUrl,
+  liveMode: state.liveMode,
+  liveVoice: state.liveVoice,
+  liveBackendModel: state.liveBackendModel,
+  liveWebSearch: state.liveWebSearch,
   realtimeAPIMode: state.realtimeAPIMode,
   realtimeAPIModeContentType: state.realtimeAPIModeContentType,
   realtimeAPIModeVoice: state.realtimeAPIModeVoice,
@@ -1339,7 +1365,7 @@ export type PersistedSettings = ReturnType<typeof selectPersistedSettings>
 
 const settingsStore = create<SettingsState>()(
   exclusivityMiddleware(
-    persist(() => getInitialValuesFromEnv(), {
+    persist(() => normalizeLiveSettings(getInitialValuesFromEnv()), {
       name: 'aitube-kit-settings',
       version: CURRENT_SETTINGS_VERSION,
       migrate: (persistedState, storedVersion) =>

--- a/src/features/vrmViewer/model.ts
+++ b/src/features/vrmViewer/model.ts
@@ -20,6 +20,7 @@ import type { PlaybackObserver } from '../messages/characterRenderer'
  * 3Dキャラクターを管理するクラス
  */
 export class Model {
+  public externalLipSyncVolume: number | null = null
   public vrm?: VRM | null
   public mixer?: THREE.AnimationMixer
   public emoteController?: EmoteController
@@ -166,7 +167,7 @@ export class Model {
   public update(delta: number): void {
     if (this._lipSync) {
       const { volume } = this._lipSync.update()
-      this.emoteController?.lipSync('aa', volume)
+      this.emoteController?.lipSync('aa', this.externalLipSyncVolume ?? volume)
     }
 
     this.emoteController?.update(delta)

--- a/src/lib/accessPolicy/routePolicies.ts
+++ b/src/lib/accessPolicy/routePolicies.ts
@@ -31,6 +31,24 @@ export const routePolicies = {
     restrictedBehavior: 'none',
     waf: { embedAllowed: true },
   },
+  '/api/ai/live-session': {
+    path: '/api/ai/live-session',
+    featureName: 'ai/live-session',
+    methods: ['POST'],
+    resources: ['server-secret'],
+    secret: {
+      kind: 'pairs',
+      pairs: [
+        {
+          source: 'body',
+          key: 'apiKey',
+          envVars: ['OPENAI_KEY', 'OPENAI_API_KEY'],
+        },
+      ],
+    },
+    restrictedBehavior: 'none',
+    waf: { embedAllowed: true },
+  },
   '/api/ai/realtime-client-secret': {
     path: '/api/ai/realtime-client-secret',
     featureName: 'ai/realtime-client-secret',

--- a/src/pages/api/ai/live-session.ts
+++ b/src/pages/api/ai/live-session.ts
@@ -1,0 +1,145 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { z } from 'zod'
+import {
+  LIVE_MODEL,
+  DEFAULT_LIVE_BACKEND,
+  liveVoices,
+} from '@/features/live/config'
+import { LIVE_HISTORY_MAX_MESSAGES } from '@/features/live/history'
+import { routePolicies } from '@/lib/accessPolicy/routePolicies'
+import { withAccessPolicy } from '@/lib/accessPolicy/withAccessPolicy'
+
+const bodySchema = z.object({
+  apiKey: z.string().max(1024).optional(),
+  sdp: z
+    .string()
+    .min(1)
+    .max(65536)
+    .refine((s) => s.startsWith('v=0')),
+  voice: z.enum(liveVoices).default('marin'),
+  backendModel: z
+    .string()
+    .regex(/^[a-zA-Z0-9._:-]+$/)
+    .max(128)
+    .default(DEFAULT_LIVE_BACKEND),
+  instructions: z.string().default(''),
+  language: z
+    .string()
+    .regex(/^[a-zA-Z-]{2,12}$/)
+    .default('ja'),
+  webSearch: z.boolean().default(false),
+  history: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant']),
+        content: z.string(),
+      })
+    )
+    .max(LIVE_HISTORY_MAX_MESSAGES)
+    .default([]),
+})
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  res.setHeader('Cache-Control', 'no-store')
+  const parsed = bodySchema.safeParse(req.body)
+  if (!parsed.success)
+    return res
+      .status(400)
+      .json({ error: 'Invalid GPT-Live session configuration' })
+  const body = parsed.data
+  const apiKey =
+    body.apiKey || process.env.OPENAI_KEY || process.env.OPENAI_API_KEY
+  if (!apiKey)
+    return res
+      .status(400)
+      .json({ error: 'Empty API Key', errorCode: 'EmptyAPIKey' })
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 20000)
+  try {
+    const response = await fetch('https://api.openai.com/v1/live/sessions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        session: {
+          model: LIVE_MODEL,
+          instructions: `${body.instructions}\nSpeak in ${body.language}. Keep spoken replies concise and natural. Ask the backend for factual questions, reasoning, and tasks. Do not read emotion tags or formatting aloud.`,
+          audio: { output: { voice: body.voice } },
+          store: false,
+          input: body.history.map(({ role, content }) => ({
+            type: 'message',
+            role,
+            content: [
+              {
+                type: role === 'assistant' ? 'output_text' : 'input_text',
+                text: content,
+              },
+            ],
+          })),
+          delegation: {
+            type: 'responses',
+            responses: {
+              model: body.backendModel,
+              instructions: `${body.instructions}\nReturn concise answers in ${body.language} for a spoken conversation. Never claim to have performed actions without tools.`,
+              ...(body.webSearch
+                ? { tools: [{ type: 'web_search' }], tool_choice: 'auto' }
+                : {}),
+            },
+          },
+        },
+        transport: { type: 'webrtc', sdp: body.sdp },
+      }),
+    })
+    if (!response.ok) {
+      // The API is authoritative: its tokenizer and message overhead are not
+      // specified for GPT-Live. Do not substitute a character-count estimate.
+      const upstream = await response.json().catch(() => null)
+      const detail = upstream?.error
+      const tokenLimit =
+        response.status === 400 &&
+        typeof detail?.message === 'string' &&
+        /token/i.test(detail.message) &&
+        /exceed|maximum|at most|too (many|long)|limit/i.test(detail.message)
+      const field = typeof detail?.param === 'string' ? detail.param : ''
+      const errorCode = tokenLimit
+        ? /instructions/.test(field + ' ' + detail.message)
+          ? 'LiveInstructionsLimitExceeded'
+          : /input|history/.test(field + ' ' + detail.message)
+            ? 'LiveHistoryLimitExceeded'
+            : 'LiveTokenLimitExceeded'
+        : 'LiveSessionCreationFailed'
+      return res.status(response.status).json({
+        error: 'GPT-Live session creation failed',
+        errorCode,
+      })
+    }
+    const data = await response.json()
+    if (
+      typeof data.session?.id !== 'string' ||
+      typeof data.transport?.sdp !== 'string' ||
+      !data.transport.sdp.startsWith('v=0')
+    ) {
+      return res
+        .status(502)
+        .json({ error: 'Invalid GPT-Live session response' })
+    }
+    // Do not forward the resolved backend/session configuration or credentials.
+    return res.status(201).json({
+      session: { id: data.session.id },
+      transport: { type: 'webrtc', sdp: data.transport.sdp },
+    })
+  } catch {
+    return res
+      .status(controller.signal.aborted ? 504 : 502)
+      .json({ error: 'GPT-Live connection failed' })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export const config = { api: { bodyParser: { sizeLimit: '1mb' } } }
+export default withAccessPolicy(routePolicies['/api/ai/live-session'], handler)

--- a/tests/e2e/live-mode.spec.ts
+++ b/tests/e2e/live-mode.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test'
+import {
+  prepareApp,
+  gotoHome,
+  openSettings,
+  openSettingsTab,
+  closeSettings,
+  expectPersistedSetting,
+} from './helpers/app'
+
+test('GPT-Live settings, independent subtitles, and graceful stop', async ({
+  page,
+}) => {
+  await prepareApp(page, {
+    settings: {
+      selectLanguage: 'ja',
+      liveMode: false,
+      maxPastMessages: 200,
+      openaiKey: 'test-key',
+      showInputForm: true,
+    },
+    network: { blockExternal: true },
+  })
+  await page.addInitScript(() => {
+    class Peer {
+      channel = {
+        readyState: 'open',
+        onmessage: null as null | ((e: { data: string }) => void),
+        send: (data: string) => {
+          if (JSON.parse(data).type === 'session.close') {
+            this.channel.onmessage?.({
+              data: JSON.stringify({
+                type: 'session.closed',
+                usage: { seconds: 12 },
+              }),
+            })
+          }
+        },
+        close: () => {},
+      }
+      localDescription = { sdp: 'v=0\r\n' }
+      iceGatheringState = 'complete'
+      connectionState = 'connected'
+      addTrack() {}
+      createDataChannel() {
+        return this.channel
+      }
+      async createOffer() {
+        return { type: 'offer', sdp: 'v=0\r\n' }
+      }
+      async setLocalDescription() {}
+      async setRemoteDescription() {
+        for (const event of [
+          { type: 'session.started' },
+          {
+            type: 'session.input_transcript.delta',
+            delta: 'こんにちは',
+            start_ms: 1000,
+            end_ms: 1500,
+          },
+          {
+            type: 'session.output_transcript.delta',
+            delta: 'はい、',
+            start_ms: 1100,
+            end_ms: 1400,
+          },
+          {
+            type: 'session.output_transcript.delta',
+            delta: '聞こえています。',
+            start_ms: 1400,
+            end_ms: 1800,
+          },
+        ])
+          this.channel.onmessage?.({ data: JSON.stringify(event) })
+      }
+      close() {}
+    }
+    window.RTCPeerConnection = Peer as unknown as typeof RTCPeerConnection
+    navigator.mediaDevices.getUserMedia = async () => {
+      const context = new AudioContext()
+      return context.createMediaStreamDestination().stream
+    }
+  })
+  await page.route('**/api/ai/live-session', async (route) => {
+    const body = route.request().postDataJSON()
+    expect(body.voice).toBe('quartz')
+    expect(body.backendModel).toBe('gpt-5.6-terra')
+    await route.fulfill({
+      json: { session: { id: 'live_test' }, transport: { sdp: 'v=0\r\n' } },
+    })
+  })
+  await gotoHome(page)
+  await openSettings(page)
+  await openSettingsTab(page, 'ai')
+  await page.getByTestId('live-mode-toggle').click()
+  await expectPersistedSetting(page, 'liveMode', true)
+  const historyCount = page.locator('input[type="number"][max="128"]')
+  await expect(historyCount).toHaveValue('128')
+  await expectPersistedSetting(page, 'maxPastMessages', 200)
+  await historyCount.fill('35')
+  await expectPersistedSetting(page, 'maxPastMessages', 35)
+  await expect(
+    page.getByText(/GPT-Liveの上限は128件・合計8,192トークン/)
+  ).toBeVisible()
+
+  await page.getByLabel('GPT-Liveの声', { exact: true }).selectOption('quartz')
+  await closeSettings(page)
+  await expect(page.getByTestId('live-conversation')).toBeVisible()
+  await page.getByRole('button', { name: '会話を開始', exact: true }).click()
+  await expect(
+    page.getByRole('status').filter({ hasText: '会話中' })
+  ).toBeVisible()
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        JSON.parse(localStorage.getItem('aitube-kit-home')!).state.chatLog.map(
+          (m: { content: string }) => m.content
+        )
+      )
+    )
+    .toEqual(['こんにちは', 'はい、聞こえています。'])
+  await page.screenshot({ path: '/tmp/aituber-live-ui.png' })
+  await page.setViewportSize({ width: 390, height: 844 })
+  const panel = page.getByTestId('live-conversation')
+  await expect(panel).toBeVisible()
+  await expect
+    .poll(async () => (await panel.boundingBox())!.height)
+    .toBeLessThan(110)
+  await page.screenshot({ path: '/tmp/aituber-live-mobile.png' })
+  await page.getByRole('button', { name: '会話を終了', exact: true }).click()
+  await expect(
+    page.getByRole('status').filter({ hasText: '会話を終了しました' })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: '会話を開始', exact: true })
+  ).toBeEnabled()
+})

--- a/tests/e2e/live-mode.spec.ts
+++ b/tests/e2e/live-mode.spec.ts
@@ -10,7 +10,7 @@ import {
 
 test('GPT-Live settings, independent subtitles, and graceful stop', async ({
   page,
-}) => {
+}, testInfo) => {
   await prepareApp(page, {
     settings: {
       selectLanguage: 'ja',
@@ -119,14 +119,14 @@ test('GPT-Live settings, independent subtitles, and graceful stop', async ({
       )
     )
     .toEqual(['こんにちは', 'はい、聞こえています。'])
-  await page.screenshot({ path: '/tmp/aituber-live-ui.png' })
+  await page.screenshot({ path: testInfo.outputPath('live-ui.png') })
   await page.setViewportSize({ width: 390, height: 844 })
   const panel = page.getByTestId('live-conversation')
   await expect(panel).toBeVisible()
   await expect
     .poll(async () => (await panel.boundingBox())!.height)
     .toBeLessThan(110)
-  await page.screenshot({ path: '/tmp/aituber-live-mobile.png' })
+  await page.screenshot({ path: testInfo.outputPath('live-mobile.png') })
   await page.getByRole('button', { name: '会話を終了', exact: true }).click()
   await expect(
     page.getByRole('status').filter({ hasText: '会話を終了しました' })


### PR DESCRIPTION
## Summary
- OpenAIのGPT-Live-1を使う双方向音声会話モードを追加。専用WebRTC接続で音声を再生し、VRM・Live2D・PNGTuberの口パクとユーザー／アシスタントの字幕を連携します。
- 音声、Responses APIの推論モデル、Web検索を設定可能にし、システムプロンプトを音声側・推論側の両方に渡します。他の音声・自動発話モードとの排他制御も追加します。
- メイン画面には既存フォームに合わせたコンパクトな開始／終了バーを表示。声の男女分類、接続・サーバーキー利用拒否・トークン上限のエラーを表示します。
- 会話履歴は「過去のメッセージ保持数」に従い、GPT-Live時のみ最大128件に制限します。本文は文字数で切り捨てず、履歴8,192トークン／プロンプト16,384トークンの上限超過はAPIの判定を使って通知します。

## Verification
- `npx jest --runInBand --silent`: 全213スイート成功、2,292テスト成功・7件スキップ。CIで検出されたWAF生成の期待値漏れも修正済み。
- 変更したTypeScriptファイルのESLint、`git diff --check` 成功。
- 本番ソースを対象にしたTypeScriptチェック成功。リポジトリ全体の型チェックには既存のテストコードのエラーがあります。
- `E2E_PORT=3000 npx playwright test tests/e2e/live-mode.spec.ts --project=chromium --timeout=180000` 成功。設定保存、通常モードの履歴設定値保持、字幕、開始／終了、PC・スマホ表示を確認。
- 実APIでHTTP 201 → `session.started` → `session.closed` を確認済み。
- コミット `761ad07b` の独立worktreeで本番ビルド（`node node_modules/next/dist/bin/next build`）成功。既存のLint警告は残っています。

## Notes
- 通常のRealtime APIとは別の接続方式です。GPT-Liveへのアクセス権が必要です。サーバーのキーを使う場合は既存のサーバーシークレットアクセスポリシーに従います。
- 音声は接続時間、推論モデルとWeb検索は別途課金されます。設定変更は次の接続から適用します。
- ブラウザE2EのAPI・字幕はモックです。実API確認は接続の開始／終了までで、日本語会話品質・割り込み・各モデルの口パク全体の受け入れ確認は別途必要です。
- ローカル検証はNode.js 22.21.1（arm64）。プロジェクト指定のNode.js 24.xでは未確認です。
- 日本語の翻訳のみ更新しています。依存パッケージの変更はありません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GPT-Liveによるリアルタイム音声会話に対応しました。
  * 音声、推論モデル、Web検索、会話履歴の保持数を設定できます。
  * 音声入出力、字幕、利用時間、接続状態、エラーを確認できます。
  * 会話中の音声に合わせたアバターのリップシンクに対応しました。
  * GPT-Liveの会話履歴をチャットログへ保存できます。
  * GPT-Live利用時は、対応しない設定を自動的に調整します。
* **ドキュメント**
  * GPT-Liveの仕様、設定方法、料金、対応範囲、検証手順を追加しました。
* **テスト**
  * 接続、字幕、設定保存、履歴制限、エラー処理、画面表示を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->