### PR TITLE
Develop => main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ NEXT_PUBLIC_BACKGROUND_IMAGE_PATH="/backgrounds/bg-c.png"
 # Cloudflareデプロイ時はtrueに設定 / Set to true for Cloudflare deployment
 NEXT_PUBLIC_RESTRICTED_MODE="false"
 
-# デモモードの有効/無効 / Enable/disable demo mode
+# デモモードの有効/無効（GPT-Live・Realtime会話・Audio・OpenAI TTSを無効化） / Enable demo mode (disables GPT-Live, Realtime conversation, Audio mode and OpenAI TTS)
 NEXT_PUBLIC_DEMO_MODE="false"
 
 # GitHub Pages等サブパス公開時のベースパス /

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -82,7 +82,11 @@ jobs:
             fi
             printf '%s=%s\n' "$key" "$value" >> .env.local
           }
-          upsert_env_secret OPENAI_API_KEY "$OPENAI_API_KEY"
+          # Demo uses the external agent and Aivis Cloud. Never ship OpenAI keys.
+          for key in OPENAI_API_KEY OPENAI_KEY OPENAI_TTS_KEY OPENAI_EMBEDDING_KEY NEXT_PUBLIC_OPENAI_API_KEY NEXT_PUBLIC_OPENAI_KEY; do
+            upsert_env_secret "$key" ""
+          done
+          upsert_env_secret NEXT_PUBLIC_DEMO_MODE true
           upsert_env_secret ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY"
           upsert_env_secret CUSTOM_API_URL "$CUSTOM_API_URL"
           upsert_env_secret CUSTOM_API_HEADERS "$CUSTOM_API_HEADERS"
@@ -102,7 +106,6 @@ jobs:
         env:
           CLOUDFLARE_ENV_FILE: ${{ secrets.CLOUDFLARE_ENV_FILE }}
           CLOUDFLARE_PUBLIC_ENV_APPEND: ${{ secrets.CLOUDFLARE_PUBLIC_ENV_APPEND }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CUSTOM_API_URL: ${{ secrets.CUSTOM_API_URL }}
           CUSTOM_API_HEADERS: ${{ secrets.CUSTOM_API_HEADERS }}

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -87,6 +87,7 @@ jobs:
             upsert_env_secret "$key" ""
           done
           upsert_env_secret NEXT_PUBLIC_DEMO_MODE true
+          upsert_env_secret NEXT_PUBLIC_SELECT_AI_SERVICE custom-api
           upsert_env_secret ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY"
           upsert_env_secret CUSTOM_API_URL "$CUSTOM_API_URL"
           upsert_env_secret CUSTOM_API_HEADERS "$CUSTOM_API_HEADERS"

--- a/src/__tests__/features/stores/demoVoiceSettings.test.ts
+++ b/src/__tests__/features/stores/demoVoiceSettings.test.ts
@@ -1,0 +1,52 @@
+import settingsStore, {
+  CURRENT_SETTINGS_VERSION,
+} from '@/features/stores/settings'
+const originalEnv = process.env
+const initialState = settingsStore.getState()
+beforeEach(() => {
+  process.env = { ...originalEnv, NEXT_PUBLIC_DEMO_MODE: 'true' }
+})
+afterEach(() => {
+  process.env = originalEnv
+  settingsStore.setState(initialState, true)
+  localStorage.clear()
+})
+test('demo rejects mode changes without changing external agent or Aivis settings', () => {
+  settingsStore.setState({
+    selectAIService: 'custom-api',
+    selectVoice: 'aivis_cloud_api',
+  })
+  for (const mode of ['liveMode', 'realtimeAPIMode', 'audioMode'] as const) {
+    settingsStore.setState({ [mode]: true })
+    expect(settingsStore.getState()[mode]).toBe(false)
+    expect(settingsStore.getState().selectAIService).toBe('custom-api')
+    expect(settingsStore.getState().selectVoice).toBe('aivis_cloud_api')
+  }
+  settingsStore.setState({ selectVoice: 'openai' })
+  expect(settingsStore.getState().selectVoice).toBe('aivis_cloud_api')
+})
+test('persisted demo settings cannot restore disabled voice modes', async () => {
+  localStorage.setItem(
+    'aitube-kit-settings',
+    JSON.stringify({
+      version: CURRENT_SETTINGS_VERSION,
+      state: {
+        liveMode: true,
+        realtimeAPIMode: true,
+        audioMode: true,
+        selectVoice: 'openai',
+        selectAIService: 'custom-api',
+        youtubeMode: true,
+      },
+    })
+  )
+  await settingsStore.persist.rehydrate()
+  expect(settingsStore.getState()).toMatchObject({
+    liveMode: false,
+    realtimeAPIMode: false,
+    audioMode: false,
+    selectVoice: 'aivis_cloud_api',
+    selectAIService: 'custom-api',
+    youtubeMode: true,
+  })
+})

--- a/src/__tests__/features/stores/demoVoiceSettings.test.ts
+++ b/src/__tests__/features/stores/demoVoiceSettings.test.ts
@@ -50,3 +50,27 @@ test('persisted demo settings cannot restore disabled voice modes', async () => 
     youtubeMode: true,
   })
 })
+
+test.each([
+  ['', 'custom-api'],
+  ['user-owned-key', 'openai'],
+])(
+  'restores the external agent only for keyless persisted OpenAI settings',
+  async (openaiKey, expectedService) => {
+    process.env.NEXT_PUBLIC_SELECT_AI_SERVICE = 'custom-api'
+    localStorage.setItem(
+      'aitube-kit-settings',
+      JSON.stringify({
+        version: CURRENT_SETTINGS_VERSION,
+        state: {
+          selectAIService: 'openai',
+          openaiKey,
+          selectVoice: 'aivis_cloud_api',
+        },
+      })
+    )
+    await settingsStore.persist.rehydrate()
+    expect(settingsStore.getState().selectAIService).toBe(expectedService)
+    expect(settingsStore.getState().selectVoice).toBe('aivis_cloud_api')
+  }
+)

--- a/src/__tests__/pages/api/demoVoiceRestrictions.test.ts
+++ b/src/__tests__/pages/api/demoVoiceRestrictions.test.ts
@@ -1,0 +1,41 @@
+import live from '@/pages/api/ai/live-session'
+import audio from '@/pages/api/ai/audio'
+import tts from '@/pages/api/openAITTS'
+import realtime from '@/pages/api/ai/realtime-client-secret'
+import { createMockReq, createMockRes } from '../../helpers/apiRouteTestUtils'
+
+const originalEnv = process.env
+const originalFetch = global.fetch
+beforeEach(() => {
+  process.env = { ...originalEnv, NEXT_PUBLIC_DEMO_MODE: 'true' }
+  global.fetch = jest.fn()
+})
+afterEach(() => {
+  process.env = originalEnv
+  global.fetch = originalFetch
+})
+test.each([live, audio, tts, realtime])(
+  'blocks demo voice sessions even with a client key before upstream requests',
+  async (handler) => {
+    const res = createMockRes()
+    await handler(createMockReq({ body: { apiKey: 'client-key' } }), res)
+    expect(res._status).toBe(403)
+    expect(res._json).toMatchObject({ errorCode: 'FeatureDisabledInDemoMode' })
+    expect(global.fetch).not.toHaveBeenCalled()
+  }
+)
+test('preserves live transcription with the users own key', async () => {
+  ;(global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({ value: 'ephemeral', expires_at: 123 }),
+  })
+  const res = createMockRes()
+  await realtime(
+    createMockReq({
+      body: { apiKey: 'client-key', sessionType: 'transcription' },
+    }),
+    res
+  )
+  expect(global.fetch).toHaveBeenCalledTimes(1)
+  expect(res._status).toBe(200)
+})

--- a/src/components/settings/modelProvider/AzureConfig.tsx
+++ b/src/components/settings/modelProvider/AzureConfig.tsx
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 import { useTranslation } from 'react-i18next'
 import { useCallback } from 'react'
 import settingsStore from '@/features/stores/settings'
@@ -84,15 +85,19 @@ export const AzureConfig = ({
       </div>
 
       <div className="my-6">
-        <div className="my-4 text-xl font-bold">{t('RealtimeAPIMode')}</div>
-        <div className="my-2">
-          <ToggleSwitch
-            enabled={realtimeAPIMode}
-            onChange={handleRealtimeAPIModeChange}
-          />
-        </div>
+        {!isDemoMode() && (
+          <div className="my-4 text-xl font-bold">{t('RealtimeAPIMode')}</div>
+        )}
+        {!isDemoMode() && (
+          <div className="my-2">
+            <ToggleSwitch
+              enabled={realtimeAPIMode}
+              onChange={handleRealtimeAPIModeChange}
+            />
+          </div>
+        )}
 
-        {realtimeAPIMode && (
+        {!isDemoMode() && realtimeAPIMode && (
           <>
             <div className="my-4 font-bold">
               {t('RealtimeAPIModeContentType')}

--- a/src/components/settings/modelProvider/LiveConfig.tsx
+++ b/src/components/settings/modelProvider/LiveConfig.tsx
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 import { useTranslation } from 'react-i18next'
 import settingsStore from '@/features/stores/settings'
 import {
@@ -14,6 +15,7 @@ export const LiveConfig = () => {
   const voice = settingsStore((s) => s.liveVoice)
   const backend = settingsStore((s) => s.liveBackendModel)
   const webSearch = settingsStore((s) => s.liveWebSearch)
+  if (isDemoMode()) return null
   return (
     <div className="my-6">
       <div className="my-4 text-xl font-bold">GPT-Live-1</div>

--- a/src/components/settings/modelProvider/OpenAIConfig.tsx
+++ b/src/components/settings/modelProvider/OpenAIConfig.tsx
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 import { LiveConfig } from './LiveConfig'
 import { useTranslation } from 'react-i18next'
 import { useCallback } from 'react'
@@ -102,31 +103,35 @@ export const OpenAIConfig = ({
         linkLabel="OpenAI Platform"
       />
 
-      <LiveConfig />
+      {!isDemoMode() && (
+        <>
+          <LiveConfig />
 
-      <div className="my-6">
-        <div className="my-4 text-xl font-bold">{t('RealtimeAPIMode')}</div>
-        <div className="my-2">
-          <ToggleSwitch
-            enabled={realtimeAPIMode}
-            onChange={handleRealtimeAPIModeChange}
-            testId="realtime-api-mode-toggle"
-          />
-        </div>
-      </div>
+          <div className="my-6">
+            <div className="my-4 text-xl font-bold">{t('RealtimeAPIMode')}</div>
+            <div className="my-2">
+              <ToggleSwitch
+                enabled={realtimeAPIMode}
+                onChange={handleRealtimeAPIModeChange}
+                testId="realtime-api-mode-toggle"
+              />
+            </div>
+          </div>
 
-      <div className="my-6">
-        <div className="my-4 text-xl font-bold">{t('AudioMode')}</div>
-        <div className="my-2">
-          <ToggleSwitch
-            enabled={audioMode}
-            onChange={handleAudioModeChange}
-            testId="audio-mode-toggle"
-          />
-        </div>
-      </div>
+          <div className="my-6">
+            <div className="my-4 text-xl font-bold">{t('AudioMode')}</div>
+            <div className="my-2">
+              <ToggleSwitch
+                enabled={audioMode}
+                onChange={handleAudioModeChange}
+                testId="audio-mode-toggle"
+              />
+            </div>
+          </div>
+        </>
+      )}
 
-      {realtimeAPIMode && (
+      {!isDemoMode() && realtimeAPIMode && (
         <>
           <div className="my-4 font-bold">
             {t('RealtimeAPIModeContentType')}
@@ -192,7 +197,7 @@ export const OpenAIConfig = ({
         </>
       )}
 
-      {audioMode && (
+      {!isDemoMode() && audioMode && (
         <>
           <div className="my-4 font-bold">
             {t('RealtimeAPIModeContentType')}

--- a/src/components/settings/quickStart.tsx
+++ b/src/components/settings/quickStart.tsx
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 import { logger } from '@/lib/logger'
 import { useTranslation } from 'react-i18next'
 import i18n from 'i18next'
@@ -916,7 +917,9 @@ const QuickStart = () => {
             <option value="gsvitts">{t('UsingGSVITTS')}</option>
             <option value="elevenlabs">{t('UsingElevenLabs')}</option>
             <option value="cartesia">{t('UsingCartesia')}</option>
-            <option value="openai">{t('UsingOpenAITTS')}</option>
+            {!isDemoMode() && (
+              <option value="openai">{t('UsingOpenAITTS')}</option>
+            )}
             <option value="azure">{t('UsingAzureTTS')}</option>
           </select>
         </LabeledField>

--- a/src/components/settings/voice/VoiceEngineSelector.tsx
+++ b/src/components/settings/voice/VoiceEngineSelector.tsx
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 import { useTranslation } from 'react-i18next'
 
 import { AIVoice } from '@/features/constants/settings'
@@ -38,7 +39,9 @@ export const VoiceEngineSelector = ({
           <option value="gsvitts">{t('UsingGSVITTS')}</option>
           <option value="elevenlabs">{t('UsingElevenLabs')}</option>
           <option value="cartesia">{t('UsingCartesia')}</option>
-          <option value="openai">{t('UsingOpenAITTS')}</option>
+          {!isDemoMode() && (
+            <option value="openai">{t('UsingOpenAITTS')}</option>
+          )}
           <option value="azure">{t('UsingAzureTTS')}</option>
         </select>
       </div>

--- a/src/components/useRealtimeAPI.tsx
+++ b/src/components/useRealtimeAPI.tsx
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 import { logger } from '@/lib/logger'
 import { useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -306,6 +307,7 @@ const useRealtimeAPI = ({ handleReceiveTextFromRt }: Params) => {
   const onClose = useCallback((event: Event) => {}, [])
 
   const connectWebsocket = async (): Promise<WebSocket | null> => {
+    if (isDemoMode()) return null
     const wsManager = webSocketStore.getState().wsManager
     if (wsManager?.isConnected()) return wsManager.websocket
 

--- a/src/features/live/session.ts
+++ b/src/features/live/session.ts
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 export type LiveState =
   | 'idle'
   | 'connecting'
@@ -63,6 +64,10 @@ export class LiveSession {
   }
 
   async start(configuration: Record<string, unknown>) {
+    if (isDemoMode()) {
+      this.fail()
+      return
+    }
     if (this.state !== 'idle') return
     this.update('connecting')
     this.startupTimer = setTimeout(() => this.fail(), 45000)

--- a/src/features/stores/exclusionMiddleware.ts
+++ b/src/features/stores/exclusionMiddleware.ts
@@ -1,3 +1,4 @@
+import { restrictDemoVoiceSettings } from '@/utils/demoMode'
 import type { StateCreator, StoreMutatorIdentifier } from 'zustand'
 import type { SettingsState } from './settings'
 import { computeExclusions, type ExclusionResult } from './exclusionEngine'
@@ -17,8 +18,9 @@ function applyRules(
     | ((state: SettingsState) => Partial<SettingsState>),
   currentState: SettingsState
 ): ExclusionResult & { resolved: Partial<SettingsState> } {
-  const resolved =
+  const resolved = restrictDemoVoiceSettings(
     typeof partial === 'function' ? partial(currentState) : partial
+  )
 
   if (!resolved || typeof resolved !== 'object') {
     return {

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -1,3 +1,4 @@
+import { restrictDemoVoiceSettings } from '@/utils/demoMode'
 import { computeExclusions } from './exclusionEngine'
 import {
   DEFAULT_LIVE_BACKEND,
@@ -1088,10 +1089,12 @@ export const runSettingsMigrations = (
   return migrated as Partial<SettingsState>
 }
 
-const normalizeLiveSettings = (state: SettingsState): SettingsState =>
-  state.liveMode
+const normalizeLiveSettings = (input: SettingsState): SettingsState => {
+  const state = restrictDemoVoiceSettings(input)
+  return state.liveMode
     ? { ...state, ...computeExclusions({ liveMode: true }, state).corrections }
     : state
+}
 
 const mergePersistedSettings = (
   persistedState: unknown,

--- a/src/features/stores/settings.ts
+++ b/src/features/stores/settings.ts
@@ -1,4 +1,4 @@
-import { restrictDemoVoiceSettings } from '@/utils/demoMode'
+import { isDemoMode, restrictDemoVoiceSettings } from '@/utils/demoMode'
 import { computeExclusions } from './exclusionEngine'
 import {
   DEFAULT_LIVE_BACKEND,
@@ -1091,6 +1091,16 @@ export const runSettingsMigrations = (
 
 const normalizeLiveSettings = (input: SettingsState): SettingsState => {
   const state = restrictDemoVoiceSettings(input)
+  // Older demo visitors persisted the previous OpenAI default without a key.
+  // Restore the configured external agent, while preserving user-provided keys.
+  if (
+    isDemoMode() &&
+    process.env.NEXT_PUBLIC_SELECT_AI_SERVICE === 'custom-api' &&
+    state.selectAIService === 'openai' &&
+    !state.openaiKey
+  ) {
+    return { ...state, selectAIService: 'custom-api' }
+  }
   return state.liveMode
     ? { ...state, ...computeExclusions({ liveMode: true }, state).corrections }
     : state

--- a/src/lib/accessPolicy/routePolicies.ts
+++ b/src/lib/accessPolicy/routePolicies.ts
@@ -14,6 +14,7 @@ import type { RoutePolicy } from './types'
 
 export const routePolicies = {
   '/api/ai/audio': {
+    demoBehavior: 'deny',
     path: '/api/ai/audio',
     featureName: 'ai/audio',
     methods: ['POST'],
@@ -32,6 +33,7 @@ export const routePolicies = {
     waf: { embedAllowed: true },
   },
   '/api/ai/live-session': {
+    demoBehavior: 'deny',
     path: '/api/ai/live-session',
     featureName: 'ai/live-session',
     methods: ['POST'],
@@ -50,6 +52,7 @@ export const routePolicies = {
     waf: { embedAllowed: true },
   },
   '/api/ai/realtime-client-secret': {
+    demoBehavior: 'deny-realtime-conversation',
     path: '/api/ai/realtime-client-secret',
     featureName: 'ai/realtime-client-secret',
     methods: ['POST'],
@@ -287,6 +290,7 @@ export const routePolicies = {
     restrictedBehavior: 'deny',
   },
   '/api/openAITTS': {
+    demoBehavior: 'deny',
     path: '/api/openAITTS',
     featureName: 'openAITTS',
     methods: ['POST'],

--- a/src/lib/accessPolicy/types.ts
+++ b/src/lib/accessPolicy/types.ts
@@ -89,6 +89,8 @@ export type WafPolicy = {
 }
 
 export type RoutePolicy = {
+  /** Demo-only voice restrictions; transcription remains independently available. */
+  demoBehavior?: 'deny' | 'deny-realtime-conversation'
   /** '/api/...' 形式。src/pages/api 配下のファイルパスと一致すること（静的テストで検証） */
   path: string
   /** guardServerSecretAccess の featureName（現行値を維持） */

--- a/src/lib/accessPolicy/withAccessPolicy.ts
+++ b/src/lib/accessPolicy/withAccessPolicy.ts
@@ -1,3 +1,4 @@
+import { isDemoMode } from '@/utils/demoMode'
 /**
  * 統一アクセスポリシーのエントリポイント
  *
@@ -176,6 +177,18 @@ export function withAccessPolicy(
     // 1. メソッド検査
     if (!policy.methods.includes((req.method || '') as ApiHttpMethod)) {
       return sendMethodNotAllowed(res)
+    }
+
+    if (
+      isDemoMode() &&
+      (policy.demoBehavior === 'deny' ||
+        (policy.demoBehavior === 'deny-realtime-conversation' &&
+          req.body?.sessionType !== 'transcription'))
+    ) {
+      return res.status(403).json({
+        error: 'Feature disabled in demo mode',
+        errorCode: 'FeatureDisabledInDemoMode',
+      })
     }
 
     // 2. 制限モード

--- a/src/utils/demoMode.ts
+++ b/src/utils/demoMode.ts
@@ -1,0 +1,24 @@
+// Public flag is shared by browser settings and server API guards.
+export const isDemoMode = () => process.env.NEXT_PUBLIC_DEMO_MODE === 'true'
+
+type VoiceSettings = {
+  liveMode?: boolean
+  realtimeAPIMode?: boolean
+  audioMode?: boolean
+  selectVoice?: string
+}
+
+export function restrictDemoVoiceSettings<T extends VoiceSettings>(
+  state: T
+): T {
+  if (!isDemoMode()) return state
+  return {
+    ...state,
+    liveMode: false,
+    realtimeAPIMode: false,
+    audioMode: false,
+    ...(state.selectVoice === 'openai'
+      ? { selectVoice: 'aivis_cloud_api' }
+      : {}),
+  }
+}


### PR DESCRIPTION
## バグ修正

- デモサイトでGPT-Live、Realtime会話、Audioモード、OpenAI TTSを選択・実行できないようにしました。保存済み設定からの再有効化も防止します。
- デモに保存されたOpenAI TTSの選択はAivis Cloudへ戻します。通常版および文字起こしなどの対象外機能は維持します。
- CloudflareへのOpenAIキーの配布を停止し、デプロイ時にデモモードを明示的に有効化します。

- デモの通常会話の初期値を外部エージェントに戻し、キー未入力の古いOpenAI設定も起動時に補正します。利用者自身のキーがある場合は保持します。

## テスト

- 実装PR #610でLint、ユニットテスト、E2E、本番相当E2E、Cloudflare向けビルドがすべて成功しました。
- デモ設定の実サーバーで対象4 APIが403になること、設定画面で対象の選択肢が非表示になることを確認しました。
- CodeRabbitレビューに修正指摘はありません。

## その他

- Cloudflare本番のOPENAI_API_KEYは削除済みです。Aivis Cloudと外部エージェント用設定は維持しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更点**
  - デモモードでGPT-Live、Realtime会話、Audioモード、OpenAI TTSを利用できないようにしました。
  - 対応する設定項目や音声選択肢をデモモード中は表示しません。
  - 対象APIはデモモード時に拒否されますが、ユーザー自身のキーを使う文字起こしは引き続き利用できます。
  - デモモードの音声設定を自動的に制限し、保存済み設定の復元時にも適用します。
  - Cloudflareデプロイ時のデモモード設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->